### PR TITLE
Add CRUD UI project bundle save load

### DIFF
--- a/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/ActiveThingifierWorkspace.java
+++ b/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/ActiveThingifierWorkspace.java
@@ -19,6 +19,9 @@ public final class ActiveThingifierWorkspace implements AutoCloseable {
     private Thingifier thingifier;
     private ThingifierModelDefinition definition;
     private String schemaYaml;
+    private String projectPath;
+    private String projectTitle;
+    private String projectDescription;
     private long version;
 
     private ActiveThingifierWorkspace(final Thingifier thingifier) {
@@ -38,14 +41,26 @@ public final class ActiveThingifierWorkspace implements AutoCloseable {
         return new ActiveThingifierWorkspace(todoManager);
     }
 
+    static ActiveThingifierWorkspace forThingifier(final Thingifier thingifier) {
+        return new ActiveThingifierWorkspace(thingifier);
+    }
+
     public synchronized WorkspaceSnapshot snapshot() {
-        return new WorkspaceSnapshot(version, thingifier, definition, schemaYaml);
+        return new WorkspaceSnapshot(
+                version,
+                thingifier,
+                definition,
+                schemaYaml,
+                projectPath,
+                projectTitle,
+                projectDescription);
     }
 
     public synchronized WorkspaceSnapshot replaceWithYaml(final String yamlText) {
         Thingifier newThingifier = yamlLoader.loadThingifier(yamlText);
         Thingifier oldThingifier = thingifier;
         replaceWith(newThingifier);
+        clearProject();
         version++;
         if (oldThingifier != null) {
             oldThingifier.close();
@@ -72,10 +87,51 @@ public final class ActiveThingifierWorkspace implements AutoCloseable {
         return snapshot();
     }
 
+    synchronized WorkspaceSnapshot replaceWithProjectThingifier(
+            final Thingifier newThingifier,
+            final Path projectFolder,
+            final String title,
+            final String description) {
+        Thingifier oldThingifier = thingifier;
+        replaceWith(newThingifier);
+        projectPath = projectFolder.toAbsolutePath().normalize().toString();
+        projectTitle = nullToEmpty(title);
+        projectDescription = nullToEmpty(description);
+        version++;
+        if (oldThingifier != null) {
+            oldThingifier.close();
+        }
+        return snapshot();
+    }
+
+    synchronized WorkspaceSnapshot markProjectSaved(
+            final Path projectFolder, final String title, final String description) {
+        projectPath = projectFolder.toAbsolutePath().normalize().toString();
+        projectTitle = nullToEmpty(title);
+        projectDescription = nullToEmpty(description);
+        return snapshot();
+    }
+
+    synchronized Thingifier releaseThingifier() {
+        Thingifier released = thingifier;
+        thingifier = null;
+        return released;
+    }
+
     private void replaceWith(final Thingifier newThingifier) {
         thingifier = newThingifier;
         definition = modelExporter.export(newThingifier);
         schemaYaml = yamlExporter.export(definition);
+    }
+
+    private void clearProject() {
+        projectPath = "";
+        projectTitle = "";
+        projectDescription = "";
+    }
+
+    private String nullToEmpty(final String value) {
+        return value == null ? "" : value;
     }
 
     @Override

--- a/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/CrudUiArguments.java
+++ b/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/CrudUiArguments.java
@@ -7,15 +7,18 @@ public final class CrudUiArguments {
 
     private final int port;
     private final Path modelYamlPath;
+    private final Path projectPath;
 
-    private CrudUiArguments(final int port, final Path modelYamlPath) {
+    private CrudUiArguments(final int port, final Path modelYamlPath, final Path projectPath) {
         this.port = port;
         this.modelYamlPath = modelYamlPath;
+        this.projectPath = projectPath;
     }
 
     public static CrudUiArguments parse(final String[] args) {
         int configuredPort = 4567;
         Path configuredModelYamlPath = null;
+        Path configuredProjectPath = null;
 
         if (args != null) {
             for (String arg : args) {
@@ -25,10 +28,17 @@ public final class CrudUiArguments {
                 if (arg.startsWith("-modelYaml=")) {
                     configuredModelYamlPath = Paths.get(arg.substring("-modelYaml=".length()));
                 }
+                if (arg.startsWith("-project=")) {
+                    configuredProjectPath = Paths.get(arg.substring("-project=".length()));
+                }
             }
         }
 
-        return new CrudUiArguments(configuredPort, configuredModelYamlPath);
+        if (configuredProjectPath != null && configuredModelYamlPath != null) {
+            throw new IllegalArgumentException("Use either -project or -modelYaml, not both");
+        }
+
+        return new CrudUiArguments(configuredPort, configuredModelYamlPath, configuredProjectPath);
     }
 
     public int port() {
@@ -41,5 +51,13 @@ public final class CrudUiArguments {
 
     public Path modelYamlPath() {
         return modelYamlPath;
+    }
+
+    public boolean hasProjectPath() {
+        return projectPath != null;
+    }
+
+    public Path projectPath() {
+        return projectPath;
     }
 }

--- a/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/CrudUiController.java
+++ b/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/CrudUiController.java
@@ -10,6 +10,7 @@ public final class CrudUiController {
     private final WorkspaceMetadataJson metadataJson;
     private final WorkspaceDataExporter exporter;
     private final WorkspaceDataImporter importer;
+    private final WorkspaceProjectService projectService;
     private final SchemaPreviewService schemaPreviewService;
     private final WorkspaceSchemaUpgradeService schemaUpgradeService;
 
@@ -19,6 +20,7 @@ public final class CrudUiController {
         metadataJson = new WorkspaceMetadataJson();
         exporter = new WorkspaceDataExporter(workspace, apiProxy);
         importer = new WorkspaceDataImporter(workspace, apiProxy, metadataJson);
+        projectService = new WorkspaceProjectService(workspace, metadataJson);
         schemaPreviewService = new SchemaPreviewService();
         schemaUpgradeService = new WorkspaceSchemaUpgradeService(workspace, metadataJson);
     }
@@ -83,6 +85,22 @@ public final class CrudUiController {
     public UiHttpResponse importData(final String jsonText) {
         try {
             return importer.importData(jsonText);
+        } catch (ThingifierYamlException | CrudUiException | IllegalArgumentException e) {
+            return JsonSupport.error(400, e.getMessage());
+        }
+    }
+
+    public UiHttpResponse saveProject(final String requestJson) {
+        try {
+            return projectService.save(requestJson);
+        } catch (ThingifierYamlException | CrudUiException | IllegalArgumentException e) {
+            return JsonSupport.error(400, e.getMessage());
+        }
+    }
+
+    public UiHttpResponse loadProject(final String requestJson) {
+        try {
+            return projectService.load(requestJson);
         } catch (ThingifierYamlException | CrudUiException | IllegalArgumentException e) {
             return JsonSupport.error(400, e.getMessage());
         }

--- a/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/CrudUiMain.java
+++ b/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/CrudUiMain.java
@@ -1,6 +1,7 @@
 package uk.co.compendiumdev.thingifier.crudui;
 
 import java.io.IOException;
+import java.util.Map;
 import uk.co.compendiumdev.thingifier.crudui.adapter.spark.CrudUiApplication;
 
 public final class CrudUiMain {
@@ -11,7 +12,10 @@ public final class CrudUiMain {
         CrudUiArguments arguments = CrudUiArguments.parse(args);
         ActiveThingifierWorkspace workspace =
                 ActiveThingifierWorkspace.defaultTodoManagerWorkspace();
-        if (arguments.hasModelYamlPath()) {
+        if (arguments.hasProjectPath()) {
+            new WorkspaceProjectService(workspace, new WorkspaceMetadataJson())
+                    .load(JsonSupport.toJson(Map.of("path", arguments.projectPath().toString())));
+        } else if (arguments.hasModelYamlPath()) {
             workspace.replaceWithYaml(arguments.modelYamlPath());
         }
 

--- a/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceDataExporter.java
+++ b/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceDataExporter.java
@@ -27,13 +27,27 @@ public final class WorkspaceDataExporter {
     }
 
     public UiHttpResponse exportData() {
+        return UiHttpResponse.json(200, exportWorkspaceJson());
+    }
+
+    String exportWorkspaceJson() {
+        return JsonSupport.toJson(exportDocument(true));
+    }
+
+    String exportProjectDataJson() {
+        return JsonSupport.toJson(exportDocument(false));
+    }
+
+    private Map<String, Object> exportDocument(final boolean includeSchemaYaml) {
         WorkspaceSnapshot snapshot = workspace.snapshot();
         Map<String, Object> document = new LinkedHashMap<>();
         document.put("formatVersion", 1);
-        document.put("schemaYaml", snapshot.schemaYaml());
+        if (includeSchemaYaml) {
+            document.put("schemaYaml", snapshot.schemaYaml());
+        }
         document.put("entities", exportEntities(snapshot));
         document.put("relationships", exportRelationships(snapshot));
-        return UiHttpResponse.json(200, JsonSupport.toJson(document));
+        return document;
     }
 
     private Map<String, Object> exportEntities(final WorkspaceSnapshot snapshot) {

--- a/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceDataImporter.java
+++ b/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceDataImporter.java
@@ -39,6 +39,17 @@ public final class WorkspaceDataImporter {
         return UiHttpResponse.json(200, metadataJson.toJson(workspace.snapshot()));
     }
 
+    void importDataIntoCurrentWorkspace(final String jsonText) {
+        Map<?, ?> document =
+                JsonSupport.fromJsonMap(
+                        jsonText,
+                        "Project data file must contain a JSON object",
+                        "Could not parse project data JSON");
+        WorkspaceSnapshot snapshot = workspace.snapshot();
+        Map<String, String> importedIdentifiers = importEntities(document, snapshot);
+        importRelationships(document, workspace.snapshot(), importedIdentifiers);
+    }
+
     private Map<String, String> importEntities(
             final Map<?, ?> document, final WorkspaceSnapshot snapshot) {
         Map<String, String> importedIdentifiers = new LinkedHashMap<>();

--- a/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceMetadataJson.java
+++ b/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceMetadataJson.java
@@ -24,7 +24,14 @@ public final class WorkspaceMetadataJson {
         body.put("entities", entityMaps(snapshot));
         body.put("relationships", relationshipMaps(snapshot));
         body.put("schemaYaml", snapshot.schemaYaml());
+        body.put("project", projectMap(snapshot));
         return body;
+    }
+
+    public String toJson(final WorkspaceSnapshot snapshot, final String projectStatus) {
+        Map<String, Object> body = toMap(snapshot);
+        body.put("projectStatus", projectStatus);
+        return JsonSupport.toJson(body);
     }
 
     private Map<String, Object> modelMap(final WorkspaceSnapshot snapshot) {
@@ -32,6 +39,15 @@ public final class WorkspaceMetadataJson {
         model.put("title", nullToEmpty(snapshot.definition().title()));
         model.put("description", nullToEmpty(snapshot.definition().description()));
         return model;
+    }
+
+    private Map<String, Object> projectMap(final WorkspaceSnapshot snapshot) {
+        Map<String, Object> project = new LinkedHashMap<>();
+        project.put("path", snapshot.projectPath());
+        project.put("title", snapshot.projectTitle());
+        project.put("description", snapshot.projectDescription());
+        project.put("active", snapshot.hasProjectPath());
+        return project;
     }
 
     private List<Map<String, Object>> entityMaps(final WorkspaceSnapshot snapshot) {

--- a/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceProjectService.java
+++ b/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceProjectService.java
@@ -1,0 +1,174 @@
+package uk.co.compendiumdev.thingifier.crudui;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.yaml.ThingifierProjectManifest;
+import uk.co.compendiumdev.thingifier.yaml.ThingifierProjectManifestYaml;
+import uk.co.compendiumdev.thingifier.yaml.ThingifierYamlException;
+import uk.co.compendiumdev.thingifier.yaml.ThingifierYamlLoader;
+
+public final class WorkspaceProjectService {
+
+    private final ActiveThingifierWorkspace workspace;
+    private final WorkspaceMetadataJson metadataJson;
+    private final ThingifierProjectManifestYaml manifestYaml;
+    private final ThingifierYamlLoader yamlLoader;
+
+    public WorkspaceProjectService(
+            final ActiveThingifierWorkspace workspace, final WorkspaceMetadataJson metadataJson) {
+        this.workspace = workspace;
+        this.metadataJson = metadataJson;
+        this.manifestYaml = new ThingifierProjectManifestYaml();
+        this.yamlLoader = new ThingifierYamlLoader();
+    }
+
+    public UiHttpResponse save(final String requestJson) {
+        Path projectFolder = projectFolderFromRequest(requestJson);
+        WorkspaceSnapshot snapshot = workspace.snapshot();
+        ThingifierProjectManifest manifest =
+                ThingifierProjectManifest.defaultFor(
+                        snapshot.definition().title(), snapshot.definition().description());
+        WorkspaceDataExporter exporter =
+                new WorkspaceDataExporter(workspace, new DynamicThingifierApiProxy(workspace));
+
+        try {
+            if (Files.exists(projectFolder) && !Files.isDirectory(projectFolder)) {
+                throw new CrudUiException(400, "Project path must be a folder");
+            }
+            Files.createDirectories(projectFolder);
+            writeString(
+                    projectFolder.resolve(ThingifierProjectManifest.DEFAULT_SCHEMA_FILE),
+                    snapshot.schemaYaml());
+            writeString(
+                    projectFolder.resolve(ThingifierProjectManifest.DEFAULT_DATA_FILE),
+                    exporter.exportProjectDataJson());
+            writeString(
+                    projectFolder.resolve(ThingifierProjectManifest.DEFAULT_MANIFEST_FILE),
+                    manifestYaml.export(manifest));
+            WorkspaceSnapshot saved =
+                    workspace.markProjectSaved(
+                            projectFolder, manifest.title(), manifest.description());
+            return UiHttpResponse.json(200, metadataJson.toJson(saved, "saved"));
+        } catch (IOException e) {
+            throw new CrudUiException(400, "Could not save project: " + e.getMessage());
+        }
+    }
+
+    public UiHttpResponse load(final String requestJson) {
+        Path requestedPath = projectPathFromRequest(requestJson);
+        ProjectBundle bundle = ProjectBundle.resolve(requestedPath);
+        ThingifierProjectManifest manifest;
+        String schemaYaml;
+        String dataJson;
+        try {
+            manifest = manifestYaml.load(bundle.manifestPath());
+            schemaYaml = Files.readString(bundle.resolve(manifest.schemaFile()));
+            dataJson = Files.readString(bundle.resolve(manifest.dataFile()));
+        } catch (IOException e) {
+            throw new CrudUiException(400, "Could not load project: " + e.getMessage());
+        } catch (ThingifierYamlException e) {
+            throw new CrudUiException(400, e.getMessage());
+        }
+
+        ActiveThingifierWorkspace staging = null;
+        try {
+            Thingifier stagedThingifier = yamlLoader.loadThingifier(schemaYaml);
+            staging = ActiveThingifierWorkspace.forThingifier(stagedThingifier);
+            WorkspaceDataImporter importer =
+                    new WorkspaceDataImporter(
+                            staging,
+                            new DynamicThingifierApiProxy(staging),
+                            new WorkspaceMetadataJson());
+            importer.importDataIntoCurrentWorkspace(dataJson);
+            Thingifier released = staging.releaseThingifier();
+            WorkspaceSnapshot loaded =
+                    workspace.replaceWithProjectThingifier(
+                            released, bundle.folder(), manifest.title(), manifest.description());
+            return UiHttpResponse.json(200, metadataJson.toJson(loaded, "loaded"));
+        } finally {
+            if (staging != null) {
+                staging.close();
+            }
+        }
+    }
+
+    private Path projectFolderFromRequest(final String requestJson) {
+        Path path = projectPathFromRequest(requestJson).toAbsolutePath().normalize();
+        if (path.getFileName() != null
+                && ThingifierProjectManifest.DEFAULT_MANIFEST_FILE.equals(
+                        path.getFileName().toString())) {
+            throw new CrudUiException(400, "Project save path must be a folder");
+        }
+        return path;
+    }
+
+    private Path projectPathFromRequest(final String requestJson) {
+        Map<?, ?> request =
+                JsonSupport.fromJsonMap(
+                        requestJson,
+                        "Project request must contain a JSON object",
+                        "Could not parse project request JSON");
+        String path = stringValue(request.get("path")).trim();
+        if (path.isEmpty()) {
+            throw new CrudUiException(400, "Project request must contain path");
+        }
+        return Paths.get(path);
+    }
+
+    private void writeString(final Path path, final String contents) throws IOException {
+        Files.writeString(path, contents, StandardCharsets.UTF_8);
+    }
+
+    private String stringValue(final Object value) {
+        return value == null ? "" : String.valueOf(value);
+    }
+
+    private static final class ProjectBundle {
+
+        private final Path folder;
+        private final Path manifestPath;
+
+        private ProjectBundle(final Path folder, final Path manifestPath) {
+            this.folder = folder;
+            this.manifestPath = manifestPath;
+        }
+
+        static ProjectBundle resolve(final Path requestedPath) {
+            Path normalized = requestedPath.toAbsolutePath().normalize();
+            Path manifest;
+            Path folder;
+            if (Files.isDirectory(normalized)) {
+                folder = normalized;
+                manifest = folder.resolve(ThingifierProjectManifest.DEFAULT_MANIFEST_FILE);
+            } else {
+                manifest = normalized;
+                folder = manifest.getParent();
+            }
+            if (folder == null) {
+                folder = Paths.get(".").toAbsolutePath().normalize();
+            }
+            return new ProjectBundle(folder, manifest);
+        }
+
+        Path folder() {
+            return folder;
+        }
+
+        Path manifestPath() {
+            return manifestPath;
+        }
+
+        Path resolve(final String relativePath) {
+            Path resolved = folder.resolve(relativePath).normalize();
+            if (!resolved.startsWith(folder)) {
+                throw new CrudUiException(400, "Project file path escapes the project folder");
+            }
+            return resolved;
+        }
+    }
+}

--- a/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceSnapshot.java
+++ b/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceSnapshot.java
@@ -9,16 +9,33 @@ public final class WorkspaceSnapshot {
     private final Thingifier thingifier;
     private final ThingifierModelDefinition definition;
     private final String schemaYaml;
+    private final String projectPath;
+    private final String projectTitle;
+    private final String projectDescription;
 
     public WorkspaceSnapshot(
             final long version,
             final Thingifier thingifier,
             final ThingifierModelDefinition definition,
             final String schemaYaml) {
+        this(version, thingifier, definition, schemaYaml, "", "", "");
+    }
+
+    public WorkspaceSnapshot(
+            final long version,
+            final Thingifier thingifier,
+            final ThingifierModelDefinition definition,
+            final String schemaYaml,
+            final String projectPath,
+            final String projectTitle,
+            final String projectDescription) {
         this.version = version;
         this.thingifier = thingifier;
         this.definition = definition;
         this.schemaYaml = schemaYaml;
+        this.projectPath = nullToEmpty(projectPath);
+        this.projectTitle = nullToEmpty(projectTitle);
+        this.projectDescription = nullToEmpty(projectDescription);
     }
 
     public long version() {
@@ -35,5 +52,25 @@ public final class WorkspaceSnapshot {
 
     public String schemaYaml() {
         return schemaYaml;
+    }
+
+    public String projectPath() {
+        return projectPath;
+    }
+
+    public String projectTitle() {
+        return projectTitle;
+    }
+
+    public String projectDescription() {
+        return projectDescription;
+    }
+
+    public boolean hasProjectPath() {
+        return !projectPath.isEmpty();
+    }
+
+    private String nullToEmpty(final String value) {
+        return value == null ? "" : value;
     }
 }

--- a/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/adapter/spark/CrudUiApplication.java
+++ b/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/adapter/spark/CrudUiApplication.java
@@ -60,6 +60,12 @@ public final class CrudUiApplication implements AutoCloseable {
         Spark.post(
                 "/ui/import",
                 (request, response) -> write(response, controller.importData(request.body())));
+        Spark.post(
+                "/ui/project/save",
+                (request, response) -> write(response, controller.saveProject(request.body())));
+        Spark.post(
+                "/ui/project/load",
+                (request, response) -> write(response, controller.loadProject(request.body())));
         Spark.get(
                 "/docs", (request, response) -> write(response, controller.apiDocumentationPage()));
         Spark.get(

--- a/thingifier-crud-ui/src/main/resources/public/assets/app.js
+++ b/thingifier-crud-ui/src/main/resources/public/assets/app.js
@@ -22,6 +22,7 @@ const state = {
     schemaDiagramHeight: 280,
     schemaDiagramResizeStart: null,
     schemaUpgradeDialogOpen: false,
+    projectDialogAction: null,
     schemaUpgradePreview: null,
     schemaUpgradeMappings: {
         entityMappings: {},
@@ -45,8 +46,17 @@ const els = {
     newButton: document.getElementById("new-button"),
     refreshButton: document.getElementById("refresh-button"),
     exportButton: document.getElementById("export-button"),
+    saveProjectButton: document.getElementById("save-project-button"),
+    loadProjectButton: document.getElementById("load-project-button"),
     yamlFile: document.getElementById("yaml-file"),
     importFile: document.getElementById("import-file"),
+    projectDialog: document.getElementById("project-dialog"),
+    projectDialogTitle: document.getElementById("project-dialog-title"),
+    projectDialogDescription: document.getElementById("project-dialog-description"),
+    projectDialogWarning: document.getElementById("project-dialog-warning"),
+    projectPathInput: document.getElementById("project-path-input"),
+    projectDialogConfirm: document.getElementById("project-dialog-confirm"),
+    projectDialogCancel: document.getElementById("project-dialog-cancel"),
     schemaWorkspaceLink: document.getElementById("schema-workspace-link"),
     schemaDirtyStatus: document.getElementById("schema-dirty-status"),
     schemaReset: document.getElementById("schema-reset-button"),
@@ -208,7 +218,11 @@ function renderHeader() {
         return;
     }
     els.title.textContent = state.workspace.model.title || "Thingifier";
-    els.description.textContent = state.workspace.model.description || "";
+    const description = state.workspace.model.description || "";
+    const projectPath = state.workspace.project && state.workspace.project.path
+        ? `Project: ${state.workspace.project.path}`
+        : "";
+    els.description.textContent = [description, projectPath].filter(Boolean).join(" | ");
 }
 
 function renderTree() {
@@ -1055,6 +1069,59 @@ function clearMessage() {
     }
     els.message.textContent = "";
     els.message.hidden = true;
+}
+
+function openProjectDialog(action) {
+    if (!els.projectDialog) {
+        return;
+    }
+    state.projectDialogAction = action;
+    const isSave = action === "save";
+    const currentPath = state.workspace && state.workspace.project
+        ? state.workspace.project.path || ""
+        : "";
+    els.projectDialogTitle.textContent = isSave ? "Save Project" : "Load Project";
+    els.projectDialogDescription.textContent = isSave
+        ? "Save the active schema and data to a server-side project folder."
+        : "Load schema and data from a server-side project folder or projectfile.erproj.";
+    els.projectDialogWarning.textContent = isSave
+        ? "Saving overwrites projectfile.erproj, schema.yaml, and data.json in the selected folder. Other files are left alone."
+        : "Loading a project replaces the current workspace schema and data.";
+    els.projectDialogConfirm.textContent = isSave ? "Save Project" : "Load Project";
+    els.projectPathInput.value = currentPath;
+    els.projectDialog.hidden = false;
+    els.projectPathInput.focus();
+}
+
+function closeProjectDialog() {
+    if (!els.projectDialog) {
+        return;
+    }
+    state.projectDialogAction = null;
+    els.projectDialog.hidden = true;
+}
+
+async function submitProjectDialog() {
+    if (!state.projectDialogAction || !els.projectPathInput) {
+        return;
+    }
+    const path = els.projectPathInput.value.trim();
+    if (!path) {
+        showMessage("Enter a project folder path.", true);
+        return;
+    }
+    const action = state.projectDialogAction;
+    const endpoint = action === "save" ? "/ui/project/save" : "/ui/project/load";
+    const workspace = await requestJson(endpoint, {
+        method: "POST",
+        body: JSON.stringify({path})
+    });
+    state.workspace = workspace;
+    state.schemaDraft = null;
+    state.schemaPreview = null;
+    closeProjectDialog();
+    await loadWorkspace();
+    showMessage(action === "save" ? "Project saved." : "Project loaded.");
 }
 
 function markSchemaDirty() {
@@ -2599,6 +2666,38 @@ if (els.exportButton) {
             URL.revokeObjectURL(url);
         } catch (error) {
             showMessage(error.message, true);
+        }
+    });
+}
+if (els.saveProjectButton) {
+    els.saveProjectButton.addEventListener("click", () => openProjectDialog("save"));
+}
+if (els.loadProjectButton) {
+    els.loadProjectButton.addEventListener("click", () => openProjectDialog("load"));
+}
+if (els.projectDialogConfirm) {
+    els.projectDialogConfirm.addEventListener("click", () => {
+        submitProjectDialog().catch(error => showMessage(error.message, true));
+    });
+}
+if (els.projectDialogCancel) {
+    els.projectDialogCancel.addEventListener("click", closeProjectDialog);
+}
+if (els.projectDialog) {
+    els.projectDialog.addEventListener("click", event => {
+        if (event.target === els.projectDialog) {
+            closeProjectDialog();
+        }
+    });
+}
+if (els.projectPathInput) {
+    els.projectPathInput.addEventListener("keydown", event => {
+        if (event.key === "Enter") {
+            event.preventDefault();
+            submitProjectDialog().catch(error => showMessage(error.message, true));
+        }
+        if (event.key === "Escape") {
+            closeProjectDialog();
         }
     });
 }

--- a/thingifier-crud-ui/src/main/resources/public/assets/styles.css
+++ b/thingifier-crud-ui/src/main/resources/public/assets/styles.css
@@ -625,6 +625,40 @@ button.danger {
     overflow: hidden;
 }
 
+.project-dialog {
+    width: min(560px, 94vw);
+}
+
+.project-dialog-body {
+    padding: 14px;
+}
+
+.field-row {
+    display: grid;
+    gap: 6px;
+}
+
+.field-row span {
+    color: var(--muted);
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+.field-row input {
+    width: 100%;
+    min-height: 36px;
+    border: 1px solid var(--line);
+    border-radius: 4px;
+    padding: 7px 9px;
+}
+
+.project-dialog-warning {
+    margin: 12px 0 0;
+    color: var(--muted);
+    line-height: 1.4;
+}
+
 .schema-dialog-header,
 .schema-dialog-footer {
     display: flex;

--- a/thingifier-crud-ui/src/main/resources/public/index.html
+++ b/thingifier-crud-ui/src/main/resources/public/index.html
@@ -29,11 +29,36 @@
                 <input id="import-file" type="file" accept="application/json,.json">
             </label>
             <button id="export-button" type="button">Export</button>
+            <button id="save-project-button" type="button">Save Project</button>
+            <button id="load-project-button" type="button">Load Project</button>
             <a class="button-link" href="/docs">API Docs</a>
             <a class="button-link" href="/swagger">Swagger UI</a>
             <a class="button-link" href="/docs/swagger">Download OpenAPI</a>
         </div>
     </header>
+
+    <div id="project-dialog" class="schema-dialog-backdrop" hidden>
+        <section class="schema-dialog project-dialog" role="dialog" aria-modal="true"
+                 aria-labelledby="project-dialog-title">
+            <div class="schema-dialog-header">
+                <div>
+                    <h2 id="project-dialog-title">Project</h2>
+                    <p id="project-dialog-description"></p>
+                </div>
+                <button id="project-dialog-cancel" type="button" aria-label="Cancel project action">Cancel</button>
+            </div>
+            <div class="project-dialog-body">
+                <label class="field-row">
+                    <span>Folder path</span>
+                    <input id="project-path-input" type="text" autocomplete="off">
+                </label>
+                <p id="project-dialog-warning" class="project-dialog-warning"></p>
+            </div>
+            <div class="schema-dialog-footer">
+                <button id="project-dialog-confirm" class="primary" type="button">Confirm</button>
+            </div>
+        </section>
+    </div>
 
     <main class="workspace">
         <aside class="outline-panel">

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/CrudUiArgumentsTest.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/CrudUiArgumentsTest.java
@@ -1,0 +1,26 @@
+package uk.co.compendiumdev.thingifier.crudui;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class CrudUiArgumentsTest {
+
+    @Test
+    public void parsesProjectPathAndPort() {
+        CrudUiArguments arguments =
+                CrudUiArguments.parse(new String[] {"-project=project-folder", "-port=4568"});
+
+        Assertions.assertTrue(arguments.hasProjectPath());
+        Assertions.assertEquals("project-folder", arguments.projectPath().toString());
+        Assertions.assertEquals(4568, arguments.port());
+    }
+
+    @Test
+    public void rejectsProjectAndModelYamlTogether() {
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        CrudUiArguments.parse(
+                                new String[] {"-project=project-folder", "-modelYaml=model.yaml"}));
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/CrudUiControllerTest.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/CrudUiControllerTest.java
@@ -19,6 +19,7 @@ public class CrudUiControllerTest {
             Assertions.assertTrue(response.body().contains("\"entities\""));
             Assertions.assertTrue(response.body().contains("\"relationships\""));
             Assertions.assertTrue(response.body().contains("\"schemaYaml\""));
+            Assertions.assertTrue(response.body().contains("\"project\""));
         }
     }
 
@@ -104,6 +105,10 @@ public class CrudUiControllerTest {
         Assertions.assertTrue(index.contains("API Docs"));
         Assertions.assertTrue(index.contains("Swagger UI"));
         Assertions.assertTrue(index.contains("Download OpenAPI"));
+        Assertions.assertTrue(index.contains("Save Project"));
+        Assertions.assertTrue(index.contains("Load Project"));
+        Assertions.assertTrue(index.contains("id=\"project-dialog\""));
+        Assertions.assertTrue(index.contains("id=\"project-path-input\""));
         Assertions.assertTrue(index.contains("Workspace"));
         Assertions.assertTrue(index.contains("Schema Edit"));
         Assertions.assertTrue(index.contains("href=\"/schema\""));
@@ -273,6 +278,11 @@ public class CrudUiControllerTest {
         Assertions.assertTrue(script.contains("/ui/schema/preview"));
         Assertions.assertTrue(script.contains("/ui/schema/upgrade/preview"));
         Assertions.assertTrue(script.contains("/ui/schema/upgrade/apply"));
+        Assertions.assertTrue(script.contains("/ui/project/save"));
+        Assertions.assertTrue(script.contains("/ui/project/load"));
+        Assertions.assertTrue(script.contains("openProjectDialog"));
+        Assertions.assertTrue(script.contains("Project saved."));
+        Assertions.assertTrue(script.contains("Project loaded."));
         Assertions.assertTrue(script.contains("schemaUpgradeMappings"));
         Assertions.assertTrue(script.contains("schemaUpgradeDialogOpen"));
         Assertions.assertTrue(script.contains("previewSchemaUpgrade"));
@@ -321,6 +331,8 @@ public class CrudUiControllerTest {
         Assertions.assertTrue(styles.contains(".schema-diagram-resizer"));
         Assertions.assertTrue(styles.contains(".schema-dialog-backdrop"));
         Assertions.assertTrue(styles.contains(".schema-dialog-footer"));
+        Assertions.assertTrue(styles.contains(".project-dialog"));
+        Assertions.assertTrue(styles.contains(".project-dialog-warning"));
         Assertions.assertTrue(styles.contains(".schema-upgrade-layout"));
         Assertions.assertTrue(styles.contains(".schema-upgrade-row"));
         Assertions.assertTrue(styles.contains(".schema-upgrade-summary"));

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceProjectServiceTest.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceProjectServiceTest.java
@@ -1,0 +1,149 @@
+package uk.co.compendiumdev.thingifier.crudui;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class WorkspaceProjectServiceTest {
+
+    @TempDir Path temp;
+
+    @Test
+    public void saveCreatesProjectManifestSchemaAndDataFiles() throws Exception {
+        try (ActiveThingifierWorkspace workspace =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            workspace.replaceWithYaml(TestResources.text("/models/project-tasks.yaml"));
+            createRelatedProjectAndTodo(new DynamicThingifierApiProxy(workspace));
+            CrudUiController controller = new CrudUiController(workspace);
+            Path projectFolder = temp.resolve("project-bundle");
+
+            UiHttpResponse response = controller.saveProject(request(projectFolder));
+
+            Assertions.assertEquals(200, response.statusCode());
+            Assertions.assertTrue(Files.exists(projectFolder.resolve("projectfile.erproj")));
+            Assertions.assertTrue(Files.exists(projectFolder.resolve("schema.yaml")));
+            Assertions.assertTrue(Files.exists(projectFolder.resolve("data.json")));
+            Assertions.assertFalse(
+                    Files.readString(projectFolder.resolve("data.json")).contains("schemaYaml"));
+            Assertions.assertTrue(response.body().contains("\"projectStatus\": \"saved\""));
+            Assertions.assertTrue(response.body().contains("\"active\": true"));
+        }
+    }
+
+    @Test
+    public void savedProjectReloadsSchemaDataAndRelationshipEdges() {
+        Path projectFolder = temp.resolve("project-bundle");
+        try (ActiveThingifierWorkspace source =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            source.replaceWithYaml(TestResources.text("/models/project-tasks.yaml"));
+            createRelatedProjectAndTodo(new DynamicThingifierApiProxy(source));
+            new CrudUiController(source).saveProject(request(projectFolder));
+        }
+
+        try (ActiveThingifierWorkspace target =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            CrudUiController controller = new CrudUiController(target);
+
+            UiHttpResponse response = controller.loadProject(request(projectFolder));
+            DynamicThingifierApiProxy targetProxy = new DynamicThingifierApiProxy(target);
+
+            Assertions.assertEquals(200, response.statusCode());
+            Assertions.assertTrue(response.body().contains("\"projectStatus\": \"loaded\""));
+            Assertions.assertEquals("Project Tasks", target.snapshot().definition().title());
+            Assertions.assertTrue(targetProxy.getJson("projects").body().contains("Project A"));
+            Assertions.assertTrue(targetProxy.getJson("todos").body().contains("Task A"));
+            Assertions.assertEquals(
+                    1,
+                    root(targetProxy.getJson("projects/1/tasks").body())
+                            .getAsJsonArray("todos")
+                            .size());
+        }
+    }
+
+    @Test
+    public void loadAcceptsDirectProjectFilePath() {
+        Path projectFolder = temp.resolve("project-bundle");
+        try (ActiveThingifierWorkspace source =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            source.replaceWithYaml(TestResources.text("/models/project-tasks.yaml"));
+            new CrudUiController(source).saveProject(request(projectFolder));
+        }
+
+        try (ActiveThingifierWorkspace target =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            UiHttpResponse response =
+                    new CrudUiController(target)
+                            .loadProject(request(projectFolder.resolve("projectfile.erproj")));
+
+            Assertions.assertEquals(200, response.statusCode());
+            Assertions.assertEquals("Project Tasks", target.snapshot().definition().title());
+        }
+    }
+
+    @Test
+    public void invalidProjectLoadDoesNotMutateActiveWorkspace() throws Exception {
+        Path projectFolder = temp.resolve("invalid-project");
+        Files.createDirectories(projectFolder);
+        Files.writeString(
+                projectFolder.resolve("projectfile.erproj"),
+                "formatVersion: 1\nschemaFile: schema.yaml\ndataFile: data.json\n");
+        Files.writeString(
+                projectFolder.resolve("schema.yaml"),
+                TestResources.text("/models/project-tasks.yaml"));
+        Files.writeString(projectFolder.resolve("data.json"), "{");
+
+        try (ActiveThingifierWorkspace workspace =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            long version = workspace.snapshot().version();
+
+            UiHttpResponse response =
+                    new CrudUiController(workspace).loadProject(request(projectFolder));
+
+            Assertions.assertEquals(400, response.statusCode());
+            Assertions.assertEquals(version, workspace.snapshot().version());
+            Assertions.assertEquals("Todo Manager", workspace.snapshot().definition().title());
+        }
+    }
+
+    @Test
+    public void saveLeavesUnrelatedFilesUntouched() throws Exception {
+        Path projectFolder = temp.resolve("project-bundle");
+        Files.createDirectories(projectFolder);
+        Path extraFile = projectFolder.resolve("validators.jar");
+        Files.writeString(extraFile, "not really a jar");
+
+        try (ActiveThingifierWorkspace workspace =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            new CrudUiController(workspace).saveProject(request(projectFolder));
+        }
+
+        Assertions.assertEquals("not really a jar", Files.readString(extraFile));
+    }
+
+    private void createRelatedProjectAndTodo(final DynamicThingifierApiProxy proxy) {
+        String projectId =
+                field(proxy.postJson("projects", "{\"title\":\"Project A\"}").body(), "id");
+        String todoId = field(proxy.postJson("todos", "{\"title\":\"Task A\"}").body(), "id");
+        UiHttpResponse relationship =
+                proxy.postJson("projects/" + projectId + "/tasks", "{\"id\":\"" + todoId + "\"}");
+        Assertions.assertEquals(201, relationship.statusCode());
+    }
+
+    private String request(final Path path) {
+        return JsonSupport.toJson(Map.of("path", path.toString()));
+    }
+
+    private String field(final String json, final String fieldName) {
+        JsonObject object = root(json);
+        return object.get(fieldName).getAsString();
+    }
+
+    private JsonObject root(final String json) {
+        return JsonParser.parseString(json).getAsJsonObject();
+    }
+}

--- a/thingifier-yaml/src/main/java/uk/co/compendiumdev/thingifier/yaml/ThingifierProjectManifest.java
+++ b/thingifier-yaml/src/main/java/uk/co/compendiumdev/thingifier/yaml/ThingifierProjectManifest.java
@@ -1,0 +1,91 @@
+package uk.co.compendiumdev.thingifier.yaml;
+
+import java.nio.file.Path;
+
+public final class ThingifierProjectManifest {
+
+    public static final int SUPPORTED_FORMAT_VERSION = 1;
+    public static final String DEFAULT_MANIFEST_FILE = "projectfile.erproj";
+    public static final String DEFAULT_SCHEMA_FILE = "schema.yaml";
+    public static final String DEFAULT_DATA_FILE = "data.json";
+
+    private final int formatVersion;
+    private final String title;
+    private final String description;
+    private final String schemaFile;
+    private final String dataFile;
+
+    public ThingifierProjectManifest(
+            final int formatVersion,
+            final String title,
+            final String description,
+            final String schemaFile,
+            final String dataFile) {
+        this.formatVersion = formatVersion;
+        this.title = nullToEmpty(title);
+        this.description = nullToEmpty(description);
+        this.schemaFile = validatedRelativeFile(schemaFile, "schemaFile");
+        this.dataFile = validatedRelativeFile(dataFile, "dataFile");
+        if (formatVersion != SUPPORTED_FORMAT_VERSION) {
+            throw new ThingifierYamlException("Unsupported project formatVersion " + formatVersion);
+        }
+    }
+
+    public static ThingifierProjectManifest defaultFor(
+            final String title, final String description) {
+        return new ThingifierProjectManifest(
+                SUPPORTED_FORMAT_VERSION,
+                title,
+                description,
+                DEFAULT_SCHEMA_FILE,
+                DEFAULT_DATA_FILE);
+    }
+
+    public int formatVersion() {
+        return formatVersion;
+    }
+
+    public String title() {
+        return title;
+    }
+
+    public String description() {
+        return description;
+    }
+
+    public String schemaFile() {
+        return schemaFile;
+    }
+
+    public String dataFile() {
+        return dataFile;
+    }
+
+    private String validatedRelativeFile(final String value, final String fieldName) {
+        String text = nullToEmpty(value).trim();
+        if (text.isEmpty()) {
+            throw new ThingifierYamlException("Project manifest must contain " + fieldName);
+        }
+        if (text.startsWith("/") || text.startsWith("\\") || text.matches("^[A-Za-z]:.*")) {
+            throw new ThingifierYamlException(fieldName + " must be a relative path");
+        }
+
+        Path path = Path.of(text);
+        if (path.isAbsolute()) {
+            throw new ThingifierYamlException(fieldName + " must be a relative path");
+        }
+
+        String normalized = path.normalize().toString().replace('\\', '/');
+        if (".".equals(normalized)
+                || "..".equals(normalized)
+                || normalized.startsWith("../")
+                || normalized.contains("/../")) {
+            throw new ThingifierYamlException(fieldName + " must stay inside the project folder");
+        }
+        return normalized;
+    }
+
+    private String nullToEmpty(final String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/thingifier-yaml/src/main/java/uk/co/compendiumdev/thingifier/yaml/ThingifierProjectManifestYaml.java
+++ b/thingifier-yaml/src/main/java/uk/co/compendiumdev/thingifier/yaml/ThingifierProjectManifestYaml.java
@@ -1,0 +1,100 @@
+package uk.co.compendiumdev.thingifier.yaml;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+import org.yaml.snakeyaml.error.YAMLException;
+
+public final class ThingifierProjectManifestYaml {
+
+    public ThingifierProjectManifest load(final Path path) throws IOException {
+        try (InputStream input = Files.newInputStream(path)) {
+            return load(input);
+        }
+    }
+
+    public ThingifierProjectManifest load(final InputStream input) {
+        try {
+            return fromObject(loader().load(input));
+        } catch (YAMLException | ClassCastException | IllegalArgumentException e) {
+            throw new ThingifierYamlException("Could not parse project manifest", e);
+        }
+    }
+
+    public ThingifierProjectManifest load(final String yamlText) {
+        try {
+            return fromObject(loader().load(yamlText));
+        } catch (YAMLException | ClassCastException | IllegalArgumentException e) {
+            throw new ThingifierYamlException("Could not parse project manifest", e);
+        }
+    }
+
+    public String export(final ThingifierProjectManifest manifest) {
+        Map<String, Object> root = new LinkedHashMap<>();
+        root.put("formatVersion", manifest.formatVersion());
+        Map<String, Object> project = new LinkedHashMap<>();
+        project.put("title", manifest.title());
+        project.put("description", manifest.description());
+        root.put("project", project);
+        root.put("schemaFile", manifest.schemaFile());
+        root.put("dataFile", manifest.dataFile());
+        return dumper().dump(root);
+    }
+
+    private ThingifierProjectManifest fromObject(final Object parsed) {
+        if (!(parsed instanceof Map)) {
+            throw new ThingifierYamlException("Project manifest must contain a YAML object");
+        }
+        Map<?, ?> root = (Map<?, ?>) parsed;
+        Map<?, ?> project = mapValue(root.get("project"));
+        return new ThingifierProjectManifest(
+                intValue(root.get("formatVersion")),
+                stringValue(project.get("title")),
+                stringValue(project.get("description")),
+                stringValue(root.get("schemaFile")),
+                stringValue(root.get("dataFile")));
+    }
+
+    private int intValue(final Object value) {
+        if (value instanceof Number) {
+            return ((Number) value).intValue();
+        }
+        if (value instanceof String) {
+            return Integer.parseInt(((String) value).trim());
+        }
+        throw new ThingifierYamlException("Project manifest must contain formatVersion");
+    }
+
+    private Map<?, ?> mapValue(final Object value) {
+        if (value instanceof Map) {
+            return (Map<?, ?>) value;
+        }
+        return Map.of();
+    }
+
+    private String stringValue(final Object value) {
+        return value == null ? "" : String.valueOf(value);
+    }
+
+    private Yaml loader() {
+        final LoaderOptions options = new LoaderOptions();
+        options.setAllowDuplicateKeys(false);
+        options.setMaxAliasesForCollections(20);
+        return new Yaml(new SafeConstructor(options));
+    }
+
+    private Yaml dumper() {
+        final DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        options.setPrettyFlow(true);
+        options.setSplitLines(false);
+        return new Yaml(options);
+    }
+}

--- a/thingifier-yaml/src/test/java/uk/co/compendiumdev/thingifier/yaml/ThingifierProjectManifestYamlTest.java
+++ b/thingifier-yaml/src/test/java/uk/co/compendiumdev/thingifier/yaml/ThingifierProjectManifestYamlTest.java
@@ -1,0 +1,80 @@
+package uk.co.compendiumdev.thingifier.yaml;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ThingifierProjectManifestYamlTest {
+
+    @Test
+    void validManifestRoundTripsThroughYaml() {
+        ThingifierProjectManifest manifest =
+                new ThingifierProjectManifest(
+                        1, "Project Tasks", "A saved CRUD UI project", "schema.yaml", "data.json");
+        ThingifierProjectManifestYaml yaml = new ThingifierProjectManifestYaml();
+
+        ThingifierProjectManifest loaded = yaml.load(yaml.export(manifest));
+
+        Assertions.assertEquals(1, loaded.formatVersion());
+        Assertions.assertEquals("Project Tasks", loaded.title());
+        Assertions.assertEquals("A saved CRUD UI project", loaded.description());
+        Assertions.assertEquals("schema.yaml", loaded.schemaFile());
+        Assertions.assertEquals("data.json", loaded.dataFile());
+    }
+
+    @Test
+    void missingSchemaOrDataFileIsRejected() {
+        ThingifierProjectManifestYaml yaml = new ThingifierProjectManifestYaml();
+
+        Assertions.assertThrows(
+                ThingifierYamlException.class,
+                () -> yaml.load("formatVersion: 1\nschemaFile: schema.yaml\n"));
+        Assertions.assertThrows(
+                ThingifierYamlException.class,
+                () -> yaml.load("formatVersion: 1\ndataFile: data.json\n"));
+    }
+
+    @Test
+    void absoluteAndEscapingPathsAreRejected() {
+        ThingifierProjectManifestYaml yaml = new ThingifierProjectManifestYaml();
+
+        Assertions.assertThrows(
+                ThingifierYamlException.class,
+                () ->
+                        yaml.load(
+                                "formatVersion: 1\n"
+                                        + "schemaFile: /tmp/schema.yaml\n"
+                                        + "dataFile: data.json\n"));
+        Assertions.assertThrows(
+                ThingifierYamlException.class,
+                () ->
+                        yaml.load(
+                                "formatVersion: 1\n"
+                                        + "schemaFile: ..\\schema.yaml\n"
+                                        + "dataFile: data.json\n"));
+        Assertions.assertThrows(
+                ThingifierYamlException.class,
+                () ->
+                        yaml.load(
+                                "formatVersion: 1\n"
+                                        + "schemaFile: schema.yaml\n"
+                                        + "dataFile: ../data.json\n"));
+    }
+
+    @Test
+    void unknownFutureKeysAreTolerated() {
+        ThingifierProjectManifest loaded =
+                new ThingifierProjectManifestYaml()
+                        .load(
+                                "formatVersion: 1\n"
+                                        + "project:\n"
+                                        + "  title: Future Project\n"
+                                        + "schemaFile: schema.yaml\n"
+                                        + "dataFile: data.json\n"
+                                        + "validators:\n"
+                                        + "  - validators.jar\n");
+
+        Assertions.assertEquals("Future Project", loaded.title());
+        Assertions.assertEquals("schema.yaml", loaded.schemaFile());
+        Assertions.assertEquals("data.json", loaded.dataFile());
+    }
+}


### PR DESCRIPTION
## Summary
- add folder-based CRUD UI project bundle save/load support
- add YAML project manifest parsing/exporting in `thingifier-yaml`
- add `-project=<folder-or-projectfile>` startup support and Workspace UI save/load controls

## Verification
- `node --check thingifier-crud-ui/src/main/resources/public/assets/app.js`
- `mvn -pl thingifier-yaml,thingifier-crud-ui -am test`
- `mvn -pl thingifier-crud-ui -DskipTests checkstyle:check@project-fqn-check`
- `mvn spotless:check`
- `mvn -pl thingifier-crud-ui -am -DskipTests package`
- `mvn -pl thingifier-yaml,thingifier-crud-ui -am pmd:check checkstyle:check`

Closes #51
