### PR TITLE
Add file-backed SQLite CRUD UI projects

### DIFF
--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/repository/ThingStoreProviderConfig.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/repository/ThingStoreProviderConfig.java
@@ -10,18 +10,28 @@ public class ThingStoreProviderConfig {
     public static final String DEFAULT_REPOSITORY_MODE = "memory";
     public static final String ARG_REPOSITORY_MODE = "-thingifier-repository";
     public static final String ARG_SQLITE_DIRECTORY = "-thingifier-sqlite-directory";
+    public static final String ARG_SQLITE_FILE = "-thingifier-sqlite-file";
     public static final String ARG_SQLITE_MEMORY = "-sqlite-memory";
     public static final String ENV_REPOSITORY_MODE = "THINGIFIER_REPOSITORY";
     public static final String ENV_SQLITE_DIRECTORY = "THINGIFIER_SQLITE_DIRECTORY";
+    public static final String ENV_SQLITE_FILE = "THINGIFIER_SQLITE_FILE";
     public static final String PROPERTY_REPOSITORY_MODE = "thingifier.repository";
     public static final String PROPERTY_SQLITE_DIRECTORY = "thingifier.sqlite.directory";
+    public static final String PROPERTY_SQLITE_FILE = "thingifier.sqlite.file";
 
     private final String repositoryMode;
     private final Path sqliteDirectory;
+    private final Path sqliteFile;
 
     public ThingStoreProviderConfig(final String repositoryMode, final Path sqliteDirectory) {
+        this(repositoryMode, sqliteDirectory, null);
+    }
+
+    public ThingStoreProviderConfig(
+            final String repositoryMode, final Path sqliteDirectory, final Path sqliteFile) {
         this.repositoryMode = normalize(repositoryMode);
         this.sqliteDirectory = sqliteDirectory;
+        this.sqliteFile = sqliteFile;
     }
 
     public static ThingStoreProviderConfig fromArgs(final String[] args) {
@@ -44,7 +54,16 @@ public class ThingStoreProviderConfig {
                         System.getenv(ENV_SQLITE_DIRECTORY),
                         "thingifier-sqlite");
 
-        return new ThingStoreProviderConfig(repositoryMode, Paths.get(sqliteDirectory));
+        String sqliteFile =
+                firstNonBlank(
+                        argValue(args, ARG_SQLITE_FILE),
+                        System.getProperty(PROPERTY_SQLITE_FILE),
+                        System.getenv(ENV_SQLITE_FILE));
+
+        return new ThingStoreProviderConfig(
+                repositoryMode,
+                Paths.get(sqliteDirectory),
+                sqliteFile.isEmpty() ? null : Paths.get(sqliteFile));
     }
 
     public ThingStoreProvider createProvider() {
@@ -60,6 +79,9 @@ public class ThingStoreProviderConfig {
             case "sqlite-file":
             case "sqlite-disk":
             case "file":
+                if (sqliteFile != null) {
+                    return SqliteThingStoreProvider.fileBackedFile(sqliteFile);
+                }
                 return SqliteThingStoreProvider.fileBacked(sqliteDirectory);
             default:
                 throw new IllegalArgumentException(
@@ -77,10 +99,21 @@ public class ThingStoreProviderConfig {
         return sqliteDirectory;
     }
 
+    public Path getSqliteFile() {
+        return sqliteFile;
+    }
+
+    public boolean hasSqliteFile() {
+        return sqliteFile != null;
+    }
+
     public String describe() {
         if (repositoryMode.equals("sqlite-file")
                 || repositoryMode.equals("sqlite-disk")
                 || repositoryMode.equals("file")) {
+            if (sqliteFile != null) {
+                return repositoryMode + " at " + sqliteFile.toAbsolutePath();
+            }
             return repositoryMode + " at " + sqliteDirectory.toAbsolutePath();
         }
         return repositoryMode;

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/repository/sqlite/SqliteThingStoreProvider.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/repository/sqlite/SqliteThingStoreProvider.java
@@ -56,6 +56,27 @@ public class SqliteThingStoreProvider implements ThingStoreProvider {
                 });
     }
 
+    public static SqliteThingStoreProvider fileBackedFile(final Path databaseFile) {
+        final Path normalized = databaseFile.toAbsolutePath().normalize();
+        final Path parent = normalized.getParent();
+        if (parent != null) {
+            try {
+                Files.createDirectories(parent);
+            } catch (IOException e) {
+                throw new IllegalStateException(
+                        "Could not create SQLite repository directory " + parent, e);
+            }
+        }
+
+        return new SqliteThingStoreProvider(
+                databaseKey ->
+                        "jdbc:sqlite:"
+                                + databaseFileFor(normalized, databaseKey)
+                                        .toAbsolutePath()
+                                        .toString()
+                                        .replace("\\", "/"));
+    }
+
     @Override
     public ThingStore getDefaultStore() {
         return repositories.get(EntityRelModel.DEFAULT_DATABASE_NAME);
@@ -105,5 +126,19 @@ public class SqliteThingStoreProvider implements ThingStoreProvider {
 
     private static String safeName(final String databaseKey) {
         return databaseKey.replaceAll("[^A-Za-z0-9._-]", "_");
+    }
+
+    private static Path databaseFileFor(final Path databaseFile, final String databaseKey) {
+        if (EntityRelModel.DEFAULT_DATABASE_NAME.equals(databaseKey)) {
+            return databaseFile;
+        }
+
+        final Path parent = databaseFile.getParent();
+        final String fileName = databaseFile.getFileName().toString();
+        final int extensionAt = fileName.lastIndexOf(".");
+        final String baseName = extensionAt > 0 ? fileName.substring(0, extensionAt) : fileName;
+        final String extension = extensionAt > 0 ? fileName.substring(extensionAt) : ".sqlite";
+        final String sessionFileName = baseName + "-" + safeName(databaseKey) + extension;
+        return parent == null ? Path.of(sessionFileName) : parent.resolve(sessionFileName);
     }
 }

--- a/ercoremodel/src/test/java/uk/co/compendiumdev/thingifier/core/repository/ThingStoreContractTest.java
+++ b/ercoremodel/src/test/java/uk/co/compendiumdev/thingifier/core/repository/ThingStoreContractTest.java
@@ -1,5 +1,6 @@
 package uk.co.compendiumdev.thingifier.core.repository;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.UUID;
@@ -55,6 +56,34 @@ public class ThingStoreContractTest {
     public void sqliteProviderKeepsLogicalDatabasesSeparate() {
         try (ThingStoreProvider provider = SqliteThingStoreProvider.inMemory()) {
             exerciseProviderIsolation(provider);
+        }
+    }
+
+    @Test
+    public void directSqliteFileProviderCreatesAndReopensDatabaseFile() {
+        ERSchema schema = todoSchema();
+        Path databasePath = tempDir.resolve("direct-provider.sqlite");
+
+        try (ThingStoreProvider provider = SqliteThingStoreProvider.fileBackedFile(databasePath)) {
+            ThingStore store = provider.getDefaultStore();
+            store.administration().initializeFrom(schema);
+            create(store, schema.getEntityDefinitionNamed("project"), "File provider");
+        }
+
+        Assertions.assertTrue(Files.exists(databasePath));
+
+        try (ThingStoreProvider reopened = SqliteThingStoreProvider.fileBackedFile(databasePath)) {
+            ThingStore store = reopened.getDefaultStore();
+            store.administration().initializeFrom(schema);
+
+            Assertions.assertEquals(
+                    1, store.entityQueries().count(schema.getEntityDefinitionNamed("project")));
+            Assertions.assertEquals(
+                    "File provider",
+                    store.entityQueries()
+                            .findByPrimaryKey(schema.getEntityDefinitionNamed("project"), "1")
+                            .getFieldValue("title")
+                            .asString());
         }
     }
 

--- a/ercoremodel/src/test/java/uk/co/compendiumdev/thingifier/core/repository/ThingStoreProviderConfigTest.java
+++ b/ercoremodel/src/test/java/uk/co/compendiumdev/thingifier/core/repository/ThingStoreProviderConfigTest.java
@@ -53,6 +53,22 @@ public class ThingStoreProviderConfigTest {
     }
 
     @Test
+    public void canCreateDirectSqliteFileRepositoryFromArgs() {
+        Path databaseFile = tempDir.resolve("crud-ui.sqlite");
+        ThingStoreProviderConfig config =
+                ThingStoreProviderConfig.fromArgs(
+                        new String[] {
+                            "-thingifier-repository=sqlite-file",
+                            "-thingifier-sqlite-file=" + databaseFile
+                        });
+
+        Assertions.assertEquals("sqlite-file", config.getRepositoryMode());
+        Assertions.assertTrue(config.hasSqliteFile());
+        Assertions.assertEquals(databaseFile, config.getSqliteFile());
+        Assertions.assertTrue(config.createProvider() instanceof SqliteThingStoreProvider);
+    }
+
+    @Test
     public void rejectsUnknownRepositoryModes() {
         ThingStoreProviderConfig config =
                 ThingStoreProviderConfig.fromArgs(new String[] {"-thingifier-repository=unknown"});

--- a/thingifier-crud-ui/pom.xml
+++ b/thingifier-crud-ui/pom.xml
@@ -16,6 +16,12 @@
     <name>thingifier crud ui</name>
     <url>https://compendiumdev.co.uk</url>
 
+    <properties>
+        <playwright.version>1.61.0</playwright.version>
+        <crud.ui.headless>true</crud.ui.headless>
+        <skipITs>false</skipITs>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>uk.co.compendiumdev</groupId>
@@ -54,6 +60,12 @@
             <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.microsoft.playwright</groupId>
+            <artifactId>playwright</artifactId>
+            <version>${playwright.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -71,6 +83,62 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M4</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>install-playwright-chromium</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipITs}</skip>
+                            <executable>${java.home}/bin/java</executable>
+                            <classpathScope>test</classpathScope>
+                            <arguments>
+                                <argument>-cp</argument>
+                                <classpath/>
+                                <argument>com.microsoft.playwright.CLI</argument>
+                                <argument>install</argument>
+                                <argument>chromium</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M4</version>
+                <configuration>
+                    <skipITs>${skipITs}</skipITs>
+                    <systemPropertyVariables>
+                        <crud.ui.headless>${crud.ui.headless}</crud.ui.headless>
+                    </systemPropertyVariables>
+                    <includes>
+                        <include>**/*IT.java</include>
+                    </includes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>integration-tests</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>verify-integration-tests</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>

--- a/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/ActiveThingifierWorkspace.java
+++ b/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/ActiveThingifierWorkspace.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.apiconfig.ThingifierApiConfigProfile;
 import uk.co.compendiumdev.thingifier.application.examples.TodoManagerThingifier;
+import uk.co.compendiumdev.thingifier.application.schema.definition.ThingifierModelAssembler;
 import uk.co.compendiumdev.thingifier.application.schema.definition.ThingifierModelDefinition;
 import uk.co.compendiumdev.thingifier.application.schema.definition.ThingifierModelExporter;
 import uk.co.compendiumdev.thingifier.yaml.ThingifierYamlExporter;
@@ -19,15 +20,21 @@ public final class ActiveThingifierWorkspace implements AutoCloseable {
     private Thingifier thingifier;
     private ThingifierModelDefinition definition;
     private String schemaYaml;
+    private WorkspaceStorage storage;
     private String projectPath;
     private String projectTitle;
     private String projectDescription;
     private long version;
 
     private ActiveThingifierWorkspace(final Thingifier thingifier) {
+        this(thingifier, WorkspaceStorage.memory());
+    }
+
+    private ActiveThingifierWorkspace(final Thingifier thingifier, final WorkspaceStorage storage) {
         modelExporter = new ThingifierModelExporter();
         yamlExporter = new ThingifierYamlExporter();
         yamlLoader = new ThingifierYamlLoader();
+        this.storage = storage;
         replaceWith(thingifier);
         version = 1L;
     }
@@ -41,8 +48,22 @@ public final class ActiveThingifierWorkspace implements AutoCloseable {
         return new ActiveThingifierWorkspace(todoManager);
     }
 
+    public static ActiveThingifierWorkspace defaultTodoManagerWorkspace(
+            final WorkspaceStorage storage) {
+        ActiveThingifierWorkspace workspace = defaultTodoManagerWorkspace();
+        if (!WorkspaceStorage.MODE_MEMORY.equals(storage.mode())) {
+            workspace.switchStorage(storage);
+        }
+        return workspace;
+    }
+
     static ActiveThingifierWorkspace forThingifier(final Thingifier thingifier) {
         return new ActiveThingifierWorkspace(thingifier);
+    }
+
+    static ActiveThingifierWorkspace forThingifier(
+            final Thingifier thingifier, final WorkspaceStorage storage) {
+        return new ActiveThingifierWorkspace(thingifier, storage);
     }
 
     public synchronized WorkspaceSnapshot snapshot() {
@@ -51,13 +72,15 @@ public final class ActiveThingifierWorkspace implements AutoCloseable {
                 thingifier,
                 definition,
                 schemaYaml,
+                storage,
                 projectPath,
                 projectTitle,
                 projectDescription);
     }
 
     public synchronized WorkspaceSnapshot replaceWithYaml(final String yamlText) {
-        Thingifier newThingifier = yamlLoader.loadThingifier(yamlText);
+        Thingifier newThingifier = yamlLoader.loadThingifier(yamlText, storage.provider());
+        newThingifier.clearAllData();
         Thingifier oldThingifier = thingifier;
         replaceWith(newThingifier);
         clearProject();
@@ -74,11 +97,19 @@ public final class ActiveThingifierWorkspace implements AutoCloseable {
 
     public synchronized WorkspaceSnapshot replaceWithMigratedThingifier(
             final Thingifier newThingifier, final long expectedVersion) {
+        return replaceWithMigratedThingifier(newThingifier, storage, expectedVersion);
+    }
+
+    public synchronized WorkspaceSnapshot replaceWithMigratedThingifier(
+            final Thingifier newThingifier,
+            final WorkspaceStorage newStorage,
+            final long expectedVersion) {
         if (version != expectedVersion) {
             throw new IllegalStateException(
                     "Workspace changed; refresh schema preview before applying");
         }
         Thingifier oldThingifier = thingifier;
+        storage = newStorage;
         replaceWith(newThingifier);
         version++;
         if (oldThingifier != null) {
@@ -89,12 +120,28 @@ public final class ActiveThingifierWorkspace implements AutoCloseable {
 
     synchronized WorkspaceSnapshot replaceWithProjectThingifier(
             final Thingifier newThingifier,
+            final WorkspaceStorage newStorage,
             final Path projectFolder,
             final String title,
             final String description) {
+        return replaceWithProjectThingifier(
+                newThingifier,
+                newStorage,
+                projectFolder.toAbsolutePath().normalize().toString(),
+                title,
+                description);
+    }
+
+    synchronized WorkspaceSnapshot replaceWithProjectThingifier(
+            final Thingifier newThingifier,
+            final WorkspaceStorage newStorage,
+            final String projectPathDisplay,
+            final String title,
+            final String description) {
         Thingifier oldThingifier = thingifier;
+        storage = newStorage;
         replaceWith(newThingifier);
-        projectPath = projectFolder.toAbsolutePath().normalize().toString();
+        projectPath = nullToEmpty(projectPathDisplay);
         projectTitle = nullToEmpty(title);
         projectDescription = nullToEmpty(description);
         version++;
@@ -102,6 +149,41 @@ public final class ActiveThingifierWorkspace implements AutoCloseable {
             oldThingifier.close();
         }
         return snapshot();
+    }
+
+    public synchronized WorkspaceSnapshot switchStorage(final WorkspaceStorage newStorage) {
+        if (sameStorage(newStorage)) {
+            return snapshot();
+        }
+
+        final String dataJson =
+                new WorkspaceDataExporter(this, new DynamicThingifierApiProxy(this))
+                        .exportProjectDataJson();
+        ActiveThingifierWorkspace staging = null;
+        try {
+            Thingifier stagedThingifier =
+                    new ThingifierModelAssembler().assemble(definition, newStorage.provider());
+            stagedThingifier.clearAllData();
+            staging = ActiveThingifierWorkspace.forThingifier(stagedThingifier, newStorage);
+            new WorkspaceDataImporter(
+                            staging,
+                            new DynamicThingifierApiProxy(staging),
+                            new WorkspaceMetadataJson())
+                    .importDataIntoCurrentWorkspace(dataJson);
+            Thingifier released = staging.releaseThingifier();
+            Thingifier oldThingifier = thingifier;
+            storage = newStorage;
+            replaceWith(released);
+            version++;
+            if (oldThingifier != null) {
+                oldThingifier.close();
+            }
+            return snapshot();
+        } finally {
+            if (staging != null) {
+                staging.close();
+            }
+        }
     }
 
     synchronized WorkspaceSnapshot markProjectSaved(
@@ -128,6 +210,11 @@ public final class ActiveThingifierWorkspace implements AutoCloseable {
         projectPath = "";
         projectTitle = "";
         projectDescription = "";
+    }
+
+    private boolean sameStorage(final WorkspaceStorage other) {
+        return storage.mode().equals(other.mode())
+                && storage.sqliteFilePath().equals(other.sqliteFilePath());
     }
 
     private String nullToEmpty(final String value) {

--- a/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/CrudUiArguments.java
+++ b/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/CrudUiArguments.java
@@ -2,17 +2,24 @@ package uk.co.compendiumdev.thingifier.crudui;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import uk.co.compendiumdev.thingifier.core.repository.ThingStoreProviderConfig;
 
 public final class CrudUiArguments {
 
     private final int port;
     private final Path modelYamlPath;
     private final Path projectPath;
+    private final WorkspaceStorage storage;
 
-    private CrudUiArguments(final int port, final Path modelYamlPath, final Path projectPath) {
+    private CrudUiArguments(
+            final int port,
+            final Path modelYamlPath,
+            final Path projectPath,
+            final WorkspaceStorage storage) {
         this.port = port;
         this.modelYamlPath = modelYamlPath;
         this.projectPath = projectPath;
+        this.storage = storage;
     }
 
     public static CrudUiArguments parse(final String[] args) {
@@ -38,7 +45,11 @@ public final class CrudUiArguments {
             throw new IllegalArgumentException("Use either -project or -modelYaml, not both");
         }
 
-        return new CrudUiArguments(configuredPort, configuredModelYamlPath, configuredProjectPath);
+        return new CrudUiArguments(
+                configuredPort,
+                configuredModelYamlPath,
+                configuredProjectPath,
+                WorkspaceStorage.fromConfig(ThingStoreProviderConfig.fromArgs(args)));
     }
 
     public int port() {
@@ -59,5 +70,9 @@ public final class CrudUiArguments {
 
     public Path projectPath() {
         return projectPath;
+    }
+
+    public WorkspaceStorage storage() {
+        return storage;
     }
 }

--- a/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/CrudUiController.java
+++ b/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/CrudUiController.java
@@ -11,11 +11,19 @@ public final class CrudUiController {
     private final WorkspaceDataExporter exporter;
     private final WorkspaceDataImporter importer;
     private final WorkspaceProjectService projectService;
+    private final ProjectPathChooser projectPathChooser;
     private final SchemaPreviewService schemaPreviewService;
     private final WorkspaceSchemaUpgradeService schemaUpgradeService;
 
     public CrudUiController(final ActiveThingifierWorkspace workspace) {
+        this(workspace, new SwingProjectPathChooser());
+    }
+
+    CrudUiController(
+            final ActiveThingifierWorkspace workspace,
+            final ProjectPathChooser projectPathChooser) {
         this.workspace = workspace;
+        this.projectPathChooser = projectPathChooser;
         DynamicThingifierApiProxy apiProxy = new DynamicThingifierApiProxy(workspace);
         metadataJson = new WorkspaceMetadataJson();
         exporter = new WorkspaceDataExporter(workspace, apiProxy);
@@ -106,6 +114,67 @@ public final class CrudUiController {
         }
     }
 
+    public UiHttpResponse browseProject(final String requestJson) {
+        try {
+            ProjectActionRequest request = ProjectActionRequest.fromJson(requestJson, false);
+            ProjectPathSelection selection = projectPathChooser.choose(request);
+            if (!selection.isAvailable()) {
+                return JsonSupport.error(400, selection.message());
+            }
+            return UiHttpResponse.json(200, JsonSupport.toJson(selection.toMap()));
+        } catch (CrudUiException | IllegalArgumentException e) {
+            return JsonSupport.error(400, e.getMessage());
+        }
+    }
+
+    public UiHttpResponse checkProject(final String requestJson) {
+        try {
+            return projectService.check(requestJson);
+        } catch (ThingifierYamlException | CrudUiException | IllegalArgumentException e) {
+            return JsonSupport.error(400, e.getMessage());
+        }
+    }
+
+    public UiHttpResponse exportProjectFiles() {
+        return exportProjectFiles("{}");
+    }
+
+    public UiHttpResponse exportProjectFiles(final String requestJson) {
+        try {
+            return projectService.exportFiles(requestJson);
+        } catch (ThingifierYamlException | CrudUiException | IllegalArgumentException e) {
+            return JsonSupport.error(400, e.getMessage());
+        }
+    }
+
+    public UiHttpResponse loadProjectFiles(final String requestJson) {
+        try {
+            return projectService.loadFiles(requestJson);
+        } catch (ThingifierYamlException | CrudUiException | IllegalArgumentException e) {
+            return JsonSupport.error(400, e.getMessage());
+        }
+    }
+
+    public UiHttpResponse switchStorage(final String requestJson) {
+        try {
+            Map<?, ?> request =
+                    JsonSupport.fromJsonMap(
+                            requestJson,
+                            "Storage request must contain a JSON object",
+                            "Could not parse storage request JSON");
+            WorkspaceStorage storage =
+                    WorkspaceStorage.fromModeAndPath(
+                            stringValue(request.get("mode")),
+                            stringValue(request.get("sqliteFile")));
+            WorkspaceSnapshot snapshot = workspace.switchStorage(storage);
+            Map<String, Object> body = metadataJson.toMap(snapshot);
+            body.put("storageStatus", "switched");
+            return UiHttpResponse.json(200, JsonSupport.toJson(body));
+        } catch (CrudUiException | IllegalArgumentException | IllegalStateException e) {
+            return JsonSupport.error(400, e.getMessage());
+        }
+    }
+
     public UiHttpResponse apiDocumentationPage() {
         return UiHttpResponse.html(new ApiDocumentationPage(workspace.snapshot()).html());
     }
@@ -128,5 +197,9 @@ public final class CrudUiController {
         headers.put("Cache-Control", "no-store");
         String body = permissive ? openApi.permissiveOpenApiJson() : openApi.openApiJson();
         return new UiHttpResponse(200, "application/json", body, headers);
+    }
+
+    private String stringValue(final Object value) {
+        return value == null ? "" : String.valueOf(value);
     }
 }

--- a/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/CrudUiMain.java
+++ b/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/CrudUiMain.java
@@ -11,7 +11,7 @@ public final class CrudUiMain {
     public static void main(final String[] args) throws IOException {
         CrudUiArguments arguments = CrudUiArguments.parse(args);
         ActiveThingifierWorkspace workspace =
-                ActiveThingifierWorkspace.defaultTodoManagerWorkspace();
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace(arguments.storage());
         if (arguments.hasProjectPath()) {
             new WorkspaceProjectService(workspace, new WorkspaceMetadataJson())
                     .load(JsonSupport.toJson(Map.of("path", arguments.projectPath().toString())));

--- a/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/ProjectActionRequest.java
+++ b/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/ProjectActionRequest.java
@@ -1,0 +1,57 @@
+package uk.co.compendiumdev.thingifier.crudui;
+
+import java.util.Map;
+
+final class ProjectActionRequest {
+
+    static final String ACTION_LOAD = "load";
+    static final String ACTION_SAVE = "save";
+
+    private final String action;
+    private final String path;
+
+    private ProjectActionRequest(final String action, final String path) {
+        this.action = action;
+        this.path = path;
+    }
+
+    static ProjectActionRequest fromJson(final String requestJson, final boolean pathRequired) {
+        Map<?, ?> request =
+                JsonSupport.fromJsonMap(
+                        requestJson,
+                        "Project request must contain a JSON object",
+                        "Could not parse project request JSON");
+        String action = stringValue(request.get("action")).trim();
+        if (action.isEmpty()) {
+            throw new CrudUiException(400, "Project request must contain action");
+        }
+        if (!ACTION_LOAD.equals(action) && !ACTION_SAVE.equals(action)) {
+            throw new CrudUiException(400, "Project action must be save or load");
+        }
+        String path = stringValue(request.get("path")).trim();
+        if (pathRequired && path.isEmpty()) {
+            throw new CrudUiException(400, "Project request must contain path");
+        }
+        return new ProjectActionRequest(action, path);
+    }
+
+    String action() {
+        return action;
+    }
+
+    String path() {
+        return path;
+    }
+
+    boolean isSave() {
+        return ACTION_SAVE.equals(action);
+    }
+
+    boolean isLoad() {
+        return ACTION_LOAD.equals(action);
+    }
+
+    private static String stringValue(final Object value) {
+        return value == null ? "" : String.valueOf(value);
+    }
+}

--- a/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/ProjectPathChooser.java
+++ b/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/ProjectPathChooser.java
@@ -1,0 +1,6 @@
+package uk.co.compendiumdev.thingifier.crudui;
+
+interface ProjectPathChooser {
+
+    ProjectPathSelection choose(ProjectActionRequest request);
+}

--- a/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/ProjectPathSelection.java
+++ b/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/ProjectPathSelection.java
@@ -1,0 +1,52 @@
+package uk.co.compendiumdev.thingifier.crudui;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+final class ProjectPathSelection {
+
+    private final boolean available;
+    private final boolean selected;
+    private final String path;
+    private final String message;
+
+    private ProjectPathSelection(
+            final boolean available,
+            final boolean selected,
+            final String path,
+            final String message) {
+        this.available = available;
+        this.selected = selected;
+        this.path = path;
+        this.message = message;
+    }
+
+    static ProjectPathSelection selected(final String path) {
+        return new ProjectPathSelection(true, true, path, "Project path selected.");
+    }
+
+    static ProjectPathSelection cancelled() {
+        return new ProjectPathSelection(true, false, "", "Project browsing cancelled.");
+    }
+
+    static ProjectPathSelection unavailable(final String message) {
+        return new ProjectPathSelection(false, false, "", message);
+    }
+
+    boolean isAvailable() {
+        return available;
+    }
+
+    String message() {
+        return message;
+    }
+
+    Map<String, Object> toMap() {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("available", available);
+        body.put("selected", selected);
+        body.put("path", path);
+        body.put("message", message);
+        return body;
+    }
+}

--- a/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/SwingProjectPathChooser.java
+++ b/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/SwingProjectPathChooser.java
@@ -1,0 +1,88 @@
+package uk.co.compendiumdev.thingifier.crudui;
+
+import java.awt.EventQueue;
+import java.awt.GraphicsEnvironment;
+import java.awt.Window;
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+
+final class SwingProjectPathChooser implements ProjectPathChooser {
+
+    @Override
+    public ProjectPathSelection choose(final ProjectActionRequest request) {
+        if (GraphicsEnvironment.isHeadless()) {
+            return ProjectPathSelection.unavailable(
+                    "Native project browsing is not available in headless mode.");
+        }
+        try {
+            return chooseOnEventThread(request);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return ProjectPathSelection.unavailable("Native project browsing was interrupted.");
+        } catch (InvocationTargetException | RuntimeException e) {
+            return ProjectPathSelection.unavailable(
+                    "Native project browsing is unavailable: " + rootMessage(e));
+        }
+    }
+
+    private ProjectPathSelection chooseOnEventThread(final ProjectActionRequest request)
+            throws InterruptedException, InvocationTargetException {
+        if (EventQueue.isDispatchThread()) {
+            return showChooser(request);
+        }
+        AtomicReference<ProjectPathSelection> selection = new AtomicReference<>();
+        EventQueue.invokeAndWait(() -> selection.set(showChooser(request)));
+        return selection.get();
+    }
+
+    private ProjectPathSelection showChooser(final ProjectActionRequest request) {
+        JFileChooser chooser = new JFileChooser();
+        chooser.setDialogTitle(request.isSave() ? "Save Project" : "Load Project");
+        chooser.setFileSelectionMode(
+                request.isSave()
+                        ? JFileChooser.DIRECTORIES_ONLY
+                        : JFileChooser.FILES_AND_DIRECTORIES);
+        if (!request.path().isEmpty()) {
+            chooser.setSelectedFile(new File(request.path()));
+        }
+
+        JFrame owner = foregroundOwner();
+        try {
+            int result =
+                    request.isSave()
+                            ? chooser.showSaveDialog(owner)
+                            : chooser.showOpenDialog(owner);
+            if (result != JFileChooser.APPROVE_OPTION || chooser.getSelectedFile() == null) {
+                return ProjectPathSelection.cancelled();
+            }
+            return ProjectPathSelection.selected(
+                    chooser.getSelectedFile().toPath().toAbsolutePath().normalize().toString());
+        } finally {
+            owner.dispose();
+        }
+    }
+
+    private JFrame foregroundOwner() {
+        JFrame owner = new JFrame("Thingifier Project Browser");
+        owner.setType(Window.Type.UTILITY);
+        owner.setUndecorated(true);
+        owner.setAlwaysOnTop(true);
+        owner.setSize(1, 1);
+        owner.setLocationRelativeTo(null);
+        owner.setVisible(true);
+        owner.toFront();
+        owner.requestFocus();
+        return owner;
+    }
+
+    private String rootMessage(final Throwable throwable) {
+        Throwable cause = throwable;
+        while (cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+        return cause.getMessage() == null ? cause.getClass().getSimpleName() : cause.getMessage();
+    }
+}

--- a/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceDataImporter.java
+++ b/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceDataImporter.java
@@ -74,7 +74,8 @@ public final class WorkspaceDataImporter {
             final Map<String, String> importedIdentifiers) {
         Map<String, Object> body = new LinkedHashMap<>();
         for (Map.Entry<?, ?> field : instance.entrySet()) {
-            body.put(String.valueOf(field.getKey()), field.getValue());
+            String fieldName = String.valueOf(field.getKey());
+            body.put(fieldName, normalizedValue(entity.fieldNamed(fieldName), field.getValue()));
         }
         String oldId = stringValue(body.get(entity.primaryKeyFieldName()));
         if (hasAutoPrimaryKey(entity)) {
@@ -153,6 +154,33 @@ public final class WorkspaceDataImporter {
         return primaryKey != null
                 && ("auto-increment".equals(primaryKey.type())
                         || "auto-guid".equals(primaryKey.type()));
+    }
+
+    private Object normalizedValue(final FieldDefinitionSpec field, final Object value) {
+        if (field == null || value == null) {
+            return value;
+        }
+        if ("boolean".equals(field.type()) && value instanceof String) {
+            String text = ((String) value).trim();
+            if ("true".equalsIgnoreCase(text) || "false".equalsIgnoreCase(text)) {
+                return Boolean.valueOf(text);
+            }
+        }
+        if ("integer".equals(field.type()) && value instanceof String) {
+            try {
+                return Integer.valueOf(((String) value).trim());
+            } catch (NumberFormatException e) {
+                return value;
+            }
+        }
+        if ("float".equals(field.type()) && value instanceof String) {
+            try {
+                return Double.valueOf(((String) value).trim());
+            } catch (NumberFormatException e) {
+                return value;
+            }
+        }
+        return value;
     }
 
     private Map<?, ?> mapValue(final Object value, final String errorMessage) {

--- a/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceMetadataJson.java
+++ b/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceMetadataJson.java
@@ -25,6 +25,7 @@ public final class WorkspaceMetadataJson {
         body.put("relationships", relationshipMaps(snapshot));
         body.put("schemaYaml", snapshot.schemaYaml());
         body.put("project", projectMap(snapshot));
+        body.put("storage", storageMap(snapshot));
         return body;
     }
 
@@ -48,6 +49,14 @@ public final class WorkspaceMetadataJson {
         project.put("description", snapshot.projectDescription());
         project.put("active", snapshot.hasProjectPath());
         return project;
+    }
+
+    private Map<String, Object> storageMap(final WorkspaceSnapshot snapshot) {
+        Map<String, Object> storage = new LinkedHashMap<>();
+        storage.put("mode", snapshot.storage().mode());
+        storage.put("sqliteFile", snapshot.storage().sqliteFilePath());
+        storage.put("fileBacked", snapshot.storage().isSqliteFile());
+        return storage;
     }
 
     private List<Map<String, Object>> entityMaps(final WorkspaceSnapshot snapshot) {

--- a/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceProjectService.java
+++ b/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceProjectService.java
@@ -5,14 +5,25 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.application.schema.definition.ThingifierModelAssembler;
 import uk.co.compendiumdev.thingifier.yaml.ThingifierProjectManifest;
 import uk.co.compendiumdev.thingifier.yaml.ThingifierProjectManifestYaml;
 import uk.co.compendiumdev.thingifier.yaml.ThingifierYamlException;
 import uk.co.compendiumdev.thingifier.yaml.ThingifierYamlLoader;
 
 public final class WorkspaceProjectService {
+
+    private static final String FILE_TYPE_BASE64 = "base64";
+    private static final String FILE_TYPE_TEXT = "text";
+    private static final String PROJECT_STORAGE_JSON = "json";
+    private static final String PROJECT_STORAGE_SQLITE = "sqlite";
 
     private final ActiveThingifierWorkspace workspace;
     private final WorkspaceMetadataJson metadataJson;
@@ -30,29 +41,17 @@ public final class WorkspaceProjectService {
     public UiHttpResponse save(final String requestJson) {
         Path projectFolder = projectFolderFromRequest(requestJson);
         WorkspaceSnapshot snapshot = workspace.snapshot();
-        ThingifierProjectManifest manifest =
-                ThingifierProjectManifest.defaultFor(
-                        snapshot.definition().title(), snapshot.definition().description());
-        WorkspaceDataExporter exporter =
-                new WorkspaceDataExporter(workspace, new DynamicThingifierApiProxy(workspace));
+        String projectStorageMode = projectStorageModeFromRequest(requestJson, snapshot);
 
         try {
             if (Files.exists(projectFolder) && !Files.isDirectory(projectFolder)) {
                 throw new CrudUiException(400, "Project path must be a folder");
             }
             Files.createDirectories(projectFolder);
-            writeString(
-                    projectFolder.resolve(ThingifierProjectManifest.DEFAULT_SCHEMA_FILE),
-                    snapshot.schemaYaml());
-            writeString(
-                    projectFolder.resolve(ThingifierProjectManifest.DEFAULT_DATA_FILE),
-                    exporter.exportProjectDataJson());
-            writeString(
-                    projectFolder.resolve(ThingifierProjectManifest.DEFAULT_MANIFEST_FILE),
-                    manifestYaml.export(manifest));
             WorkspaceSnapshot saved =
-                    workspace.markProjectSaved(
-                            projectFolder, manifest.title(), manifest.description());
+                    PROJECT_STORAGE_SQLITE.equals(projectStorageMode)
+                            ? saveSqliteBackedProject(projectFolder, snapshot)
+                            : saveJsonBackedProject(projectFolder, snapshot);
             return UiHttpResponse.json(200, metadataJson.toJson(saved, "saved"));
         } catch (IOException e) {
             throw new CrudUiException(400, "Could not save project: " + e.getMessage());
@@ -62,17 +61,89 @@ public final class WorkspaceProjectService {
     public UiHttpResponse load(final String requestJson) {
         Path requestedPath = projectPathFromRequest(requestJson);
         ProjectBundle bundle = ProjectBundle.resolve(requestedPath);
+        return loadProjectBundle(bundle, bundle.folder().toString());
+    }
+
+    public UiHttpResponse check(final String requestJson) {
+        ProjectActionRequest request = ProjectActionRequest.fromJson(requestJson, true);
+        if (request.isSave()) {
+            return UiHttpResponse.json(200, JsonSupport.toJson(checkSavePath(request.path())));
+        }
+        return UiHttpResponse.json(200, JsonSupport.toJson(checkLoadPath(request.path())));
+    }
+
+    public UiHttpResponse exportFiles() {
+        return exportFiles("{}");
+    }
+
+    public UiHttpResponse exportFiles(final String requestJson) {
+        try {
+            WorkspaceSnapshot snapshot = workspace.snapshot();
+            String projectStorageMode = projectStorageModeFromRequest(requestJson, snapshot);
+            List<Map<String, Object>> files =
+                    PROJECT_STORAGE_SQLITE.equals(projectStorageMode)
+                            ? sqliteBackedProjectFiles(snapshot)
+                            : jsonBackedProjectFiles(snapshot);
+            Map<String, Object> body = new LinkedHashMap<>();
+            body.put("formatVersion", 1);
+            body.put("projectStatus", "exported");
+            body.put("files", files);
+            body.put("projectStorageMode", projectStorageMode);
+            body.put(
+                    "storageMode",
+                    PROJECT_STORAGE_SQLITE.equals(projectStorageMode)
+                            ? WorkspaceStorage.MODE_SQLITE_FILE
+                            : WorkspaceStorage.MODE_MEMORY);
+            return UiHttpResponse.json(200, JsonSupport.toJson(body));
+        } catch (IOException e) {
+            throw new CrudUiException(400, "Could not export project files: " + e.getMessage());
+        }
+    }
+
+    public UiHttpResponse loadFiles(final String requestJson) {
+        Map<?, ?> request =
+                JsonSupport.fromJsonMap(
+                        requestJson,
+                        "Project file load request must contain a JSON object",
+                        "Could not parse project file load JSON");
+        String folderName = stringValue(request.get("folderName")).trim();
+        Object filesValue = request.get("files");
+        if (!(filesValue instanceof List)) {
+            throw new CrudUiException(400, "Project file load request must contain files");
+        }
+
+        try {
+            Path tempFolder = Files.createTempDirectory("thingifier-crud-ui-browser-project-");
+            writePayloadFiles(tempFolder, (List<?>) filesValue);
+            ProjectBundle bundle = ProjectBundle.resolve(tempFolder);
+            return loadProjectBundle(bundle, browserProjectDisplay(folderName));
+        } catch (IOException e) {
+            throw new CrudUiException(400, "Could not load project files: " + e.getMessage());
+        }
+    }
+
+    private UiHttpResponse loadProjectBundle(
+            final ProjectBundle bundle, final String projectPathDisplay) {
         ThingifierProjectManifest manifest;
         String schemaYaml;
-        String dataJson;
         try {
             manifest = manifestYaml.load(bundle.manifestPath());
             schemaYaml = Files.readString(bundle.resolve(manifest.schemaFile()));
-            dataJson = Files.readString(bundle.resolve(manifest.dataFile()));
         } catch (IOException e) {
             throw new CrudUiException(400, "Could not load project: " + e.getMessage());
         } catch (ThingifierYamlException e) {
             throw new CrudUiException(400, e.getMessage());
+        }
+
+        if (isSqliteBackedProject(bundle, manifest)) {
+            return loadSqliteBackedProject(bundle, manifest, schemaYaml, projectPathDisplay);
+        }
+
+        String dataJson;
+        try {
+            dataJson = Files.readString(bundle.resolve(manifest.dataFile()));
+        } catch (IOException e) {
+            throw new CrudUiException(400, "Could not load project: " + e.getMessage());
         }
 
         ActiveThingifierWorkspace staging = null;
@@ -88,13 +159,375 @@ public final class WorkspaceProjectService {
             Thingifier released = staging.releaseThingifier();
             WorkspaceSnapshot loaded =
                     workspace.replaceWithProjectThingifier(
-                            released, bundle.folder(), manifest.title(), manifest.description());
+                            released,
+                            WorkspaceStorage.memory(),
+                            projectPathDisplay,
+                            manifest.title(),
+                            manifest.description());
             return UiHttpResponse.json(200, metadataJson.toJson(loaded, "loaded"));
         } finally {
             if (staging != null) {
                 staging.close();
             }
         }
+    }
+
+    private WorkspaceSnapshot saveJsonBackedProject(
+            final Path projectFolder, final WorkspaceSnapshot snapshot) throws IOException {
+        ThingifierProjectManifest manifest =
+                ThingifierProjectManifest.defaultFor(
+                        snapshot.definition().title(), snapshot.definition().description());
+        WorkspaceDataExporter exporter =
+                new WorkspaceDataExporter(workspace, new DynamicThingifierApiProxy(workspace));
+
+        writeString(
+                projectFolder.resolve(ThingifierProjectManifest.DEFAULT_SCHEMA_FILE),
+                snapshot.schemaYaml());
+        writeString(
+                projectFolder.resolve(ThingifierProjectManifest.DEFAULT_DATA_FILE),
+                exporter.exportProjectDataJson());
+        writeString(
+                projectFolder.resolve(ThingifierProjectManifest.DEFAULT_MANIFEST_FILE),
+                manifestYaml.export(manifest));
+        if (!WorkspaceStorage.MODE_MEMORY.equals(workspace.snapshot().storage().mode())) {
+            workspace.switchStorage(WorkspaceStorage.memory());
+        }
+        return workspace.markProjectSaved(projectFolder, manifest.title(), manifest.description());
+    }
+
+    private WorkspaceSnapshot saveSqliteBackedProject(
+            final Path projectFolder, final WorkspaceSnapshot snapshot) throws IOException {
+        ThingifierProjectManifest manifest =
+                ThingifierProjectManifest.sqliteFileBackedFor(
+                        snapshot.definition().title(), snapshot.definition().description());
+        Path targetDatabase = projectFolder.resolve(manifest.sqliteFile()).normalize();
+        if (!targetDatabase.startsWith(projectFolder)) {
+            throw new CrudUiException(400, "Project SQLite file path escapes the project folder");
+        }
+
+        writeString(
+                projectFolder.resolve(ThingifierProjectManifest.DEFAULT_SCHEMA_FILE),
+                snapshot.schemaYaml());
+        if (!samePath(targetDatabase, snapshot.storage().sqliteFile())) {
+            migrateWorkspaceToSqliteFile(targetDatabase);
+        }
+        writeString(
+                projectFolder.resolve(ThingifierProjectManifest.DEFAULT_MANIFEST_FILE),
+                manifestYaml.export(manifest));
+        return workspace.markProjectSaved(projectFolder, manifest.title(), manifest.description());
+    }
+
+    private void migrateWorkspaceToSqliteFile(final Path targetDatabase) throws IOException {
+        String dataJson =
+                new WorkspaceDataExporter(workspace, new DynamicThingifierApiProxy(workspace))
+                        .exportProjectDataJson();
+        deleteDatabaseFiles(targetDatabase);
+
+        ActiveThingifierWorkspace staging = null;
+        try {
+            WorkspaceSnapshot snapshot = workspace.snapshot();
+            WorkspaceStorage targetStorage = WorkspaceStorage.sqliteFile(targetDatabase);
+            Thingifier stagedThingifier =
+                    new ThingifierModelAssembler()
+                            .assemble(snapshot.definition(), targetStorage.provider());
+            stagedThingifier.clearAllData();
+            staging = ActiveThingifierWorkspace.forThingifier(stagedThingifier, targetStorage);
+            new WorkspaceDataImporter(
+                            staging,
+                            new DynamicThingifierApiProxy(staging),
+                            new WorkspaceMetadataJson())
+                    .importDataIntoCurrentWorkspace(dataJson);
+            Thingifier released = staging.releaseThingifier();
+            workspace.replaceWithProjectThingifier(
+                    released,
+                    targetStorage,
+                    targetDatabase.getParent(),
+                    snapshot.definition().title(),
+                    snapshot.definition().description());
+        } finally {
+            if (staging != null) {
+                staging.close();
+            }
+        }
+    }
+
+    private UiHttpResponse loadSqliteBackedProject(
+            final ProjectBundle bundle,
+            final ThingifierProjectManifest manifest,
+            final String schemaYaml,
+            final String projectPathDisplay) {
+        WorkspaceStorage storage = WorkspaceStorage.sqliteFile(sqliteDataPath(bundle, manifest));
+        Thingifier stagedThingifier = yamlLoader.loadThingifier(schemaYaml, storage.provider());
+        WorkspaceSnapshot loaded =
+                workspace.replaceWithProjectThingifier(
+                        stagedThingifier,
+                        storage,
+                        projectPathDisplay,
+                        manifest.title(),
+                        manifest.description());
+        return UiHttpResponse.json(200, metadataJson.toJson(loaded, "loaded"));
+    }
+
+    private boolean isSqliteBackedProject(
+            final ProjectBundle bundle, final ThingifierProjectManifest manifest) {
+        if (manifest.isSqliteFileStorage()) {
+            return true;
+        }
+        if (manifest.dataFile().isEmpty()) {
+            return false;
+        }
+        return hasSqliteHeader(bundle.resolve(manifest.dataFile()));
+    }
+
+    private Path sqliteDataPath(
+            final ProjectBundle bundle, final ThingifierProjectManifest manifest) {
+        String sqliteFile =
+                manifest.sqliteFile().isEmpty() ? manifest.dataFile() : manifest.sqliteFile();
+        return bundle.resolve(sqliteFile);
+    }
+
+    private boolean hasSqliteHeader(final Path path) {
+        if (!Files.isRegularFile(path)) {
+            return false;
+        }
+        byte[] expected = "SQLite format 3\u0000".getBytes(StandardCharsets.US_ASCII);
+        byte[] actual = new byte[expected.length];
+        try (java.io.InputStream input = Files.newInputStream(path)) {
+            int read = input.read(actual);
+            return read == expected.length && Arrays.equals(expected, actual);
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    private Map<String, Object> checkSavePath(final String pathText) {
+        Path path = Paths.get(pathText).toAbsolutePath().normalize();
+        Map<String, Object> body = baseCheckBody(ProjectActionRequest.ACTION_SAVE, path);
+        if (path.getFileName() != null
+                && ThingifierProjectManifest.DEFAULT_MANIFEST_FILE.equals(
+                        path.getFileName().toString())) {
+            body.put("message", "Project save path must be a folder");
+            return body;
+        }
+        if (Files.exists(path) && !Files.isDirectory(path)) {
+            body.put("message", "Project path must be a folder");
+            return body;
+        }
+        List<String> managedFiles = managedFilesIn(path);
+        body.put("valid", true);
+        body.put("canProceed", true);
+        body.put("kind", Files.exists(path) ? "folder" : "creatable-folder");
+        body.put("exists", Files.exists(path));
+        body.put("managedFiles", managedFiles);
+        body.put(
+                "message",
+                Files.exists(path)
+                        ? "Project folder is available."
+                        : "Project folder can be created.");
+        if (!managedFiles.isEmpty()) {
+            body.put(
+                    "warning",
+                    "Saving will overwrite managed project files: "
+                            + String.join(", ", managedFiles));
+        }
+        return body;
+    }
+
+    private Map<String, Object> checkLoadPath(final String pathText) {
+        Path path = Paths.get(pathText).toAbsolutePath().normalize();
+        Map<String, Object> body = baseCheckBody(ProjectActionRequest.ACTION_LOAD, path);
+        ProjectBundle bundle = ProjectBundle.resolve(path);
+        Path manifestPath = bundle.manifestPath();
+        body.put("kind", Files.isDirectory(path) ? "folder" : "project-file");
+        if (!Files.exists(manifestPath)) {
+            body.put("message", "Project file does not exist.");
+            return body;
+        }
+        if (!Files.isRegularFile(manifestPath)) {
+            body.put("message", "Project file path must be a file.");
+            return body;
+        }
+        try {
+            ThingifierProjectManifest manifest = manifestYaml.load(manifestPath);
+            Path schemaFile = bundle.resolve(manifest.schemaFile());
+            if (!Files.exists(schemaFile)) {
+                body.put("message", "Project schema file does not exist.");
+                return body;
+            }
+            if (isSqliteBackedProject(bundle, manifest)) {
+                Path sqliteFile = sqliteDataPath(bundle, manifest);
+                if (!Files.exists(sqliteFile)) {
+                    body.put("message", "Project SQLite file does not exist.");
+                    return body;
+                }
+            } else {
+                Path dataFile = bundle.resolve(manifest.dataFile());
+                if (!Files.exists(dataFile)) {
+                    body.put("message", "Project data file does not exist.");
+                    return body;
+                }
+            }
+            body.put("valid", true);
+            body.put("canProceed", true);
+            body.put("message", "Project can be loaded.");
+        } catch (ThingifierYamlException e) {
+            body.put("message", e.getMessage());
+        } catch (IOException e) {
+            body.put("message", "Could not check project: " + e.getMessage());
+        }
+        return body;
+    }
+
+    private Map<String, Object> baseCheckBody(final String action, final Path path) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("action", action);
+        body.put("path", path.toString());
+        body.put("valid", false);
+        body.put("canProceed", false);
+        body.put("managedFiles", List.of());
+        body.put("warning", "");
+        return body;
+    }
+
+    private List<String> managedFilesIn(final Path folder) {
+        List<String> managedFiles = new ArrayList<>();
+        if (!Files.isDirectory(folder)) {
+            return managedFiles;
+        }
+        addIfExists(managedFiles, folder, ThingifierProjectManifest.DEFAULT_MANIFEST_FILE);
+        addIfExists(managedFiles, folder, ThingifierProjectManifest.DEFAULT_SCHEMA_FILE);
+        addIfExists(managedFiles, folder, ThingifierProjectManifest.DEFAULT_DATA_FILE);
+        addIfExists(managedFiles, folder, ThingifierProjectManifest.DEFAULT_SQLITE_FILE);
+        return managedFiles;
+    }
+
+    private void addIfExists(final List<String> files, final Path folder, final String name) {
+        if (Files.exists(folder.resolve(name))) {
+            files.add(name);
+        }
+    }
+
+    private List<Map<String, Object>> jsonBackedProjectFiles(final WorkspaceSnapshot snapshot) {
+        ThingifierProjectManifest manifest =
+                ThingifierProjectManifest.defaultFor(
+                        snapshot.definition().title(), snapshot.definition().description());
+        WorkspaceDataExporter exporter =
+                new WorkspaceDataExporter(workspace, new DynamicThingifierApiProxy(workspace));
+        List<Map<String, Object>> files = new ArrayList<>();
+        files.add(
+                textFile(
+                        ThingifierProjectManifest.DEFAULT_MANIFEST_FILE,
+                        manifestYaml.export(manifest)));
+        files.add(textFile(ThingifierProjectManifest.DEFAULT_SCHEMA_FILE, snapshot.schemaYaml()));
+        files.add(
+                textFile(
+                        ThingifierProjectManifest.DEFAULT_DATA_FILE,
+                        exporter.exportProjectDataJson()));
+        return files;
+    }
+
+    private List<Map<String, Object>> sqliteBackedProjectFiles(final WorkspaceSnapshot snapshot)
+            throws IOException {
+        ThingifierProjectManifest manifest =
+                ThingifierProjectManifest.sqliteFileBackedFor(
+                        snapshot.definition().title(), snapshot.definition().description());
+        List<Map<String, Object>> files = new ArrayList<>();
+        files.add(
+                textFile(
+                        ThingifierProjectManifest.DEFAULT_MANIFEST_FILE,
+                        manifestYaml.export(manifest)));
+        files.add(textFile(ThingifierProjectManifest.DEFAULT_SCHEMA_FILE, snapshot.schemaYaml()));
+        files.add(
+                binaryFile(
+                        ThingifierProjectManifest.DEFAULT_SQLITE_FILE,
+                        sqliteDatabaseBytesForSnapshot(snapshot)));
+        return files;
+    }
+
+    private byte[] sqliteDatabaseBytesForSnapshot(final WorkspaceSnapshot snapshot)
+            throws IOException {
+        String dataJson =
+                new WorkspaceDataExporter(workspace, new DynamicThingifierApiProxy(workspace))
+                        .exportProjectDataJson();
+        Path tempFolder = Files.createTempDirectory("thingifier-crud-ui-project-export-");
+        Path tempDatabase = tempFolder.resolve(ThingifierProjectManifest.DEFAULT_SQLITE_FILE);
+        ActiveThingifierWorkspace staging = null;
+        try {
+            WorkspaceStorage targetStorage = WorkspaceStorage.sqliteFile(tempDatabase);
+            Thingifier stagedThingifier =
+                    new ThingifierModelAssembler()
+                            .assemble(snapshot.definition(), targetStorage.provider());
+            stagedThingifier.clearAllData();
+            staging = ActiveThingifierWorkspace.forThingifier(stagedThingifier, targetStorage);
+            new WorkspaceDataImporter(
+                            staging,
+                            new DynamicThingifierApiProxy(staging),
+                            new WorkspaceMetadataJson())
+                    .importDataIntoCurrentWorkspace(dataJson);
+        } finally {
+            if (staging != null) {
+                staging.close();
+            }
+        }
+        byte[] bytes = Files.readAllBytes(tempDatabase);
+        deleteDatabaseFiles(tempDatabase);
+        Files.deleteIfExists(tempFolder);
+        return bytes;
+    }
+
+    private Map<String, Object> textFile(final String name, final String contents) {
+        Map<String, Object> file = new LinkedHashMap<>();
+        file.put("name", name);
+        file.put("type", FILE_TYPE_TEXT);
+        file.put("content", contents);
+        return file;
+    }
+
+    private Map<String, Object> binaryFile(final String name, final byte[] contents) {
+        Map<String, Object> file = new LinkedHashMap<>();
+        file.put("name", name);
+        file.put("type", FILE_TYPE_BASE64);
+        file.put("content", Base64.getEncoder().encodeToString(contents));
+        return file;
+    }
+
+    private void writePayloadFiles(final Path folder, final List<?> files) throws IOException {
+        for (Object value : files) {
+            if (!(value instanceof Map)) {
+                throw new CrudUiException(400, "Project files must be objects");
+            }
+            Map<?, ?> file = (Map<?, ?>) value;
+            String name = stringValue(file.get("name")).trim();
+            String type = stringValue(file.get("type")).trim();
+            String content = stringValue(file.get("content"));
+            Path target = payloadPath(folder, name);
+            if (FILE_TYPE_BASE64.equals(type)) {
+                Files.write(target, Base64.getDecoder().decode(content));
+            } else if (FILE_TYPE_TEXT.equals(type) || type.isEmpty()) {
+                writeString(target, content);
+            } else {
+                throw new CrudUiException(400, "Unsupported project file type: " + type);
+            }
+        }
+    }
+
+    private Path payloadPath(final Path folder, final String fileName) {
+        if (fileName.isEmpty()
+                || fileName.contains("/")
+                || fileName.contains("\\")
+                || Paths.get(fileName).isAbsolute()) {
+            throw new CrudUiException(400, "Project file names must be project-root files");
+        }
+        Path resolved = folder.resolve(fileName).normalize();
+        if (!resolved.startsWith(folder)) {
+            throw new CrudUiException(400, "Project file path escapes the project folder");
+        }
+        return resolved;
+    }
+
+    private String browserProjectDisplay(final String folderName) {
+        String safeName = folderName.isEmpty() ? "selected folder" : folderName;
+        return "Browser folder: " + safeName;
     }
 
     private Path projectFolderFromRequest(final String requestJson) {
@@ -108,11 +541,7 @@ public final class WorkspaceProjectService {
     }
 
     private Path projectPathFromRequest(final String requestJson) {
-        Map<?, ?> request =
-                JsonSupport.fromJsonMap(
-                        requestJson,
-                        "Project request must contain a JSON object",
-                        "Could not parse project request JSON");
+        Map<?, ?> request = projectRequestMap(requestJson);
         String path = stringValue(request.get("path")).trim();
         if (path.isEmpty()) {
             throw new CrudUiException(400, "Project request must contain path");
@@ -120,8 +549,61 @@ public final class WorkspaceProjectService {
         return Paths.get(path);
     }
 
+    private String projectStorageModeFromRequest(
+            final String requestJson, final WorkspaceSnapshot snapshot) {
+        Map<?, ?> request = optionalProjectRequestMap(requestJson);
+        String requested = stringValue(request.get("projectStorageMode")).trim();
+        if (requested.isEmpty()) {
+            requested = stringValue(request.get("storageMode")).trim();
+        }
+        if (requested.isEmpty()) {
+            return snapshot.storage().isSqliteFile()
+                    ? PROJECT_STORAGE_SQLITE
+                    : PROJECT_STORAGE_JSON;
+        }
+        String normalized = requested.toLowerCase().replace("_", "-");
+        if (PROJECT_STORAGE_JSON.equals(normalized)
+                || "data-json".equals(normalized)
+                || WorkspaceStorage.MODE_MEMORY.equals(normalized)) {
+            return PROJECT_STORAGE_JSON;
+        }
+        if (PROJECT_STORAGE_SQLITE.equals(normalized)
+                || WorkspaceStorage.MODE_SQLITE_FILE.equals(normalized)
+                || "data-sqlite".equals(normalized)) {
+            return PROJECT_STORAGE_SQLITE;
+        }
+        throw new CrudUiException(400, "Project storage mode must be json or sqlite");
+    }
+
+    private Map<?, ?> optionalProjectRequestMap(final String requestJson) {
+        if (requestJson == null || requestJson.trim().isEmpty()) {
+            return Map.of();
+        }
+        return projectRequestMap(requestJson);
+    }
+
+    private Map<?, ?> projectRequestMap(final String requestJson) {
+        return JsonSupport.fromJsonMap(
+                requestJson,
+                "Project request must contain a JSON object",
+                "Could not parse project request JSON");
+    }
+
     private void writeString(final Path path, final String contents) throws IOException {
         Files.writeString(path, contents, StandardCharsets.UTF_8);
+    }
+
+    private void deleteDatabaseFiles(final Path databasePath) throws IOException {
+        Files.deleteIfExists(databasePath);
+        Files.deleteIfExists(Path.of(databasePath.toString() + "-wal"));
+        Files.deleteIfExists(Path.of(databasePath.toString() + "-shm"));
+    }
+
+    private boolean samePath(final Path first, final Path second) {
+        if (first == null || second == null) {
+            return false;
+        }
+        return first.toAbsolutePath().normalize().equals(second.toAbsolutePath().normalize());
     }
 
     private String stringValue(final Object value) {

--- a/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceSchemaUpgradeService.java
+++ b/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceSchemaUpgradeService.java
@@ -64,7 +64,9 @@ public final class WorkspaceSchemaUpgradeService {
         try {
             WorkspaceSnapshot upgraded =
                     workspace.replaceWithMigratedThingifier(
-                            result.targetThingifier(), request.expectedWorkspaceVersion());
+                            result.targetThingifier(),
+                            result.targetStorage(),
+                            request.expectedWorkspaceVersion());
             result.releaseTargetThingifier();
             result.markApplied(upgraded, metadataJson.toMap(upgraded));
             return UiHttpResponse.json(200, JsonSupport.toJson(result.body()));
@@ -104,17 +106,27 @@ public final class WorkspaceSchemaUpgradeService {
         result.addWarnings(mappings.warnings());
         result.putSummary(mappings.summaryMap(sourceData));
 
-        Thingifier targetThingifier = assembler.assemble(request.definition());
+        WorkspaceStorage targetStorage = targetStorageFor(snapshot.storage());
+        Thingifier targetThingifier =
+                assembler.assemble(request.definition(), targetStorage.provider());
+        targetThingifier.clearAllData();
         try {
             migrate(sourceData, request.definition(), targetThingifier, mappings, result);
             validateFinalData(request.definition(), targetThingifier, result);
-            result.targetThingifier(targetThingifier);
+            result.targetThingifier(targetThingifier, targetStorage);
         } catch (IllegalArgumentException | IllegalStateException | IndexOutOfBoundsException e) {
             targetThingifier.close();
             result.addBlockingError("migration", e.getMessage());
         }
         result.finish();
         return result;
+    }
+
+    private WorkspaceStorage targetStorageFor(final WorkspaceStorage currentStorage) {
+        if (WorkspaceStorage.MODE_SQLITE_MEMORY.equals(currentStorage.mode())) {
+            return WorkspaceStorage.sqliteMemory();
+        }
+        return WorkspaceStorage.memory();
     }
 
     private void migrate(
@@ -1129,6 +1141,7 @@ public final class WorkspaceSchemaUpgradeService {
         private final List<Map<String, Object>> coercions;
         private final List<Map<String, Object>> valueAssignments;
         private Thingifier targetThingifier;
+        private WorkspaceStorage targetStorage;
         private int statusCode;
 
         private MigrationResult(final long workspaceVersion) {
@@ -1245,12 +1258,18 @@ public final class WorkspaceSchemaUpgradeService {
             errors.add(error);
         }
 
-        private void targetThingifier(final Thingifier targetThingifier) {
+        private void targetThingifier(
+                final Thingifier targetThingifier, final WorkspaceStorage targetStorage) {
             this.targetThingifier = targetThingifier;
+            this.targetStorage = targetStorage;
         }
 
         private Thingifier targetThingifier() {
             return targetThingifier;
+        }
+
+        private WorkspaceStorage targetStorage() {
+            return targetStorage == null ? WorkspaceStorage.memory() : targetStorage;
         }
 
         private boolean canApply() {
@@ -1293,12 +1312,14 @@ public final class WorkspaceSchemaUpgradeService {
 
         private void releaseTargetThingifier() {
             targetThingifier = null;
+            targetStorage = null;
         }
 
         private void closeTargetThingifier() {
             if (targetThingifier != null) {
                 targetThingifier.close();
                 targetThingifier = null;
+                targetStorage = null;
             }
         }
     }

--- a/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceSnapshot.java
+++ b/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceSnapshot.java
@@ -9,6 +9,7 @@ public final class WorkspaceSnapshot {
     private final Thingifier thingifier;
     private final ThingifierModelDefinition definition;
     private final String schemaYaml;
+    private final WorkspaceStorage storage;
     private final String projectPath;
     private final String projectTitle;
     private final String projectDescription;
@@ -18,7 +19,7 @@ public final class WorkspaceSnapshot {
             final Thingifier thingifier,
             final ThingifierModelDefinition definition,
             final String schemaYaml) {
-        this(version, thingifier, definition, schemaYaml, "", "", "");
+        this(version, thingifier, definition, schemaYaml, WorkspaceStorage.memory(), "", "", "");
     }
 
     public WorkspaceSnapshot(
@@ -26,6 +27,7 @@ public final class WorkspaceSnapshot {
             final Thingifier thingifier,
             final ThingifierModelDefinition definition,
             final String schemaYaml,
+            final WorkspaceStorage storage,
             final String projectPath,
             final String projectTitle,
             final String projectDescription) {
@@ -33,6 +35,7 @@ public final class WorkspaceSnapshot {
         this.thingifier = thingifier;
         this.definition = definition;
         this.schemaYaml = schemaYaml;
+        this.storage = storage == null ? WorkspaceStorage.memory() : storage;
         this.projectPath = nullToEmpty(projectPath);
         this.projectTitle = nullToEmpty(projectTitle);
         this.projectDescription = nullToEmpty(projectDescription);
@@ -52,6 +55,10 @@ public final class WorkspaceSnapshot {
 
     public String schemaYaml() {
         return schemaYaml;
+    }
+
+    public WorkspaceStorage storage() {
+        return storage;
     }
 
     public String projectPath() {

--- a/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceStorage.java
+++ b/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceStorage.java
@@ -1,0 +1,105 @@
+package uk.co.compendiumdev.thingifier.crudui;
+
+import java.nio.file.Path;
+import uk.co.compendiumdev.thingifier.core.repository.ThingStoreProvider;
+import uk.co.compendiumdev.thingifier.core.repository.ThingStoreProviderConfig;
+import uk.co.compendiumdev.thingifier.core.repository.inmemory.InMemoryThingStoreProvider;
+import uk.co.compendiumdev.thingifier.core.repository.sqlite.SqliteThingStoreProvider;
+
+public final class WorkspaceStorage {
+
+    public static final String MODE_MEMORY = "memory";
+    public static final String MODE_SQLITE_MEMORY = "sqlite-memory";
+    public static final String MODE_SQLITE_FILE = "sqlite-file";
+
+    private final String mode;
+    private final Path sqliteFile;
+
+    private WorkspaceStorage(final String mode, final Path sqliteFile) {
+        this.mode = mode;
+        this.sqliteFile = sqliteFile == null ? null : sqliteFile.toAbsolutePath().normalize();
+    }
+
+    public static WorkspaceStorage memory() {
+        return new WorkspaceStorage(MODE_MEMORY, null);
+    }
+
+    public static WorkspaceStorage sqliteMemory() {
+        return new WorkspaceStorage(MODE_SQLITE_MEMORY, null);
+    }
+
+    public static WorkspaceStorage sqliteFile(final Path sqliteFile) {
+        if (sqliteFile == null || sqliteFile.toString().trim().isEmpty()) {
+            throw new IllegalArgumentException("SQLite file path is required");
+        }
+        return new WorkspaceStorage(MODE_SQLITE_FILE, sqliteFile);
+    }
+
+    public static WorkspaceStorage fromConfig(final ThingStoreProviderConfig config) {
+        String mode = normalize(config.getRepositoryMode());
+        if (MODE_SQLITE_MEMORY.equals(mode)
+                || "sqlite".equals(mode)
+                || "sqlite-in-memory".equals(mode)) {
+            return sqliteMemory();
+        }
+        if (MODE_SQLITE_FILE.equals(mode) || "sqlite-disk".equals(mode) || "file".equals(mode)) {
+            if (config.hasSqliteFile()) {
+                return sqliteFile(config.getSqliteFile());
+            }
+            return sqliteFile(config.getSqliteDirectory().resolve("thingifier.sqlite"));
+        }
+        return memory();
+    }
+
+    public static WorkspaceStorage fromModeAndPath(final String mode, final String sqliteFile) {
+        String normalizedMode = normalize(mode);
+        if (normalizedMode.isEmpty() || MODE_MEMORY.equals(normalizedMode)) {
+            return memory();
+        }
+        if (MODE_SQLITE_MEMORY.equals(normalizedMode)
+                || "sqlite".equals(normalizedMode)
+                || "sqlite-in-memory".equals(normalizedMode)) {
+            return sqliteMemory();
+        }
+        if (MODE_SQLITE_FILE.equals(normalizedMode)
+                || "sqlite-disk".equals(normalizedMode)
+                || "file".equals(normalizedMode)) {
+            return sqliteFile(Path.of(nullToEmpty(sqliteFile).trim()));
+        }
+        throw new IllegalArgumentException("Unknown workspace storage mode " + mode);
+    }
+
+    public ThingStoreProvider provider() {
+        if (MODE_SQLITE_MEMORY.equals(mode)) {
+            return SqliteThingStoreProvider.inMemory();
+        }
+        if (MODE_SQLITE_FILE.equals(mode)) {
+            return SqliteThingStoreProvider.fileBackedFile(sqliteFile);
+        }
+        return new InMemoryThingStoreProvider();
+    }
+
+    public String mode() {
+        return mode;
+    }
+
+    public boolean isSqliteFile() {
+        return MODE_SQLITE_FILE.equals(mode);
+    }
+
+    public String sqliteFilePath() {
+        return sqliteFile == null ? "" : sqliteFile.toString();
+    }
+
+    public Path sqliteFile() {
+        return sqliteFile;
+    }
+
+    private static String normalize(final String value) {
+        return nullToEmpty(value).trim().toLowerCase().replace("_", "-");
+    }
+
+    private static String nullToEmpty(final String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/adapter/spark/CrudUiApplication.java
+++ b/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/adapter/spark/CrudUiApplication.java
@@ -66,6 +66,23 @@ public final class CrudUiApplication implements AutoCloseable {
         Spark.post(
                 "/ui/project/load",
                 (request, response) -> write(response, controller.loadProject(request.body())));
+        Spark.post(
+                "/ui/project/browse",
+                (request, response) -> write(response, controller.browseProject(request.body())));
+        Spark.post(
+                "/ui/project/check",
+                (request, response) -> write(response, controller.checkProject(request.body())));
+        Spark.post(
+                "/ui/project/export-files",
+                (request, response) ->
+                        write(response, controller.exportProjectFiles(request.body())));
+        Spark.post(
+                "/ui/project/load-files",
+                (request, response) ->
+                        write(response, controller.loadProjectFiles(request.body())));
+        Spark.post(
+                "/ui/storage/switch",
+                (request, response) -> write(response, controller.switchStorage(request.body())));
         Spark.get(
                 "/docs", (request, response) -> write(response, controller.apiDocumentationPage()));
         Spark.get(
@@ -116,6 +133,8 @@ public final class CrudUiApplication implements AutoCloseable {
 
     @Override
     public void close() {
+        Spark.stop();
+        Spark.awaitStop();
         workspace.close();
     }
 }

--- a/thingifier-crud-ui/src/main/resources/public/assets/app.js
+++ b/thingifier-crud-ui/src/main/resources/public/assets/app.js
@@ -48,6 +48,9 @@ const els = {
     exportButton: document.getElementById("export-button"),
     saveProjectButton: document.getElementById("save-project-button"),
     loadProjectButton: document.getElementById("load-project-button"),
+    storageModeSelect: document.getElementById("storage-mode-select"),
+    storageFileInput: document.getElementById("storage-file-input"),
+    switchStorageButton: document.getElementById("switch-storage-button"),
     yamlFile: document.getElementById("yaml-file"),
     importFile: document.getElementById("import-file"),
     projectDialog: document.getElementById("project-dialog"),
@@ -55,6 +58,15 @@ const els = {
     projectDialogDescription: document.getElementById("project-dialog-description"),
     projectDialogWarning: document.getElementById("project-dialog-warning"),
     projectPathInput: document.getElementById("project-path-input"),
+    projectRecentPaths: document.getElementById("project-recent-paths"),
+    projectBrowseButton: document.getElementById("project-browse-button"),
+    projectValidateButton: document.getElementById("project-validate-button"),
+    projectBrowserSaveButton: document.getElementById("project-browser-save-button"),
+    projectBrowserLoadButton: document.getElementById("project-browser-load-button"),
+    projectBrowserStatus: document.getElementById("project-browser-status"),
+    projectSaveStorageOptions: document.getElementById("project-save-storage-options"),
+    projectSaveStorageJson: document.getElementById("project-save-storage-json"),
+    projectSaveStorageSqlite: document.getElementById("project-save-storage-sqlite"),
     projectDialogConfirm: document.getElementById("project-dialog-confirm"),
     projectDialogCancel: document.getElementById("project-dialog-cancel"),
     schemaWorkspaceLink: document.getElementById("schema-workspace-link"),
@@ -99,6 +111,8 @@ const els = {
     schemaMermaidDiagram: document.getElementById("schema-mermaid-diagram")
 };
 
+const PROJECT_RECENT_PATHS_KEY = "thingifier-crud-ui.projectPaths";
+
 async function requestJson(path, options = {}) {
     const response = await fetch(path, {
         headers: {
@@ -133,6 +147,7 @@ async function loadWorkspace() {
     clearMessage();
     state.workspace = await requestJson("/ui/workspace");
     renderHeader();
+    syncStorageControlsFromWorkspace();
     if (!els.tree) {
         return;
     }
@@ -222,7 +237,18 @@ function renderHeader() {
     const projectPath = state.workspace.project && state.workspace.project.path
         ? `Project: ${state.workspace.project.path}`
         : "";
-    els.description.textContent = [description, projectPath].filter(Boolean).join(" | ");
+    els.description.textContent = [description, projectPath, storageDescription()].filter(Boolean).join(" | ");
+}
+
+function storageDescription() {
+    const storage = state.workspace && state.workspace.storage ? state.workspace.storage : {};
+    if (storage.mode === "sqlite-file") {
+        return `Storage: SQLite File${storage.sqliteFile ? ` (${storage.sqliteFile})` : ""}`;
+    }
+    if (storage.mode === "sqlite-memory") {
+        return "Storage: SQLite In Memory";
+    }
+    return "Storage: In Memory";
 }
 
 function renderTree() {
@@ -235,6 +261,7 @@ function renderTree() {
             entity.plural,
             state.entityCounts[entity.name] ?? "",
             isExpanded(entityKey));
+        setTestId(button, testIdFor("outline-entity", entity.name));
         button.addEventListener("click", event => {
             if (clickedCaret(event)) {
                 toggleExpanded(entityKey);
@@ -248,6 +275,7 @@ function renderTree() {
         if (isExpanded(entityKey)) {
             const group = document.createElement("div");
             group.className = "tree-children entity-children";
+            setTestId(group, testIdFor("outline-entity-children", entity.name));
             node.instances.forEach(instance => renderInstanceNode(group, entity, instance));
             if (node.instances.length === 0) {
                 group.appendChild(emptyTreeNode("No instances"));
@@ -265,6 +293,7 @@ function renderInstanceNode(container, entity, instanceNode) {
         instanceLabel(entity, row),
         "",
         isExpanded(instanceKey));
+    setTestId(button, testIdFor("outline-instance", entity.name, primaryValue(entity, row)));
     button.addEventListener("click", event => {
         if (clickedCaret(event)) {
             toggleExpanded(instanceKey);
@@ -281,6 +310,7 @@ function renderInstanceNode(container, entity, instanceNode) {
 
     const relationshipGroup = document.createElement("div");
     relationshipGroup.className = "tree-children relationship-group";
+    setTestId(relationshipGroup, testIdFor("outline-relationships", entity.name, primaryValue(entity, row)));
     instanceNode.relationships.forEach(relationshipNode => {
         renderRelationshipNode(relationshipGroup, entity, row, relationshipNode);
     });
@@ -298,6 +328,7 @@ function renderRelationshipNode(container, entity, sourceRow, relationshipNode) 
         relationship.name,
         relationshipNode.rows.length,
         isExpanded(relationshipKey));
+    setTestId(button, testIdFor("outline-relationship", entity.name, primaryValue(entity, sourceRow), relationship.name));
     button.addEventListener("click", event => {
         if (clickedCaret(event)) {
             toggleExpanded(relationshipKey);
@@ -314,12 +345,14 @@ function renderRelationshipNode(container, entity, sourceRow, relationshipNode) 
 
     const relatedGroup = document.createElement("div");
     relatedGroup.className = "tree-children related-instance-group";
+    setTestId(relatedGroup, testIdFor("outline-related-instances", entity.name, primaryValue(entity, sourceRow), relationship.name));
     relationshipNode.rows.forEach(row => {
         const relatedButton = treeButton(
             `relationship-item relationship-instance ${isSelectedRow(relationshipNode.target, row) ? "active" : ""}`,
             instanceLabel(relationshipNode.target, row),
             "",
             null);
+        setTestId(relatedButton, testIdFor("outline-related-instance", relationshipNode.target.name, primaryValue(relationshipNode.target, row)));
         relatedButton.addEventListener(
             "click",
             () => selectRelatedInstance(relationshipNode.target, relationshipNode.rows, row));
@@ -482,6 +515,7 @@ function renderGrid(rows, gridEntity = state.currentEntity) {
     const fields = gridEntity.fields;
     const table = document.createElement("table");
     table.className = "data-grid";
+    setTestId(table, testIdFor("data-grid", gridEntity.name));
     table.appendChild(gridHead(fields, gridEntity, isRelationshipGrid(gridEntity)));
     table.appendChild(gridBody(filteredRows(rows, gridEntity), fields, gridEntity));
     els.gridHost.innerHTML = "";
@@ -508,6 +542,7 @@ function gridHead(fields, entity, hasRelationshipActions = false) {
         input.className = "filter-input";
         input.placeholder = "Filter";
         input.value = state.filters[field.name] || "";
+        setTestId(input, testIdFor("grid-filter", entity.name, field.name));
         input.addEventListener("input", event => {
             state.filters[field.name] = event.target.value;
             renderGrid(state.currentRows, entity);
@@ -528,6 +563,7 @@ function gridBody(rows, fields, entity) {
     const tbody = document.createElement("tbody");
     rows.forEach(rowData => {
         const row = document.createElement("tr");
+        setTestId(row, testIdFor("grid-row", entity.name, primaryValue(entity, rowData)));
         if (isSelectedRow(entity, rowData)) {
             row.className = "selected";
         }
@@ -544,6 +580,7 @@ function gridBody(rows, fields, entity) {
             remove.className = "danger compact-button";
             remove.textContent = "Remove";
             remove.title = "Remove from relationship";
+            setTestId(remove, testIdFor("relationship-row-remove", entity.name, primaryValue(entity, rowData)));
             remove.addEventListener("click", event => {
                 event.stopPropagation();
                 removeRelationship(rowData);
@@ -569,6 +606,7 @@ function relationshipManagementPanel(targetEntity, relatedRows) {
     const context = state.relationshipContext;
     const panel = document.createElement("section");
     panel.className = "relationship-manager";
+    setTestId(panel, "relationship-manager");
 
     const heading = document.createElement("div");
     heading.className = "relationship-manager-heading";
@@ -592,6 +630,7 @@ function relationshipManagementPanel(targetEntity, relatedRows) {
 function connectExistingPanel(targetEntity, relatedRows) {
     const card = document.createElement("form");
     card.className = "relationship-manager-card";
+    setTestId(card, "relationship-connect-existing");
     const title = document.createElement("h4");
     title.textContent = "Connect existing";
     card.appendChild(title);
@@ -600,6 +639,7 @@ function connectExistingPanel(targetEntity, relatedRows) {
     const select = document.createElement("select");
     select.name = "target";
     select.disabled = availableRows.length === 0;
+    setTestId(select, "relationship-connect-select");
     availableRows.forEach(row => {
         const option = document.createElement("option");
         option.value = primaryValue(targetEntity, row);
@@ -620,6 +660,7 @@ function connectExistingPanel(targetEntity, relatedRows) {
     button.className = "primary";
     button.textContent = "Connect existing";
     button.disabled = availableRows.length === 0;
+    setTestId(button, "relationship-connect-submit");
     card.appendChild(button);
     card.addEventListener("submit", event => {
         event.preventDefault();
@@ -631,6 +672,7 @@ function connectExistingPanel(targetEntity, relatedRows) {
 function createAndConnectPanel(targetEntity) {
     const card = document.createElement("form");
     card.className = "relationship-manager-card relationship-create-form";
+    setTestId(card, "relationship-create-and-connect");
     const title = document.createElement("h4");
     title.textContent = "Create and connect";
     card.appendChild(title);
@@ -650,6 +692,7 @@ function createAndConnectPanel(targetEntity) {
     button.type = "submit";
     button.className = "primary";
     button.textContent = "Create and connect";
+    setTestId(button, "relationship-create-submit");
     card.appendChild(button);
     card.addEventListener("submit", event => {
         event.preventDefault();
@@ -697,6 +740,7 @@ function renderEditor(row = state.selectedRow) {
 
     const form = document.createElement("form");
     form.className = "editor-form";
+    setTestId(form, "editor-form");
     entity.fields.forEach(field => form.appendChild(fieldControl(field, row, isCreate)));
     els.editor.appendChild(form);
 
@@ -706,6 +750,7 @@ function renderEditor(row = state.selectedRow) {
     save.type = "button";
     save.className = "primary";
     save.textContent = "Save";
+    setTestId(save, "editor-save-button");
     save.addEventListener("click", () => saveEntity(entity, form, isCreate));
     actions.appendChild(save);
     if (!isCreate) {
@@ -714,6 +759,7 @@ function renderEditor(row = state.selectedRow) {
             disconnect.type = "button";
             disconnect.className = "danger";
             disconnect.textContent = "Remove from relationship";
+            setTestId(disconnect, "editor-remove-relationship-button");
             disconnect.addEventListener("click", () => removeRelationship(row));
             actions.appendChild(disconnect);
         }
@@ -721,6 +767,7 @@ function renderEditor(row = state.selectedRow) {
         remove.type = "button";
         remove.className = "danger";
         remove.textContent = "Delete";
+        setTestId(remove, "editor-delete-button");
         remove.addEventListener("click", () => deleteEntity(entity, row));
         actions.appendChild(remove);
     }
@@ -730,6 +777,7 @@ function renderEditor(row = state.selectedRow) {
 function fieldControl(field, row, isCreate, idPrefix = "editor") {
     const wrap = document.createElement("div");
     wrap.className = "field-control";
+    setTestId(wrap, testIdFor("field-control", idPrefix, field.name));
     const readOnly = field.auto || (!isCreate && field.primary);
     const autoAssigned = isCreate && field.auto;
     if (readOnly) {
@@ -743,6 +791,7 @@ function fieldControl(field, row, isCreate, idPrefix = "editor") {
     const input = inputFor(field, value, autoAssigned);
     input.name = field.name;
     input.id = `${idPrefix}-${field.name}`;
+    setTestId(input, testIdFor("field-input", idPrefix, field.name));
     label.htmlFor = input.id;
     wrap.appendChild(label);
     if (readOnly) {
@@ -804,10 +853,25 @@ function inputFor(field, value, forceText = false) {
         textarea.value = value ? JSON.stringify(value, null, 2) : "";
         return textarea;
     }
+    if (field.type === "string" && !stringFieldHasMaxLength(field)) {
+        const textarea = document.createElement("textarea");
+        textarea.className = "long-text-input";
+        textarea.rows = 4;
+        textarea.value = value ?? "";
+        return textarea;
+    }
     const input = document.createElement("input");
     input.type = field.type === "date" ? "date" : "text";
     input.value = value ?? "";
     return input;
+}
+
+function stringFieldHasMaxLength(field) {
+    if (field.truncateTo !== null && field.truncateTo !== undefined && field.truncateTo !== "") {
+        return true;
+    }
+    return Array.isArray(field.validations)
+        && field.validations.some(validation => validation && validation.type === "maximumLength");
 }
 
 async function saveEntity(entity, form, isCreate) {
@@ -920,7 +984,7 @@ function bodyFromForm(entity, form) {
 
 function valueFromInput(field, input) {
     if (field.type === "boolean") {
-        return input.checked ? "true" : "false";
+        return input.checked;
     }
     if (field.type === "object") {
         try {
@@ -1071,6 +1135,74 @@ function clearMessage() {
     els.message.hidden = true;
 }
 
+function escapeHtml(value) {
+    return String(value).replace(/[&<>"']/g, character => ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        "\"": "&quot;",
+        "'": "&#39;"
+    }[character]));
+}
+
+function testIdPart(value) {
+    return String(value ?? "")
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "") || "blank";
+}
+
+function testIdFor(prefix, ...parts) {
+    return [prefix, ...parts.map(testIdPart)].join("-");
+}
+
+function setTestId(element, id) {
+    element.setAttribute("data-testid", id);
+    return element;
+}
+
+function projectRecentPaths() {
+    try {
+        const paths = JSON.parse(localStorage.getItem(PROJECT_RECENT_PATHS_KEY) || "[]");
+        return Array.isArray(paths) ? paths.filter(path => typeof path === "string") : [];
+    } catch (error) {
+        return [];
+    }
+}
+
+function rememberProjectPath(path) {
+    if (!path) {
+        return;
+    }
+    const paths = projectRecentPaths().filter(existing => existing !== path);
+    paths.unshift(path);
+    localStorage.setItem(PROJECT_RECENT_PATHS_KEY, JSON.stringify(paths.slice(0, 8)));
+    renderProjectRecentPaths();
+}
+
+function renderProjectRecentPaths() {
+    if (!els.projectRecentPaths) {
+        return;
+    }
+    els.projectRecentPaths.innerHTML = projectRecentPaths()
+        .map(path => `<option value="${escapeHtml(path)}"></option>`)
+        .join("");
+}
+
+function setProjectDialogStatus(text, error = false) {
+    if (!els.projectBrowserStatus) {
+        return;
+    }
+    els.projectBrowserStatus.textContent = text || "";
+    els.projectBrowserStatus.className = error
+        ? "project-browser-status error"
+        : "project-browser-status";
+}
+
+function browserDirectoryPickerAvailable() {
+    return typeof window.showDirectoryPicker === "function";
+}
+
 function openProjectDialog(action) {
     if (!els.projectDialog) {
         return;
@@ -1085,12 +1217,50 @@ function openProjectDialog(action) {
         ? "Save the active schema and data to a server-side project folder."
         : "Load schema and data from a server-side project folder or projectfile.erproj.";
     els.projectDialogWarning.textContent = isSave
-        ? "Saving overwrites projectfile.erproj, schema.yaml, and data.json in the selected folder. Other files are left alone."
+        ? "Saving overwrites managed project files in the selected folder. Other files are left alone."
         : "Loading a project replaces the current workspace schema and data.";
     els.projectDialogConfirm.textContent = isSave ? "Save Project" : "Load Project";
+    syncProjectSaveStorageOptions(isSave);
+    if (els.projectBrowserSaveButton) {
+        els.projectBrowserSaveButton.hidden = !isSave;
+        els.projectBrowserSaveButton.disabled = !browserDirectoryPickerAvailable();
+    }
+    if (els.projectBrowserLoadButton) {
+        els.projectBrowserLoadButton.hidden = isSave;
+        els.projectBrowserLoadButton.disabled = !browserDirectoryPickerAvailable();
+    }
+    setProjectDialogStatus(
+        browserDirectoryPickerAvailable()
+            ? ""
+            : "Browser folder picker is not available in this browser; use Browse or type a path.");
+    renderProjectRecentPaths();
     els.projectPathInput.value = currentPath;
     els.projectDialog.hidden = false;
     els.projectPathInput.focus();
+}
+
+function syncProjectSaveStorageOptions(isSave) {
+    if (!els.projectSaveStorageOptions) {
+        return;
+    }
+    els.projectSaveStorageOptions.hidden = !isSave;
+    if (!isSave) {
+        return;
+    }
+    const storage = state.workspace && state.workspace.storage ? state.workspace.storage : {};
+    const saveAsSqlite = storage.mode === "sqlite-file";
+    if (els.projectSaveStorageJson) {
+        els.projectSaveStorageJson.checked = !saveAsSqlite;
+    }
+    if (els.projectSaveStorageSqlite) {
+        els.projectSaveStorageSqlite.checked = saveAsSqlite;
+    }
+}
+
+function selectedProjectStorageMode() {
+    return els.projectSaveStorageSqlite && els.projectSaveStorageSqlite.checked
+        ? "sqlite"
+        : "json";
 }
 
 function closeProjectDialog() {
@@ -1099,6 +1269,52 @@ function closeProjectDialog() {
     }
     state.projectDialogAction = null;
     els.projectDialog.hidden = true;
+}
+
+async function browseProjectPath() {
+    if (!state.projectDialogAction || !els.projectPathInput) {
+        return;
+    }
+    if (els.projectBrowseButton) {
+        els.projectBrowseButton.disabled = true;
+    }
+    setProjectDialogStatus("Waiting for native project browser...");
+    try {
+        const selection = await requestJson("/ui/project/browse", {
+            method: "POST",
+            body: JSON.stringify({
+                action: state.projectDialogAction,
+                path: els.projectPathInput.value.trim()
+            })
+        });
+        setProjectDialogStatus(selection.message || "");
+        if (selection.selected && selection.path) {
+            els.projectPathInput.value = selection.path;
+            rememberProjectPath(selection.path);
+            await validateProjectPath();
+        }
+    } finally {
+        if (els.projectBrowseButton) {
+            els.projectBrowseButton.disabled = false;
+        }
+    }
+}
+
+async function validateProjectPath() {
+    if (!state.projectDialogAction || !els.projectPathInput) {
+        return;
+    }
+    const path = els.projectPathInput.value.trim();
+    if (!path) {
+        setProjectDialogStatus("Enter a project folder path.", true);
+        return;
+    }
+    const result = await requestJson("/ui/project/check", {
+        method: "POST",
+        body: JSON.stringify({action: state.projectDialogAction, path})
+    });
+    const text = result.warning || result.message || "Project path checked.";
+    setProjectDialogStatus(text, !result.canProceed);
 }
 
 async function submitProjectDialog() {
@@ -1112,16 +1328,58 @@ async function submitProjectDialog() {
     }
     const action = state.projectDialogAction;
     const endpoint = action === "save" ? "/ui/project/save" : "/ui/project/load";
+    const requestBody = action === "save"
+        ? {path, projectStorageMode: selectedProjectStorageMode()}
+        : {path};
     const workspace = await requestJson(endpoint, {
         method: "POST",
-        body: JSON.stringify({path})
+        body: JSON.stringify(requestBody)
     });
     state.workspace = workspace;
     state.schemaDraft = null;
     state.schemaPreview = null;
+    rememberProjectPath(path);
     closeProjectDialog();
     await loadWorkspace();
     showMessage(action === "save" ? "Project saved." : "Project loaded.");
+}
+
+function syncStorageControlsFromWorkspace() {
+    if (!els.storageModeSelect) {
+        return;
+    }
+    const storage = state.workspace && state.workspace.storage ? state.workspace.storage : {};
+    els.storageModeSelect.value = storage.mode || "memory";
+    if (els.storageFileInput) {
+        els.storageFileInput.value = storage.sqliteFile || "";
+    }
+    updateStorageFileInputAvailability();
+}
+
+function updateStorageFileInputAvailability() {
+    if (!els.storageModeSelect || !els.storageFileInput) {
+        return;
+    }
+    els.storageFileInput.disabled = els.storageModeSelect.value !== "sqlite-file";
+}
+
+async function switchStorage() {
+    if (!els.storageModeSelect) {
+        return;
+    }
+    const mode = els.storageModeSelect.value;
+    const sqliteFile = els.storageFileInput ? els.storageFileInput.value.trim() : "";
+    if (mode === "sqlite-file" && !sqliteFile) {
+        showMessage("Enter a SQLite file path.", true);
+        return;
+    }
+    const workspace = await requestJson("/ui/storage/switch", {
+        method: "POST",
+        body: JSON.stringify({mode, sqliteFile})
+    });
+    state.workspace = workspace;
+    await loadWorkspace();
+    showMessage("Storage switched.");
 }
 
 function markSchemaDirty() {
@@ -1309,6 +1567,7 @@ function renderSchemaFieldTree(container, entityIndex, fields, parentPath) {
 function schemaTreeSection(title, addAction) {
     const section = document.createElement("section");
     section.className = "schema-tree-section";
+    setTestId(section, testIdFor("schema-section", title));
     const heading = document.createElement("div");
     heading.className = "schema-tree-heading";
     const text = document.createElement("span");
@@ -1325,6 +1584,7 @@ function schemaTreeNode(label, selection, meta) {
     const button = document.createElement("button");
     button.type = "button";
     button.className = `schema-tree-node ${schemaSelectionMatches(selection) ? "active" : ""}`;
+    setTestId(button, testIdFor("schema-tree", schemaSelectionKey(selection), label));
     const labelSpan = document.createElement("span");
     labelSpan.className = "tree-node-label";
     labelSpan.textContent = label;
@@ -1646,6 +1906,7 @@ function wrapSchemaDetail(primary, single, secondary) {
 function schemaCard(title) {
     const card = document.createElement("section");
     card.className = "schema-card";
+    setTestId(card, testIdFor("schema-card", title));
     const heading = document.createElement("h3");
     heading.textContent = title;
     card.appendChild(heading);
@@ -1869,6 +2130,7 @@ function renderSchemaUpgradePanel() {
 function upgradeMappingPanel() {
     const panel = document.createElement("div");
     panel.className = "schema-upgrade-card";
+    setTestId(panel, "schema-upgrade-mappings");
     panel.appendChild(sectionHeading("Migration Mappings"));
     panel.appendChild(upgradeEntityMappings());
     panel.appendChild(upgradeFieldMappings());
@@ -1879,6 +2141,7 @@ function upgradeMappingPanel() {
 function upgradeReportPanel() {
     const panel = document.createElement("div");
     panel.className = "schema-upgrade-card";
+    setTestId(panel, "schema-upgrade-report");
     panel.appendChild(sectionHeading("Upgrade Preview"));
     const preview = state.schemaUpgradePreview;
     if (!preview) {
@@ -1989,10 +2252,12 @@ function upgradeRelationshipMappings() {
 function upgradeSelectRow(labelText, value, options, emptyLabel, onChange) {
     const row = document.createElement("label");
     row.className = "schema-upgrade-row";
+    setTestId(row, testIdFor("schema-upgrade-row", labelText));
     const label = document.createElement("span");
     label.textContent = labelText;
     row.appendChild(label);
     const select = document.createElement("select");
+    setTestId(select, testIdFor("schema-upgrade-select", labelText));
     options.forEach(optionValue => {
         const option = document.createElement("option");
         option.value = optionValue;
@@ -2261,6 +2526,8 @@ function schemaTextControl(labelText, value, onInput, type = "text", helpText = 
         input.type = type;
     }
     input.value = value === undefined || value === null ? "" : value;
+    setTestId(label, testIdFor("schema-control", labelText || "blank"));
+    setTestId(input, testIdFor("schema-input", labelText || "blank"));
     input.addEventListener("input", () => onInput(input.value));
     label.appendChild(input);
     return label;
@@ -2269,6 +2536,8 @@ function schemaTextControl(labelText, value, onInput, type = "text", helpText = 
 function schemaSelectControl(labelText, value, options, onChange, helpText = "") {
     const label = schemaControlLabel(labelText, helpText);
     const select = document.createElement("select");
+    setTestId(label, testIdFor("schema-control", labelText || "blank"));
+    setTestId(select, testIdFor("schema-input", labelText || "blank"));
     const selectedValue = value === undefined || value === null ? "" : String(value);
     if (!options.includes(selectedValue)) {
         options = [selectedValue, ...options].filter((item, index, list) => item || index === list.indexOf(item));
@@ -2290,6 +2559,8 @@ function schemaCheckboxControl(labelText, value, onChange, helpText = "") {
     const input = document.createElement("input");
     input.type = "checkbox";
     input.checked = Boolean(value);
+    setTestId(label, testIdFor("schema-control", labelText || "blank"));
+    setTestId(input, testIdFor("schema-input", labelText || "blank"));
     input.addEventListener("change", () => onChange(input.checked));
     label.appendChild(input);
     return label;
@@ -2320,6 +2591,7 @@ function schemaActionButton(text, onClick, className = "compact-button", helpTex
     button.type = "button";
     button.className = className;
     button.textContent = text;
+    setTestId(button, testIdFor("schema-action", text));
     if (helpText) {
         button.setAttribute("data-tippy-content", helpText);
     }
@@ -2426,6 +2698,101 @@ function downloadText(filename, text, type) {
     link.download = filename;
     link.click();
     URL.revokeObjectURL(url);
+}
+
+async function browserSaveProject() {
+    if (!browserDirectoryPickerAvailable()) {
+        setProjectDialogStatus("Browser folder picker is not available in this browser.", true);
+        return;
+    }
+    const directory = await window.showDirectoryPicker({mode: "readwrite"});
+    if (els.projectPathInput) {
+        els.projectPathInput.value = directory.name || "";
+    }
+    const project = await requestJson("/ui/project/export-files", {
+        method: "POST",
+        body: JSON.stringify({projectStorageMode: selectedProjectStorageMode()})
+    });
+    for (const file of project.files || []) {
+        const handle = await directory.getFileHandle(file.name, {create: true});
+        const writable = await handle.createWritable();
+        if (file.type === "base64") {
+            await writable.write(base64ToBytes(file.content || ""));
+        } else {
+            await writable.write(file.content || "");
+        }
+        await writable.close();
+    }
+    setProjectDialogStatus(`Browser project saved: ${directory.name}`);
+    showMessage(`Browser project saved: ${directory.name}`);
+}
+
+async function browserLoadProject() {
+    if (!browserDirectoryPickerAvailable()) {
+        setProjectDialogStatus("Browser folder picker is not available in this browser.", true);
+        return;
+    }
+    const directory = await window.showDirectoryPicker();
+    const files = [];
+    await addTextProjectFile(files, directory, "projectfile.erproj", true);
+    await addTextProjectFile(files, directory, "schema.yaml", true);
+    await addTextProjectFile(files, directory, "data.json", false);
+    await addBinaryProjectFile(files, directory, "data.sqlite", false);
+    const workspace = await requestJson("/ui/project/load-files", {
+        method: "POST",
+        body: JSON.stringify({folderName: directory.name, files})
+    });
+    state.workspace = workspace;
+    state.schemaDraft = null;
+    state.schemaPreview = null;
+    closeProjectDialog();
+    await loadWorkspace();
+    showMessage(`Browser project loaded: ${directory.name}`);
+}
+
+async function addTextProjectFile(files, directory, name, required) {
+    const file = await projectFileFromDirectory(directory, name, required);
+    if (!file) {
+        return;
+    }
+    files.push({name, type: "text", content: await file.text()});
+}
+
+async function addBinaryProjectFile(files, directory, name, required) {
+    const file = await projectFileFromDirectory(directory, name, required);
+    if (!file) {
+        return;
+    }
+    files.push({name, type: "base64", content: bytesToBase64(new Uint8Array(await file.arrayBuffer()))});
+}
+
+async function projectFileFromDirectory(directory, name, required) {
+    try {
+        const handle = await directory.getFileHandle(name);
+        return await handle.getFile();
+    } catch (error) {
+        if (required) {
+            throw new Error(`Browser project folder must contain ${name}.`);
+        }
+        return null;
+    }
+}
+
+function bytesToBase64(bytes) {
+    let binary = "";
+    for (const byte of bytes) {
+        binary += String.fromCharCode(byte);
+    }
+    return btoa(binary);
+}
+
+function base64ToBytes(base64) {
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index++) {
+        bytes[index] = binary.charCodeAt(index);
+    }
+    return bytes;
 }
 
 async function copySchemaOutput(kind) {
@@ -2675,9 +3042,37 @@ if (els.saveProjectButton) {
 if (els.loadProjectButton) {
     els.loadProjectButton.addEventListener("click", () => openProjectDialog("load"));
 }
+if (els.storageModeSelect) {
+    els.storageModeSelect.addEventListener("change", updateStorageFileInputAvailability);
+}
+if (els.switchStorageButton) {
+    els.switchStorageButton.addEventListener("click", () => {
+        switchStorage().catch(error => showMessage(error.message, true));
+    });
+}
 if (els.projectDialogConfirm) {
     els.projectDialogConfirm.addEventListener("click", () => {
         submitProjectDialog().catch(error => showMessage(error.message, true));
+    });
+}
+if (els.projectBrowseButton) {
+    els.projectBrowseButton.addEventListener("click", () => {
+        browseProjectPath().catch(error => setProjectDialogStatus(error.message, true));
+    });
+}
+if (els.projectValidateButton) {
+    els.projectValidateButton.addEventListener("click", () => {
+        validateProjectPath().catch(error => setProjectDialogStatus(error.message, true));
+    });
+}
+if (els.projectBrowserSaveButton) {
+    els.projectBrowserSaveButton.addEventListener("click", () => {
+        browserSaveProject().catch(error => setProjectDialogStatus(error.message, true));
+    });
+}
+if (els.projectBrowserLoadButton) {
+    els.projectBrowserLoadButton.addEventListener("click", () => {
+        browserLoadProject().catch(error => setProjectDialogStatus(error.message, true));
     });
 }
 if (els.projectDialogCancel) {

--- a/thingifier-crud-ui/src/main/resources/public/assets/styles.css
+++ b/thingifier-crud-ui/src/main/resources/public/assets/styles.css
@@ -200,6 +200,28 @@ button.danger {
     cursor: pointer;
 }
 
+.storage-controls {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding-left: 8px;
+    border-left: 1px solid var(--line);
+}
+
+.storage-controls select,
+.storage-controls input {
+    min-height: 32px;
+}
+
+.storage-controls input {
+    width: 190px;
+}
+
+.storage-controls input:disabled {
+    background: #f0f2f5;
+    color: var(--muted);
+}
+
 .workspace {
     flex: 1;
     min-height: 0;
@@ -651,6 +673,61 @@ button.danger {
     border: 1px solid var(--line);
     border-radius: 4px;
     padding: 7px 9px;
+}
+
+.field-row .project-path-controls {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    gap: 8px;
+    align-items: center;
+    color: var(--ink);
+    font-size: 14px;
+    font-weight: 400;
+    text-transform: none;
+}
+
+.project-save-storage-options {
+    display: grid;
+    gap: 8px;
+    margin: 12px 0 0;
+    padding: 10px;
+    border: 1px solid var(--line);
+    border-radius: 4px;
+}
+
+.project-save-storage-options legend {
+    color: var(--muted);
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+.project-save-storage-options label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.project-save-storage-options input {
+    width: auto;
+}
+
+.project-browser-actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-top: 12px;
+}
+
+.project-browser-status {
+    min-height: 18px;
+    margin: 10px 0 0;
+    color: var(--muted);
+    line-height: 1.4;
+}
+
+.project-browser-status.error {
+    color: var(--danger);
 }
 
 .project-dialog-warning {

--- a/thingifier-crud-ui/src/main/resources/public/index.html
+++ b/thingifier-crud-ui/src/main/resources/public/index.html
@@ -8,54 +8,90 @@
     <link rel="stylesheet" href="/assets/styles.css">
 </head>
 <body>
-<div class="app-shell">
+<div class="app-shell" data-testid="workspace-page">
     <header class="topbar">
         <div>
-            <h1 id="model-title">Thingifier</h1>
-            <p id="model-description"></p>
+            <h1 id="model-title" data-testid="model-title">Thingifier</h1>
+            <p id="model-description" data-testid="model-description"></p>
         </div>
         <div class="toolbar">
             <nav class="view-nav" aria-label="Application views">
-                <a class="button-link active" href="/">Workspace</a>
-                <a class="button-link" href="/schema">Schema Edit</a>
+                <a class="button-link active" href="/" data-testid="workspace-link">Workspace</a>
+                <a class="button-link" href="/schema" data-testid="schema-link">Schema Edit</a>
             </nav>
-            <button id="refresh-button" type="button">Refresh</button>
-            <label class="file-action">
+            <button id="refresh-button" type="button" data-testid="refresh-button">Refresh</button>
+            <label class="file-action" data-testid="yaml-file-label">
                 Load YAML
-                <input id="yaml-file" type="file" accept=".yaml,.yml,text/yaml">
+                <input id="yaml-file" type="file" accept=".yaml,.yml,text/yaml" data-testid="yaml-file">
             </label>
-            <label class="file-action">
+            <label class="file-action" data-testid="import-file-label">
                 Import
-                <input id="import-file" type="file" accept="application/json,.json">
+                <input id="import-file" type="file" accept="application/json,.json" data-testid="import-file">
             </label>
-            <button id="export-button" type="button">Export</button>
-            <button id="save-project-button" type="button">Save Project</button>
-            <button id="load-project-button" type="button">Load Project</button>
-            <a class="button-link" href="/docs">API Docs</a>
-            <a class="button-link" href="/swagger">Swagger UI</a>
-            <a class="button-link" href="/docs/swagger">Download OpenAPI</a>
+            <button id="export-button" type="button" data-testid="export-button">Export</button>
+            <button id="save-project-button" type="button" data-testid="save-project-button">Save Project</button>
+            <button id="load-project-button" type="button" data-testid="load-project-button">Load Project</button>
+            <div class="storage-controls" aria-label="Workspace storage" data-testid="storage-controls">
+                <select id="storage-mode-select" aria-label="Storage mode" data-testid="storage-mode-select">
+                    <option value="memory">In Memory</option>
+                    <option value="sqlite-memory">SQLite In Memory</option>
+                    <option value="sqlite-file">SQLite File</option>
+                </select>
+                <input id="storage-file-input" type="text" placeholder="SQLite file path"
+                       autocomplete="off" data-testid="storage-file-input">
+                <button id="switch-storage-button" type="button" data-testid="switch-storage-button">Switch Storage</button>
+            </div>
+            <a class="button-link" href="/docs" data-testid="docs-link">API Docs</a>
+            <a class="button-link" href="/swagger" data-testid="swagger-link">Swagger UI</a>
+            <a class="button-link" href="/docs/swagger" data-testid="download-openapi-link">Download OpenAPI</a>
         </div>
     </header>
 
-    <div id="project-dialog" class="schema-dialog-backdrop" hidden>
+    <div id="project-dialog" class="schema-dialog-backdrop" hidden data-testid="project-dialog">
         <section class="schema-dialog project-dialog" role="dialog" aria-modal="true"
                  aria-labelledby="project-dialog-title">
             <div class="schema-dialog-header">
                 <div>
-                    <h2 id="project-dialog-title">Project</h2>
-                    <p id="project-dialog-description"></p>
+                    <h2 id="project-dialog-title" data-testid="project-dialog-title">Project</h2>
+                    <p id="project-dialog-description" data-testid="project-dialog-description"></p>
                 </div>
-                <button id="project-dialog-cancel" type="button" aria-label="Cancel project action">Cancel</button>
+                <button id="project-dialog-cancel" type="button" aria-label="Cancel project action"
+                        data-testid="project-dialog-cancel">Cancel</button>
             </div>
             <div class="project-dialog-body">
                 <label class="field-row">
                     <span>Folder path</span>
-                    <input id="project-path-input" type="text" autocomplete="off">
+                    <span class="project-path-controls">
+                        <input id="project-path-input" type="text" autocomplete="off"
+                               list="project-recent-paths" data-testid="project-path-input">
+                        <datalist id="project-recent-paths" data-testid="project-recent-paths"></datalist>
+                        <button id="project-browse-button" type="button" data-testid="project-browse-button">Browse</button>
+                        <button id="project-validate-button" type="button" data-testid="project-validate-button">Validate Path</button>
+                    </span>
                 </label>
-                <p id="project-dialog-warning" class="project-dialog-warning"></p>
+                <fieldset id="project-save-storage-options" class="project-save-storage-options"
+                          data-testid="project-save-storage-options">
+                    <legend>Save project data as</legend>
+                    <label>
+                        <input id="project-save-storage-json" name="project-save-storage"
+                               type="radio" value="json" data-testid="project-save-storage-json">
+                        <span>JSON data file</span>
+                    </label>
+                    <label>
+                        <input id="project-save-storage-sqlite" name="project-save-storage"
+                               type="radio" value="sqlite" data-testid="project-save-storage-sqlite">
+                        <span>SQLite database file</span>
+                    </label>
+                </fieldset>
+                <div class="project-browser-actions">
+                    <button id="project-browser-save-button" type="button" data-testid="project-browser-save-button">Browser Save...</button>
+                    <button id="project-browser-load-button" type="button" data-testid="project-browser-load-button">Browser Load...</button>
+                </div>
+                <p id="project-browser-status" class="project-browser-status" data-testid="project-browser-status"></p>
+                <p id="project-dialog-warning" class="project-dialog-warning" data-testid="project-dialog-warning"></p>
             </div>
             <div class="schema-dialog-footer">
-                <button id="project-dialog-confirm" class="primary" type="button">Confirm</button>
+                <button id="project-dialog-confirm" class="primary" type="button" data-testid="project-dialog-confirm">Confirm</button>
             </div>
         </section>
     </div>
@@ -65,23 +101,23 @@
             <div class="panel-heading">
                 <span>Outline</span>
             </div>
-            <nav id="outline-tree" class="outline-tree"></nav>
+            <nav id="outline-tree" class="outline-tree" data-testid="outline-tree"></nav>
         </aside>
 
         <section class="data-panel">
             <div class="grid-toolbar">
                 <div>
-                    <h2 id="grid-title">Select an entity</h2>
-                    <p id="grid-context"></p>
+                    <h2 id="grid-title" data-testid="grid-title">Select an entity</h2>
+                    <p id="grid-context" data-testid="grid-context"></p>
                 </div>
                 <div class="grid-actions">
-                    <input id="search-input" type="search" placeholder="Search">
-                    <button id="new-button" type="button">New</button>
+                    <input id="search-input" type="search" placeholder="Search" data-testid="search-input">
+                    <button id="new-button" type="button" data-testid="new-button">New</button>
                 </div>
             </div>
-            <div id="message-bar" class="message-bar" hidden></div>
-            <div id="grid-host" class="grid-host"></div>
-            <section id="editor-panel" class="editor-panel"></section>
+            <div id="message-bar" class="message-bar" hidden data-testid="message-bar"></div>
+            <div id="grid-host" class="grid-host" data-testid="grid-host"></div>
+            <section id="editor-panel" class="editor-panel" data-testid="editor-panel"></section>
         </section>
     </main>
 </div>

--- a/thingifier-crud-ui/src/main/resources/public/schema.html
+++ b/thingifier-crud-ui/src/main/resources/public/schema.html
@@ -9,30 +9,30 @@
     <link rel="stylesheet" href="https://unpkg.com/tippy.js@6/dist/tippy.css">
 </head>
 <body data-page="schema">
-<div class="app-shell">
+<div class="app-shell" data-testid="schema-page">
     <header class="topbar">
         <div>
-            <h1 id="model-title">Schema Edit</h1>
-            <p id="model-description"></p>
+            <h1 id="model-title" data-testid="model-title">Schema Edit</h1>
+            <p id="model-description" data-testid="model-description"></p>
         </div>
         <div class="toolbar">
             <nav class="view-nav" aria-label="Application views">
-                <a id="schema-workspace-link" class="button-link" href="/">Workspace</a>
-                <a class="button-link active" href="/schema">Schema Edit</a>
+                <a id="schema-workspace-link" class="button-link" href="/" data-testid="schema-workspace-link">Workspace</a>
+                <a class="button-link active" href="/schema" data-testid="schema-link">Schema Edit</a>
             </nav>
-            <span id="schema-dirty-status" class="schema-dirty-status" hidden>Unsaved changes</span>
-            <button id="schema-reset-button" type="button">Reset Draft</button>
-            <button id="schema-save-yaml-button" class="primary" type="button">Save as YAML</button>
-            <button id="schema-validate-button" type="button">Validate</button>
-            <button id="schema-apply-workspace-button" class="primary" type="button" disabled>Apply to Workspace</button>
-            <button id="schema-toggle-yaml-button" type="button">YAML Draft</button>
-            <button id="schema-toggle-exports-button" type="button">Exports</button>
+            <span id="schema-dirty-status" class="schema-dirty-status" hidden data-testid="schema-dirty-status">Unsaved changes</span>
+            <button id="schema-reset-button" type="button" data-testid="schema-reset-button">Reset Draft</button>
+            <button id="schema-save-yaml-button" class="primary" type="button" data-testid="schema-save-yaml-button">Save as YAML</button>
+            <button id="schema-validate-button" type="button" data-testid="schema-validate-button">Validate</button>
+            <button id="schema-apply-workspace-button" class="primary" type="button" disabled data-testid="schema-apply-workspace-button">Apply to Workspace</button>
+            <button id="schema-toggle-yaml-button" type="button" data-testid="schema-toggle-yaml-button">YAML Draft</button>
+            <button id="schema-toggle-exports-button" type="button" data-testid="schema-toggle-exports-button">Exports</button>
         </div>
     </header>
 
-    <div id="message-bar" class="message-bar" hidden></div>
+    <div id="message-bar" class="message-bar" hidden data-testid="message-bar"></div>
 
-    <main id="schema-editor" class="schema-editor">
+    <main id="schema-editor" class="schema-editor" data-testid="schema-editor">
         <section class="schema-diagram-panel schema-top-panel">
             <div class="schema-toolbar">
                 <div>
@@ -40,16 +40,16 @@
                     <p>Rendered from the current draft.</p>
                 </div>
                 <div class="schema-diagram-actions">
-                    <button id="schema-zoom-out-button" type="button" aria-label="Zoom out ER diagram">-</button>
-                    <button id="schema-zoom-reset-button" type="button">100%</button>
-                    <button id="schema-zoom-in-button" type="button" aria-label="Zoom in ER diagram">+</button>
-                    <button id="schema-layout-toggle-button" type="button">Vertical Layout</button>
-                    <button id="schema-toggle-diagram-button" type="button">Hide Diagram</button>
+                    <button id="schema-zoom-out-button" type="button" aria-label="Zoom out ER diagram" data-testid="schema-zoom-out-button">-</button>
+                    <button id="schema-zoom-reset-button" type="button" data-testid="schema-zoom-reset-button">100%</button>
+                    <button id="schema-zoom-in-button" type="button" aria-label="Zoom in ER diagram" data-testid="schema-zoom-in-button">+</button>
+                    <button id="schema-layout-toggle-button" type="button" data-testid="schema-layout-toggle-button">Vertical Layout</button>
+                    <button id="schema-toggle-diagram-button" type="button" data-testid="schema-toggle-diagram-button">Hide Diagram</button>
                 </div>
             </div>
-            <div id="schema-diagram-content">
-                <div id="schema-mermaid-diagram" class="schema-mermaid-diagram"></div>
-                <div class="schema-diagram-key" aria-label="ER relationship symbol key">
+            <div id="schema-diagram-content" data-testid="schema-diagram-content">
+                <div id="schema-mermaid-diagram" class="schema-mermaid-diagram" data-testid="schema-mermaid-diagram"></div>
+                <div class="schema-diagram-key" aria-label="ER relationship symbol key" data-testid="schema-diagram-key">
                     <span class="schema-key-title">Relationship Key</span>
                     <span>
                         <svg class="er-key-symbol" viewBox="0 0 48 20" aria-hidden="true">
@@ -88,38 +88,38 @@
                 </div>
             </div>
         </section>
-        <div id="schema-diagram-resizer" class="schema-diagram-resizer" role="separator" aria-orientation="horizontal" aria-label="Resize ER diagram"></div>
-        <div id="schema-validation" class="schema-validation"></div>
+        <div id="schema-diagram-resizer" class="schema-diagram-resizer" role="separator" aria-orientation="horizontal" aria-label="Resize ER diagram" data-testid="schema-diagram-resizer"></div>
+        <div id="schema-validation" class="schema-validation" data-testid="schema-validation"></div>
 
         <section class="schema-workbench">
             <aside class="schema-tree-panel">
                 <div class="panel-heading">
                     <span>Schema</span>
-                    <button id="schema-add-entity-button" class="compact-button" type="button">Add Entity</button>
+                    <button id="schema-add-entity-button" class="compact-button" type="button" data-testid="schema-add-entity-button">Add Entity</button>
                 </div>
-                <nav id="schema-tree" class="schema-tree"></nav>
+                <nav id="schema-tree" class="schema-tree" data-testid="schema-tree"></nav>
             </aside>
 
             <section class="schema-detail-panel">
                 <div class="panel-heading">
-                    <span id="schema-detail-title">Select schema item</span>
+                    <span id="schema-detail-title" data-testid="schema-detail-title">Select schema item</span>
                 </div>
-                <div id="schema-detail-host" class="schema-detail-host"></div>
+                <div id="schema-detail-host" class="schema-detail-host" data-testid="schema-detail-host"></div>
             </section>
         </section>
 
-        <section id="schema-yaml-section" class="schema-yaml-panel" hidden>
+        <section id="schema-yaml-section" class="schema-yaml-panel" hidden data-testid="schema-yaml-section">
             <div class="schema-toolbar">
                 <div>
                     <h2>YAML Draft</h2>
                     <p>Edit raw YAML, then parse it back into the draft.</p>
                 </div>
-                <button id="schema-parse-yaml-button" type="button">Parse YAML</button>
+                <button id="schema-parse-yaml-button" type="button" data-testid="schema-parse-yaml-button">Parse YAML</button>
             </div>
-            <textarea id="schema-yaml-input" class="schema-code-input" spellcheck="false"></textarea>
+            <textarea id="schema-yaml-input" class="schema-code-input" spellcheck="false" data-testid="schema-yaml-input"></textarea>
         </section>
 
-        <section id="schema-exports-section" class="schema-export-panel" hidden>
+        <section id="schema-exports-section" class="schema-export-panel" hidden data-testid="schema-exports-section">
             <div class="schema-toolbar">
                 <div>
                     <h2>Exports</h2>
@@ -130,47 +130,47 @@
                 <label>
                     <span class="schema-output-heading">
                         Canonical YAML
-                        <button id="schema-copy-yaml" class="icon-button copy-button" type="button" aria-label="Copy YAML">Copy</button>
+                        <button id="schema-copy-yaml" class="icon-button copy-button" type="button" aria-label="Copy YAML" data-testid="schema-copy-yaml">Copy</button>
                     </span>
-                    <textarea id="schema-canonical-yaml" class="schema-code-output" readonly spellcheck="false"></textarea>
+                    <textarea id="schema-canonical-yaml" class="schema-code-output" readonly spellcheck="false" data-testid="schema-canonical-yaml"></textarea>
                 </label>
                 <label>
                     <span class="schema-output-heading">
                         Mermaid
                         <span>
-                            <button id="schema-copy-mermaid" class="icon-button copy-button" type="button" aria-label="Copy Mermaid">Copy</button>
-                            <button id="schema-download-mermaid" type="button">Save Mermaid</button>
+                            <button id="schema-copy-mermaid" class="icon-button copy-button" type="button" aria-label="Copy Mermaid" data-testid="schema-copy-mermaid">Copy</button>
+                            <button id="schema-download-mermaid" type="button" data-testid="schema-download-mermaid">Save Mermaid</button>
                         </span>
                     </span>
-                    <textarea id="schema-mermaid-output" class="schema-code-output" readonly spellcheck="false"></textarea>
+                    <textarea id="schema-mermaid-output" class="schema-code-output" readonly spellcheck="false" data-testid="schema-mermaid-output"></textarea>
                 </label>
                 <label>
                     <span class="schema-output-heading">
                         Graphviz DOT
                         <span>
-                            <button id="schema-copy-graphviz" class="icon-button copy-button" type="button" aria-label="Copy Graphviz">Copy</button>
-                            <button id="schema-download-graphviz" type="button">Save Graphviz</button>
+                            <button id="schema-copy-graphviz" class="icon-button copy-button" type="button" aria-label="Copy Graphviz" data-testid="schema-copy-graphviz">Copy</button>
+                            <button id="schema-download-graphviz" type="button" data-testid="schema-download-graphviz">Save Graphviz</button>
                         </span>
                     </span>
-                    <textarea id="schema-graphviz-output" class="schema-code-output" readonly spellcheck="false"></textarea>
+                    <textarea id="schema-graphviz-output" class="schema-code-output" readonly spellcheck="false" data-testid="schema-graphviz-output"></textarea>
                 </label>
             </div>
         </section>
     </main>
 </div>
-<div id="schema-upgrade-dialog" class="schema-dialog-backdrop" hidden>
+<div id="schema-upgrade-dialog" class="schema-dialog-backdrop" hidden data-testid="schema-upgrade-dialog">
     <section class="schema-dialog" role="dialog" aria-modal="true" aria-labelledby="schema-upgrade-dialog-title">
         <div class="schema-dialog-header">
             <div>
                 <h2 id="schema-upgrade-dialog-title">Apply to Workspace</h2>
                 <p>Preview how current data will migrate before replacing the live workspace.</p>
             </div>
-            <button id="schema-upgrade-cancel-button" type="button" aria-label="Cancel schema workspace apply">Cancel</button>
+            <button id="schema-upgrade-cancel-button" type="button" aria-label="Cancel schema workspace apply" data-testid="schema-upgrade-cancel-button">Cancel</button>
         </div>
-        <div id="schema-upgrade-host" class="schema-upgrade-host"></div>
+        <div id="schema-upgrade-host" class="schema-upgrade-host" data-testid="schema-upgrade-host"></div>
         <div class="schema-dialog-footer">
-            <button id="schema-upgrade-preview-button" type="button">Refresh Preview</button>
-            <button id="schema-upgrade-confirm-button" class="primary" type="button" disabled>Confirm Apply</button>
+            <button id="schema-upgrade-preview-button" type="button" data-testid="schema-upgrade-preview-button">Refresh Preview</button>
+            <button id="schema-upgrade-confirm-button" class="primary" type="button" disabled data-testid="schema-upgrade-confirm-button">Confirm Apply</button>
         </div>
     </section>
 </div>

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/ActiveThingifierWorkspaceTest.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/ActiveThingifierWorkspaceTest.java
@@ -1,9 +1,16 @@
 package uk.co.compendiumdev.thingifier.crudui;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class ActiveThingifierWorkspaceTest {
+
+    @TempDir Path temp;
 
     @Test
     public void defaultWorkspaceStartsWithTodoManager() {
@@ -30,5 +37,81 @@ public class ActiveThingifierWorkspaceTest {
             Assertions.assertNotNull(snapshot.definition().entityNamed("todo"));
             Assertions.assertNull(snapshot.definition().entityNamed("project"));
         }
+    }
+
+    @Test
+    public void switchToSqliteMemoryMigratesDataAndRelationships() {
+        try (ActiveThingifierWorkspace workspace =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            workspace.replaceWithYaml(TestResources.text("/models/project-tasks.yaml"));
+            createRelatedProjectAndTodo(new DynamicThingifierApiProxy(workspace));
+
+            workspace.switchStorage(WorkspaceStorage.sqliteMemory());
+
+            DynamicThingifierApiProxy proxy = new DynamicThingifierApiProxy(workspace);
+            Assertions.assertEquals("sqlite-memory", workspace.snapshot().storage().mode());
+            Assertions.assertTrue(proxy.getJson("projects").body().contains("Project A"));
+            Assertions.assertTrue(proxy.getJson("todos").body().contains("Task A"));
+            Assertions.assertEquals(
+                    1,
+                    root(proxy.getJson("projects/1/tasks").body()).getAsJsonArray("todos").size());
+        }
+    }
+
+    @Test
+    public void switchToSqliteFileCreatesFileAndMigratesData() {
+        Path databaseFile = temp.resolve("workspace.sqlite");
+        try (ActiveThingifierWorkspace workspace =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            workspace.replaceWithYaml(TestResources.text("/models/project-tasks.yaml"));
+            createRelatedProjectAndTodo(new DynamicThingifierApiProxy(workspace));
+
+            workspace.switchStorage(WorkspaceStorage.sqliteFile(databaseFile));
+
+            DynamicThingifierApiProxy proxy = new DynamicThingifierApiProxy(workspace);
+            Assertions.assertTrue(Files.exists(databaseFile));
+            Assertions.assertEquals("sqlite-file", workspace.snapshot().storage().mode());
+            Assertions.assertTrue(proxy.getJson("projects").body().contains("Project A"));
+            Assertions.assertEquals(
+                    1,
+                    root(proxy.getJson("projects/1/tasks").body()).getAsJsonArray("todos").size());
+        }
+    }
+
+    @Test
+    public void switchFromSqliteFileBackToMemoryMigratesData() {
+        Path databaseFile = temp.resolve("workspace.sqlite");
+        try (ActiveThingifierWorkspace workspace =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            workspace.replaceWithYaml(TestResources.text("/models/project-tasks.yaml"));
+            createRelatedProjectAndTodo(new DynamicThingifierApiProxy(workspace));
+            workspace.switchStorage(WorkspaceStorage.sqliteFile(databaseFile));
+
+            workspace.switchStorage(WorkspaceStorage.memory());
+
+            DynamicThingifierApiProxy proxy = new DynamicThingifierApiProxy(workspace);
+            Assertions.assertEquals("memory", workspace.snapshot().storage().mode());
+            Assertions.assertTrue(proxy.getJson("projects").body().contains("Project A"));
+            Assertions.assertEquals(
+                    1,
+                    root(proxy.getJson("projects/1/tasks").body()).getAsJsonArray("todos").size());
+        }
+    }
+
+    private void createRelatedProjectAndTodo(final DynamicThingifierApiProxy proxy) {
+        String projectId =
+                field(proxy.postJson("projects", "{\"title\":\"Project A\"}").body(), "id");
+        String todoId = field(proxy.postJson("todos", "{\"title\":\"Task A\"}").body(), "id");
+        UiHttpResponse relationship =
+                proxy.postJson("projects/" + projectId + "/tasks", "{\"id\":\"" + todoId + "\"}");
+        Assertions.assertEquals(201, relationship.statusCode());
+    }
+
+    private String field(final String json, final String fieldName) {
+        return root(json).get(fieldName).getAsString();
+    }
+
+    private JsonObject root(final String json) {
+        return JsonParser.parseString(json).getAsJsonObject();
     }
 }

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/CrudUiArgumentsTest.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/CrudUiArgumentsTest.java
@@ -23,4 +23,18 @@ public class CrudUiArgumentsTest {
                         CrudUiArguments.parse(
                                 new String[] {"-project=project-folder", "-modelYaml=model.yaml"}));
     }
+
+    @Test
+    public void parsesStorageModeAndSqliteFilePath() {
+        CrudUiArguments arguments =
+                CrudUiArguments.parse(
+                        new String[] {
+                            "-modelYaml=model.yaml",
+                            "-thingifier-repository=sqlite-file",
+                            "-thingifier-sqlite-file=data.sqlite"
+                        });
+
+        Assertions.assertEquals("sqlite-file", arguments.storage().mode());
+        Assertions.assertTrue(arguments.storage().sqliteFilePath().endsWith("data.sqlite"));
+    }
 }

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/CrudUiControllerTest.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/CrudUiControllerTest.java
@@ -2,10 +2,15 @@ package uk.co.compendiumdev.thingifier.crudui;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import java.nio.file.Path;
+import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class CrudUiControllerTest {
+
+    @TempDir Path temp;
 
     @Test
     public void workspaceRouteReturnsSchemaMetadata() {
@@ -15,11 +20,107 @@ public class CrudUiControllerTest {
 
             UiHttpResponse response = controller.workspace();
 
-            Assertions.assertEquals(200, response.statusCode());
+            Assertions.assertEquals(200, response.statusCode(), response.body());
             Assertions.assertTrue(response.body().contains("\"entities\""));
             Assertions.assertTrue(response.body().contains("\"relationships\""));
             Assertions.assertTrue(response.body().contains("\"schemaYaml\""));
             Assertions.assertTrue(response.body().contains("\"project\""));
+            Assertions.assertTrue(response.body().contains("\"storage\""));
+        }
+    }
+
+    @Test
+    public void storageSwitchEndpointChangesWorkspaceStorageMode() {
+        try (ActiveThingifierWorkspace workspace =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            CrudUiController controller = new CrudUiController(workspace);
+            Path databaseFile = temp.resolve("controller.sqlite");
+
+            UiHttpResponse response =
+                    controller.switchStorage(
+                            JsonSupport.toJson(
+                                    Map.of(
+                                            "mode",
+                                            "sqlite-file",
+                                            "sqliteFile",
+                                            databaseFile.toString())));
+
+            Assertions.assertEquals(200, response.statusCode(), response.body());
+            Assertions.assertEquals("sqlite-file", workspace.snapshot().storage().mode());
+            Assertions.assertTrue(response.body().contains("\"storageStatus\": \"switched\""));
+        }
+    }
+
+    @Test
+    public void projectBrowseEndpointReturnsSelectedPathFromChooser() {
+        try (ActiveThingifierWorkspace workspace =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            Path chosen = temp.resolve("chosen-project");
+            CrudUiController controller =
+                    new CrudUiController(
+                            workspace, request -> ProjectPathSelection.selected(chosen.toString()));
+
+            UiHttpResponse response =
+                    controller.browseProject(
+                            JsonSupport.toJson(Map.of("action", "save", "path", "")));
+            JsonObject body = JsonParser.parseString(response.body()).getAsJsonObject();
+
+            Assertions.assertEquals(200, response.statusCode());
+            Assertions.assertTrue(body.get("selected").getAsBoolean());
+            Assertions.assertEquals(chosen.toString(), body.get("path").getAsString());
+        }
+    }
+
+    @Test
+    public void projectBrowseEndpointReturnsCancelledSelection() {
+        try (ActiveThingifierWorkspace workspace =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            CrudUiController controller =
+                    new CrudUiController(workspace, request -> ProjectPathSelection.cancelled());
+
+            UiHttpResponse response =
+                    controller.browseProject(
+                            JsonSupport.toJson(Map.of("action", "load", "path", "")));
+            JsonObject body = JsonParser.parseString(response.body()).getAsJsonObject();
+
+            Assertions.assertEquals(200, response.statusCode());
+            Assertions.assertFalse(body.get("selected").getAsBoolean());
+            Assertions.assertEquals(
+                    "Project browsing cancelled.", body.get("message").getAsString());
+        }
+    }
+
+    @Test
+    public void projectBrowseEndpointReportsUnavailableChooserAsBadRequest() {
+        try (ActiveThingifierWorkspace workspace =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            CrudUiController controller =
+                    new CrudUiController(
+                            workspace,
+                            request -> ProjectPathSelection.unavailable("Browse unavailable"));
+
+            UiHttpResponse response =
+                    controller.browseProject(
+                            JsonSupport.toJson(Map.of("action", "save", "path", "")));
+
+            Assertions.assertEquals(400, response.statusCode());
+            Assertions.assertTrue(response.body().contains("Browse unavailable"));
+        }
+    }
+
+    @Test
+    public void sqliteFileStorageSwitchRequiresAFilePathAndDoesNotMutateWorkspace() {
+        try (ActiveThingifierWorkspace workspace =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            CrudUiController controller = new CrudUiController(workspace);
+            long version = workspace.snapshot().version();
+
+            UiHttpResponse response =
+                    controller.switchStorage(JsonSupport.toJson(Map.of("mode", "sqlite-file")));
+
+            Assertions.assertEquals(400, response.statusCode());
+            Assertions.assertEquals(version, workspace.snapshot().version());
+            Assertions.assertEquals("memory", workspace.snapshot().storage().mode());
         }
     }
 
@@ -109,6 +210,14 @@ public class CrudUiControllerTest {
         Assertions.assertTrue(index.contains("Load Project"));
         Assertions.assertTrue(index.contains("id=\"project-dialog\""));
         Assertions.assertTrue(index.contains("id=\"project-path-input\""));
+        Assertions.assertTrue(index.contains("id=\"project-recent-paths\""));
+        Assertions.assertTrue(index.contains("id=\"project-browse-button\""));
+        Assertions.assertTrue(index.contains("id=\"project-validate-button\""));
+        Assertions.assertTrue(index.contains("id=\"project-browser-save-button\""));
+        Assertions.assertTrue(index.contains("id=\"project-browser-load-button\""));
+        Assertions.assertTrue(index.contains("Browser Save..."));
+        Assertions.assertTrue(index.contains("Browser Load..."));
+        Assertions.assertTrue(index.contains("Validate Path"));
         Assertions.assertTrue(index.contains("Workspace"));
         Assertions.assertTrue(index.contains("Schema Edit"));
         Assertions.assertTrue(index.contains("href=\"/schema\""));
@@ -280,6 +389,20 @@ public class CrudUiControllerTest {
         Assertions.assertTrue(script.contains("/ui/schema/upgrade/apply"));
         Assertions.assertTrue(script.contains("/ui/project/save"));
         Assertions.assertTrue(script.contains("/ui/project/load"));
+        Assertions.assertTrue(script.contains("/ui/project/browse"));
+        Assertions.assertTrue(script.contains("/ui/project/check"));
+        Assertions.assertTrue(script.contains("/ui/project/load-files"));
+        Assertions.assertTrue(script.contains("/ui/project/export-files"));
+        Assertions.assertTrue(script.contains("browserSaveProject"));
+        Assertions.assertTrue(script.contains("browserLoadProject"));
+        Assertions.assertTrue(script.contains("validateProjectPath"));
+        Assertions.assertTrue(script.contains("projectRecentPaths"));
+        Assertions.assertTrue(script.contains("showDirectoryPicker"));
+        Assertions.assertTrue(script.contains("Browser folder picker is not available"));
+        Assertions.assertTrue(script.contains("/ui/storage/switch"));
+        Assertions.assertTrue(script.contains("storageModeSelect"));
+        Assertions.assertTrue(script.contains("storageFileInput"));
+        Assertions.assertTrue(script.contains("Storage switched."));
         Assertions.assertTrue(script.contains("openProjectDialog"));
         Assertions.assertTrue(script.contains("Project saved."));
         Assertions.assertTrue(script.contains("Project loaded."));
@@ -333,6 +456,9 @@ public class CrudUiControllerTest {
         Assertions.assertTrue(styles.contains(".schema-dialog-footer"));
         Assertions.assertTrue(styles.contains(".project-dialog"));
         Assertions.assertTrue(styles.contains(".project-dialog-warning"));
+        Assertions.assertTrue(styles.contains(".project-path-controls"));
+        Assertions.assertTrue(styles.contains(".project-browser-actions"));
+        Assertions.assertTrue(styles.contains(".project-browser-status"));
         Assertions.assertTrue(styles.contains(".schema-upgrade-layout"));
         Assertions.assertTrue(styles.contains(".schema-upgrade-row"));
         Assertions.assertTrue(styles.contains(".schema-upgrade-summary"));

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceProjectServiceTest.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceProjectServiceTest.java
@@ -4,6 +4,10 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -66,6 +70,176 @@ public class WorkspaceProjectServiceTest {
     }
 
     @Test
+    public void sqliteBackedSaveCreatesManifestSchemaAndDatabaseFile() throws Exception {
+        Path projectFolder = temp.resolve("sqlite-project-bundle");
+        try (ActiveThingifierWorkspace workspace =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            workspace.replaceWithYaml(TestResources.text("/models/project-tasks.yaml"));
+            createRelatedProjectAndTodo(new DynamicThingifierApiProxy(workspace));
+            workspace.switchStorage(WorkspaceStorage.sqliteFile(temp.resolve("source.sqlite")));
+
+            UiHttpResponse response =
+                    new CrudUiController(workspace).saveProject(request(projectFolder));
+
+            Assertions.assertEquals(200, response.statusCode());
+            Assertions.assertTrue(Files.exists(projectFolder.resolve("projectfile.erproj")));
+            Assertions.assertTrue(Files.exists(projectFolder.resolve("schema.yaml")));
+            Assertions.assertTrue(Files.exists(projectFolder.resolve("data.sqlite")));
+            Assertions.assertFalse(Files.exists(projectFolder.resolve("data.json")));
+            Assertions.assertTrue(
+                    Files.readString(projectFolder.resolve("projectfile.erproj"))
+                            .contains("dataFile: data.sqlite"));
+            Assertions.assertFalse(
+                    Files.readString(projectFolder.resolve("projectfile.erproj"))
+                            .contains("storage:"));
+        }
+    }
+
+    @Test
+    public void saveAsSqliteFromMemorySwitchesWorkspaceToProjectDatabaseFile() throws Exception {
+        Path projectFolder = temp.resolve("sqlite-save-as-project");
+        try (ActiveThingifierWorkspace workspace =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            workspace.replaceWithYaml(TestResources.text("/models/project-tasks.yaml"));
+            createRelatedProjectAndTodo(new DynamicThingifierApiProxy(workspace));
+
+            UiHttpResponse response =
+                    new CrudUiController(workspace).saveProject(request(projectFolder, "sqlite"));
+
+            Assertions.assertEquals(200, response.statusCode(), response.body());
+            Assertions.assertTrue(Files.exists(projectFolder.resolve("data.sqlite")));
+            Assertions.assertFalse(Files.exists(projectFolder.resolve("data.json")));
+            Assertions.assertEquals("sqlite-file", workspace.snapshot().storage().mode());
+            Assertions.assertEquals(
+                    projectFolder.resolve("data.sqlite").toAbsolutePath().normalize().toString(),
+                    workspace.snapshot().storage().sqliteFilePath());
+            Assertions.assertTrue(
+                    new DynamicThingifierApiProxy(workspace)
+                            .getJson("projects")
+                            .body()
+                            .contains("Project A"));
+        }
+    }
+
+    @Test
+    public void saveAsJsonFromSqliteSwitchesWorkspaceToInMemoryStorage() throws Exception {
+        Path projectFolder = temp.resolve("json-save-as-project");
+        try (ActiveThingifierWorkspace workspace =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            workspace.replaceWithYaml(TestResources.text("/models/project-tasks.yaml"));
+            createRelatedProjectAndTodo(new DynamicThingifierApiProxy(workspace));
+            workspace.switchStorage(WorkspaceStorage.sqliteFile(temp.resolve("source.sqlite")));
+
+            UiHttpResponse response =
+                    new CrudUiController(workspace).saveProject(request(projectFolder, "json"));
+
+            Assertions.assertEquals(200, response.statusCode(), response.body());
+            Assertions.assertTrue(Files.exists(projectFolder.resolve("data.json")));
+            Assertions.assertFalse(
+                    Files.readString(projectFolder.resolve("projectfile.erproj"))
+                            .contains("sqlite-file"));
+            Assertions.assertEquals("memory", workspace.snapshot().storage().mode());
+            Assertions.assertTrue(
+                    new DynamicThingifierApiProxy(workspace)
+                            .getJson("projects")
+                            .body()
+                            .contains("Project A"));
+        }
+    }
+
+    @Test
+    public void sqliteBackedProjectReloadsDataAndSwitchesStorageMode() {
+        Path projectFolder = temp.resolve("sqlite-project-bundle");
+        try (ActiveThingifierWorkspace source =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            source.replaceWithYaml(TestResources.text("/models/project-tasks.yaml"));
+            createRelatedProjectAndTodo(new DynamicThingifierApiProxy(source));
+            source.switchStorage(WorkspaceStorage.sqliteFile(temp.resolve("source.sqlite")));
+            new CrudUiController(source).saveProject(request(projectFolder));
+        }
+
+        try (ActiveThingifierWorkspace target =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            UiHttpResponse response =
+                    new CrudUiController(target).loadProject(request(projectFolder));
+            DynamicThingifierApiProxy targetProxy = new DynamicThingifierApiProxy(target);
+
+            Assertions.assertEquals(200, response.statusCode());
+            Assertions.assertEquals("sqlite-file", target.snapshot().storage().mode());
+            Assertions.assertTrue(
+                    target.snapshot().storage().sqliteFilePath().endsWith("data.sqlite"));
+            Assertions.assertTrue(targetProxy.getJson("projects").body().contains("Project A"));
+            Assertions.assertEquals(
+                    1,
+                    root(targetProxy.getJson("projects/1/tasks").body())
+                            .getAsJsonArray("todos")
+                            .size());
+        }
+    }
+
+    @Test
+    public void loadProjectTreatsSqliteDataFileAsSqliteStorageWithoutStorageBlock()
+            throws Exception {
+        Path projectFolder = temp.resolve("edited-sqlite-project-bundle");
+        try (ActiveThingifierWorkspace source =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            source.replaceWithYaml(TestResources.text("/models/project-tasks.yaml"));
+            createRelatedProjectAndTodo(new DynamicThingifierApiProxy(source));
+            source.switchStorage(WorkspaceStorage.sqliteFile(temp.resolve("source.sqlite")));
+            new CrudUiController(source).saveProject(request(projectFolder));
+        }
+        Files.move(
+                projectFolder.resolve("data.sqlite"), projectFolder.resolve("todomanager.sqlite"));
+        Files.writeString(
+                projectFolder.resolve("projectfile.erproj"),
+                "formatVersion: 1\n"
+                        + "project:\n"
+                        + "  title: Edited SQLite Project\n"
+                        + "schemaFile: schema.yaml\n"
+                        + "dataFile: todomanager.sqlite\n");
+
+        try (ActiveThingifierWorkspace target =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            UiHttpResponse response =
+                    new CrudUiController(target).loadProject(request(projectFolder));
+            DynamicThingifierApiProxy targetProxy = new DynamicThingifierApiProxy(target);
+
+            Assertions.assertEquals(200, response.statusCode(), response.body());
+            Assertions.assertEquals("sqlite-file", target.snapshot().storage().mode());
+            Assertions.assertTrue(
+                    target.snapshot().storage().sqliteFilePath().endsWith("todomanager.sqlite"));
+            Assertions.assertTrue(targetProxy.getJson("projects").body().contains("Project A"));
+        }
+    }
+
+    @Test
+    public void loadProjectSniffsSqliteDataFileWhenFilenameHasNoSqliteExtension() throws Exception {
+        Path projectFolder = temp.resolve("sniffed-sqlite-project-bundle");
+        try (ActiveThingifierWorkspace source =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            source.replaceWithYaml(TestResources.text("/models/project-tasks.yaml"));
+            createRelatedProjectAndTodo(new DynamicThingifierApiProxy(source));
+            source.switchStorage(WorkspaceStorage.sqliteFile(temp.resolve("source.sqlite")));
+            new CrudUiController(source).saveProject(request(projectFolder));
+        }
+        Files.move(projectFolder.resolve("data.sqlite"), projectFolder.resolve("data.bin"));
+        Files.writeString(
+                projectFolder.resolve("projectfile.erproj"),
+                "formatVersion: 1\n" + "schemaFile: schema.yaml\n" + "dataFile: data.bin\n");
+
+        try (ActiveThingifierWorkspace target =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            UiHttpResponse response =
+                    new CrudUiController(target).loadProject(request(projectFolder));
+
+            Assertions.assertEquals(200, response.statusCode(), response.body());
+            Assertions.assertEquals("sqlite-file", target.snapshot().storage().mode());
+            Assertions.assertTrue(
+                    target.snapshot().storage().sqliteFilePath().endsWith("data.bin"));
+        }
+    }
+
+    @Test
     public void loadAcceptsDirectProjectFilePath() {
         Path projectFolder = temp.resolve("project-bundle");
         try (ActiveThingifierWorkspace source =
@@ -82,6 +256,199 @@ public class WorkspaceProjectServiceTest {
 
             Assertions.assertEquals(200, response.statusCode());
             Assertions.assertEquals("Project Tasks", target.snapshot().definition().title());
+        }
+    }
+
+    @Test
+    public void checkSavePathReportsCreatableFolderAndManagedFiles() throws Exception {
+        Path creatableFolder = temp.resolve("new-project");
+        try (ActiveThingifierWorkspace workspace =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            CrudUiController controller = new CrudUiController(workspace);
+
+            JsonObject creatable =
+                    root(controller.checkProject(actionRequest("save", creatableFolder)).body());
+
+            Assertions.assertTrue(creatable.get("canProceed").getAsBoolean());
+            Assertions.assertEquals("creatable-folder", creatable.get("kind").getAsString());
+
+            Path existingFolder = temp.resolve("existing-project");
+            Files.createDirectories(existingFolder);
+            Files.writeString(existingFolder.resolve("projectfile.erproj"), "managed");
+            Files.writeString(existingFolder.resolve("schema.yaml"), "managed");
+
+            JsonObject existing =
+                    root(controller.checkProject(actionRequest("save", existingFolder)).body());
+
+            Assertions.assertTrue(existing.get("canProceed").getAsBoolean());
+            Assertions.assertTrue(
+                    existing.get("warning").getAsString().contains("projectfile.erproj"));
+            Assertions.assertTrue(existing.get("warning").getAsString().contains("schema.yaml"));
+        }
+    }
+
+    @Test
+    public void checkLoadPathAcceptsFolderAndDirectProjectFile() {
+        Path projectFolder = temp.resolve("project-bundle");
+        try (ActiveThingifierWorkspace source =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            new CrudUiController(source).saveProject(request(projectFolder));
+        }
+        try (ActiveThingifierWorkspace workspace =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            CrudUiController controller = new CrudUiController(workspace);
+
+            JsonObject folderCheck =
+                    root(controller.checkProject(actionRequest("load", projectFolder)).body());
+            JsonObject fileCheck =
+                    root(
+                            controller
+                                    .checkProject(
+                                            actionRequest(
+                                                    "load",
+                                                    projectFolder.resolve("projectfile.erproj")))
+                                    .body());
+
+            Assertions.assertTrue(folderCheck.get("canProceed").getAsBoolean());
+            Assertions.assertEquals("folder", folderCheck.get("kind").getAsString());
+            Assertions.assertTrue(fileCheck.get("canProceed").getAsBoolean());
+            Assertions.assertEquals("project-file", fileCheck.get("kind").getAsString());
+        }
+    }
+
+    @Test
+    public void browserExportFilesEmitsJsonBackedProjectFiles() {
+        try (ActiveThingifierWorkspace workspace =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            UiHttpResponse response = new CrudUiController(workspace).exportProjectFiles();
+            JsonObject body = root(response.body());
+
+            Assertions.assertEquals(200, response.statusCode());
+            Assertions.assertTrue(response.body().contains("\"projectStatus\": \"exported\""));
+            Assertions.assertTrue(response.body().contains("\"projectfile.erproj\""));
+            Assertions.assertTrue(response.body().contains("\"schema.yaml\""));
+            Assertions.assertTrue(response.body().contains("\"data.json\""));
+            Assertions.assertFalse(response.body().contains("\"data.sqlite\""));
+            Assertions.assertEquals("memory", body.get("storageMode").getAsString());
+            Assertions.assertEquals("json", body.get("projectStorageMode").getAsString());
+        }
+    }
+
+    @Test
+    public void browserExportFilesEmitsSqliteBackedProjectFiles() {
+        try (ActiveThingifierWorkspace workspace =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            workspace.switchStorage(WorkspaceStorage.sqliteFile(temp.resolve("source.sqlite")));
+
+            UiHttpResponse response = new CrudUiController(workspace).exportProjectFiles();
+            JsonObject body = root(response.body());
+
+            Assertions.assertEquals(200, response.statusCode());
+            Assertions.assertTrue(response.body().contains("\"projectfile.erproj\""));
+            Assertions.assertTrue(response.body().contains("\"schema.yaml\""));
+            Assertions.assertTrue(response.body().contains("\"data.sqlite\""));
+            Assertions.assertFalse(response.body().contains("\"data.json\""));
+            Assertions.assertEquals("sqlite-file", body.get("storageMode").getAsString());
+            Assertions.assertEquals("sqlite", body.get("projectStorageMode").getAsString());
+        }
+    }
+
+    @Test
+    public void browserExportFilesCanExportSqliteProjectFromMemoryWorkspace() {
+        try (ActiveThingifierWorkspace workspace =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            UiHttpResponse response =
+                    new CrudUiController(workspace)
+                            .exportProjectFiles(
+                                    JsonSupport.toJson(Map.of("projectStorageMode", "sqlite")));
+            JsonObject body = root(response.body());
+
+            Assertions.assertEquals(200, response.statusCode());
+            Assertions.assertTrue(response.body().contains("\"data.sqlite\""));
+            Assertions.assertFalse(response.body().contains("\"data.json\""));
+            Assertions.assertEquals("sqlite-file", body.get("storageMode").getAsString());
+            Assertions.assertEquals("sqlite", body.get("projectStorageMode").getAsString());
+            Assertions.assertEquals("memory", workspace.snapshot().storage().mode());
+        }
+    }
+
+    @Test
+    public void browserLoadFilesLoadsJsonBackedProjectWithoutServerPath() throws Exception {
+        Path projectFolder = temp.resolve("browser-json-project");
+        try (ActiveThingifierWorkspace source =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            source.replaceWithYaml(TestResources.text("/models/project-tasks.yaml"));
+            createRelatedProjectAndTodo(new DynamicThingifierApiProxy(source));
+            new CrudUiController(source).saveProject(request(projectFolder));
+        }
+
+        try (ActiveThingifierWorkspace target =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            UiHttpResponse response =
+                    new CrudUiController(target)
+                            .loadProjectFiles(browserFilePayload(projectFolder, "browser-json"));
+            DynamicThingifierApiProxy targetProxy = new DynamicThingifierApiProxy(target);
+
+            Assertions.assertEquals(200, response.statusCode(), response.body());
+            Assertions.assertEquals("Project Tasks", target.snapshot().definition().title());
+            Assertions.assertEquals(
+                    "Browser folder: browser-json", target.snapshot().projectPath());
+            Assertions.assertTrue(targetProxy.getJson("projects").body().contains("Project A"));
+            Assertions.assertEquals(
+                    1,
+                    root(targetProxy.getJson("projects/1/tasks").body())
+                            .getAsJsonArray("todos")
+                            .size());
+        }
+    }
+
+    @Test
+    public void browserLoadFilesLoadsSqliteBackedProject() throws Exception {
+        Path projectFolder = temp.resolve("browser-sqlite-project");
+        try (ActiveThingifierWorkspace source =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            source.replaceWithYaml(TestResources.text("/models/project-tasks.yaml"));
+            createRelatedProjectAndTodo(new DynamicThingifierApiProxy(source));
+            source.switchStorage(WorkspaceStorage.sqliteFile(temp.resolve("source.sqlite")));
+            new CrudUiController(source).saveProject(request(projectFolder));
+        }
+
+        try (ActiveThingifierWorkspace target =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            UiHttpResponse response =
+                    new CrudUiController(target)
+                            .loadProjectFiles(browserFilePayload(projectFolder, "browser-sqlite"));
+            DynamicThingifierApiProxy targetProxy = new DynamicThingifierApiProxy(target);
+
+            Assertions.assertEquals(200, response.statusCode(), response.body());
+            Assertions.assertEquals("sqlite-file", target.snapshot().storage().mode());
+            Assertions.assertEquals(
+                    "Browser folder: browser-sqlite", target.snapshot().projectPath());
+            Assertions.assertTrue(targetProxy.getJson("projects").body().contains("Project A"));
+            Assertions.assertEquals(
+                    1,
+                    root(targetProxy.getJson("projects/1/tasks").body())
+                            .getAsJsonArray("todos")
+                            .size());
+        }
+    }
+
+    @Test
+    public void invalidBrowserLoadFilesDoesNotMutateWorkspace() {
+        try (ActiveThingifierWorkspace workspace =
+                ActiveThingifierWorkspace.defaultTodoManagerWorkspace()) {
+            long version = workspace.snapshot().version();
+            List<Map<String, Object>> files = new ArrayList<>();
+            files.add(textPayload("projectfile.erproj", "not: valid: yaml"));
+            UiHttpResponse response =
+                    new CrudUiController(workspace)
+                            .loadProjectFiles(
+                                    JsonSupport.toJson(
+                                            Map.of("folderName", "bad-project", "files", files)));
+
+            Assertions.assertEquals(400, response.statusCode());
+            Assertions.assertEquals(version, workspace.snapshot().version());
+            Assertions.assertEquals("Todo Manager", workspace.snapshot().definition().title());
         }
     }
 
@@ -136,6 +503,49 @@ public class WorkspaceProjectServiceTest {
 
     private String request(final Path path) {
         return JsonSupport.toJson(Map.of("path", path.toString()));
+    }
+
+    private String request(final Path path, final String projectStorageMode) {
+        return JsonSupport.toJson(
+                Map.of("path", path.toString(), "projectStorageMode", projectStorageMode));
+    }
+
+    private String actionRequest(final String action, final Path path) {
+        return JsonSupport.toJson(Map.of("action", action, "path", path.toString()));
+    }
+
+    private String browserFilePayload(final Path folder, final String folderName) throws Exception {
+        List<Map<String, Object>> files = new ArrayList<>();
+        files.add(
+                textPayload(
+                        "projectfile.erproj",
+                        Files.readString(folder.resolve("projectfile.erproj"))));
+        files.add(textPayload("schema.yaml", Files.readString(folder.resolve("schema.yaml"))));
+        Path dataJson = folder.resolve("data.json");
+        if (Files.exists(dataJson)) {
+            files.add(textPayload("data.json", Files.readString(dataJson)));
+        }
+        Path sqlite = folder.resolve("data.sqlite");
+        if (Files.exists(sqlite)) {
+            files.add(binaryPayload("data.sqlite", Files.readAllBytes(sqlite)));
+        }
+        return JsonSupport.toJson(Map.of("folderName", folderName, "files", files));
+    }
+
+    private Map<String, Object> textPayload(final String name, final String content) {
+        Map<String, Object> file = new LinkedHashMap<>();
+        file.put("name", name);
+        file.put("type", "text");
+        file.put("content", content);
+        return file;
+    }
+
+    private Map<String, Object> binaryPayload(final String name, final byte[] content) {
+        Map<String, Object> file = new LinkedHashMap<>();
+        file.put("name", name);
+        file.put("type", "base64");
+        file.put("content", Base64.getEncoder().encodeToString(content));
+        return file;
     }
 
     private String field(final String json, final String fieldName) {

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/BrowserFolderPickerStub.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/BrowserFolderPickerStub.java
@@ -1,0 +1,66 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e;
+
+import com.google.gson.Gson;
+import com.microsoft.playwright.Page;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+final class BrowserFolderPickerStub {
+
+    private final Page page;
+    private final Gson gson = new Gson();
+
+    BrowserFolderPickerStub(final Page page) {
+        this.page = page;
+    }
+
+    void install(final String folderName, final Map<String, String> files) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("name", folderName);
+        payload.put("files", files);
+        page.addInitScript(
+                "window.__thingifierCrudUiTestDirectory = "
+                        + gson.toJson(payload)
+                        + ";\n"
+                        + "window.showDirectoryPicker = async function() {\n"
+                        + "  const directory = window.__thingifierCrudUiTestDirectory;\n"
+                        + "  return {\n"
+                        + "    name: directory.name,\n"
+                        + "    async getFileHandle(name, options) {\n"
+                        + "      if (!(name in directory.files) && !(options && options.create)) {\n"
+                        + "        throw new Error('Missing browser file: ' + name);\n"
+                        + "      }\n"
+                        + "      if (!(name in directory.files)) {\n"
+                        + "        directory.files[name] = '';\n"
+                        + "      }\n"
+                        + "      return {\n"
+                        + "        async getFile() {\n"
+                        + "          const value = directory.files[name] || '';\n"
+                        + "          return new File([value], name, {type: 'text/plain'});\n"
+                        + "        },\n"
+                        + "        async createWritable() {\n"
+                        + "          return {\n"
+                        + "            async write(value) {\n"
+                        + "              if (value instanceof Uint8Array) {\n"
+                        + "                let binary = '';\n"
+                        + "                for (const byte of value) binary += String.fromCharCode(byte);\n"
+                        + "                directory.files[name] = btoa(binary);\n"
+                        + "              } else {\n"
+                        + "                directory.files[name] = String(value);\n"
+                        + "              }\n"
+                        + "            },\n"
+                        + "            async close() {}\n"
+                        + "          };\n"
+                        + "        }\n"
+                        + "      };\n"
+                        + "    }\n"
+                        + "  };\n"
+                        + "};");
+    }
+
+    @SuppressWarnings("unchecked")
+    Map<String, String> files() {
+        return (Map<String, String>)
+                page.evaluate("() => window.__thingifierCrudUiTestDirectory.files");
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/BrowserTestBase.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/BrowserTestBase.java
@@ -1,0 +1,138 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
+
+abstract class BrowserTestBase {
+
+    private static final Path ARTIFACT_DIR =
+            Path.of("thingifier-crud-ui", "target", "playwright-artifacts");
+    private static CrudUiTestServer sharedServer;
+    private static final ThreadLocal<BrowserTestBase> CURRENT = new ThreadLocal<>();
+
+    @RegisterExtension final BrowserFailureArtifacts artifacts = new BrowserFailureArtifacts();
+
+    protected Playwright playwright;
+    protected Browser browser;
+    protected BrowserContext context;
+    protected Page page;
+    protected final List<String> consoleMessages = new ArrayList<>();
+    protected final List<String> requestFailures = new ArrayList<>();
+
+    @BeforeAll
+    static void startCrudUi() {
+        if (sharedServer == null) {
+            sharedServer = CrudUiTestServer.start();
+        }
+    }
+
+    @AfterAll
+    static void stopCrudUi() {
+        if (sharedServer != null) {
+            sharedServer.close();
+            sharedServer = null;
+        }
+    }
+
+    @BeforeEach
+    void launchBrowser() {
+        CURRENT.set(this);
+        playwright = Playwright.create();
+        browser =
+                playwright
+                        .chromium()
+                        .launch(
+                                new BrowserType.LaunchOptions()
+                                        .setHeadless(
+                                                Boolean.parseBoolean(
+                                                        System.getProperty(
+                                                                "crud.ui.headless", "true"))));
+        context = browser.newContext(new Browser.NewContextOptions().setAcceptDownloads(true));
+        page = context.newPage();
+        page.onConsoleMessage(
+                message -> consoleMessages.add(message.type() + ": " + message.text()));
+        page.onRequestFailed(
+                request -> requestFailures.add(request.method() + " " + request.url()));
+    }
+
+    @AfterEach
+    void closeBrowser() {
+        if (context != null) {
+            context.close();
+        }
+        if (browser != null) {
+            browser.close();
+        }
+        if (playwright != null) {
+            playwright.close();
+        }
+        CURRENT.remove();
+    }
+
+    protected CrudUiTestServer server() {
+        return sharedServer;
+    }
+
+    protected CrudUiApiClient api() {
+        return sharedServer.api();
+    }
+
+    protected void resetToProjectTasks() {
+        server().resetToYaml("/models/project-tasks.yaml");
+    }
+
+    protected void resetToMinimalTodo() {
+        server().resetToYaml("/models/minimal-todo.yaml");
+    }
+
+    protected void captureArtifacts(final String displayName) {
+        try {
+            Files.createDirectories(ARTIFACT_DIR);
+            String safeName =
+                    displayName.toLowerCase().replaceAll("[^a-z0-9]+", "-").replaceAll("^-|-$", "");
+            if (page != null) {
+                page.screenshot(
+                        new Page.ScreenshotOptions()
+                                .setPath(ARTIFACT_DIR.resolve(safeName + ".png"))
+                                .setFullPage(true));
+                Files.writeString(ARTIFACT_DIR.resolve(safeName + ".html"), page.content());
+            }
+            Files.writeString(
+                    ARTIFACT_DIR.resolve(safeName + "-console.txt"),
+                    String.join(System.lineSeparator(), consoleMessages));
+            Files.writeString(
+                    ARTIFACT_DIR.resolve(safeName + "-network.txt"),
+                    String.join(System.lineSeparator(), requestFailures));
+        } catch (IOException ignored) {
+            // Failure artifacts are best-effort only.
+        }
+    }
+
+    private static final class BrowserFailureArtifacts implements TestExecutionExceptionHandler {
+
+        @Override
+        public void handleTestExecutionException(
+                final ExtensionContext context, final Throwable throwable) throws Throwable {
+            BrowserTestBase base = CURRENT.get();
+            if (base != null) {
+                base.captureArtifacts(context.getDisplayName());
+            }
+            throw throwable;
+        }
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/CrudUiApiClient.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/CrudUiApiClient.java
@@ -1,0 +1,120 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+
+final class CrudUiApiClient {
+
+    private final HttpClient client;
+    private final String baseUrl;
+
+    CrudUiApiClient(final String baseUrl) {
+        this.baseUrl = baseUrl;
+        this.client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+    }
+
+    ApiResult get(final String path) {
+        return send(HttpRequest.newBuilder(uri(path)).GET().build());
+    }
+
+    ApiResult delete(final String path) {
+        return send(HttpRequest.newBuilder(uri(path)).DELETE().build());
+    }
+
+    ApiResult postJson(final String path, final String json) {
+        return send(
+                HttpRequest.newBuilder(uri(path))
+                        .header("Content-Type", "application/json")
+                        .header("Accept", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(json))
+                        .build());
+    }
+
+    ApiResult putJson(final String path, final String json) {
+        return send(
+                HttpRequest.newBuilder(uri(path))
+                        .header("Content-Type", "application/json")
+                        .header("Accept", "application/json")
+                        .PUT(HttpRequest.BodyPublishers.ofString(json))
+                        .build());
+    }
+
+    ApiResult postText(final String path, final String text) {
+        return send(
+                HttpRequest.newBuilder(uri(path))
+                        .header("Content-Type", "text/plain")
+                        .header("Accept", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(text))
+                        .build());
+    }
+
+    String absoluteUrl(final String path) {
+        return baseUrl + path;
+    }
+
+    String encoded(final String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
+    }
+
+    private ApiResult send(final HttpRequest request) {
+        try {
+            HttpResponse<String> response =
+                    client.send(request, HttpResponse.BodyHandlers.ofString());
+            return new ApiResult(response.statusCode(), response.body(), response.headers().map());
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private URI uri(final String path) {
+        return URI.create(baseUrl + path);
+    }
+
+    static final class ApiResult {
+
+        private final int statusCode;
+        private final String body;
+        private final Map<String, java.util.List<String>> headers;
+
+        ApiResult(
+                final int statusCode,
+                final String body,
+                final Map<String, java.util.List<String>> headers) {
+            this.statusCode = statusCode;
+            this.body = body;
+            this.headers = headers;
+        }
+
+        int statusCode() {
+            return statusCode;
+        }
+
+        String body() {
+            return body;
+        }
+
+        JsonObject jsonObject() {
+            JsonElement parsed = JsonParser.parseString(body);
+            return parsed.getAsJsonObject();
+        }
+
+        String header(final String name) {
+            return headers.getOrDefault(name.toLowerCase(), java.util.List.of()).stream()
+                    .findFirst()
+                    .orElse("");
+        }
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/CrudUiApiIT.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/CrudUiApiIT.java
@@ -1,0 +1,188 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class CrudUiApiIT {
+
+    private static CrudUiTestServer server;
+    private CrudUiApiClient api;
+
+    @BeforeAll
+    static void startServer() {
+        server = CrudUiTestServer.start();
+    }
+
+    @AfterAll
+    static void stopServer() {
+        server.close();
+    }
+
+    @BeforeEach
+    void resetWorkspace() {
+        api = server.api();
+        server.resetToYaml("/models/project-tasks.yaml");
+    }
+
+    @Test
+    public void staticPagesAndGeneratedDocumentationAreReachable() {
+        assertStatusContains("/", 200, "Thingifier CRUD UI");
+        assertStatusContains("/schema", 200, "Thingifier Schema Edit");
+        assertStatusContains("/docs", 200, "API Documentation");
+        assertStatusContains("/swagger", 200, "SwaggerUIBundle");
+        assertStatusContains("/openapi.json", 200, "\"openapi\"");
+        assertStatusContains("/docs/swagger", 200, "\"openapi\"");
+    }
+
+    @Test
+    public void workspaceEndpointsImportExportAndSchemaPreviewWorkThroughHttp() {
+        JsonObject workspace = api.get("/ui/workspace").jsonObject();
+        Assertions.assertEquals(
+                "Project Tasks", workspace.getAsJsonObject("model").get("title").getAsString());
+
+        CrudUiApiClient.ApiResult fromYaml =
+                api.postText("/ui/schema/from-yaml", E2eResource.text("/models/minimal-todo.yaml"));
+        Assertions.assertEquals(200, fromYaml.statusCode(), fromYaml.body());
+        JsonObject draft = fromYaml.jsonObject().getAsJsonObject("draft");
+
+        CrudUiApiClient.ApiResult preview = api.postJson("/ui/schema/preview", draft.toString());
+        Assertions.assertEquals(200, preview.statusCode(), preview.body());
+        Assertions.assertTrue(preview.jsonObject().get("valid").getAsBoolean());
+
+        CrudUiApiClient.ApiResult created =
+                api.postJson("/api/todos", "{\"title\":\"Round trip\"}");
+        Assertions.assertEquals(201, created.statusCode(), created.body());
+        CrudUiApiClient.ApiResult exported = api.get("/ui/export");
+        Assertions.assertEquals(200, exported.statusCode(), exported.body());
+        Assertions.assertTrue(exported.body().contains("Round trip"));
+
+        CrudUiApiClient.ApiResult imported = api.postJson("/ui/import", exported.body());
+        Assertions.assertEquals(200, imported.statusCode(), imported.body());
+        Assertions.assertTrue(api.get("/api/todos").body().contains("Round trip"));
+    }
+
+    @Test
+    public void schemaUpgradePreviewAndApplyAreAvailableThroughHttp() {
+        JsonObject projectDraft =
+                api.postText("/ui/schema/from-yaml", E2eResource.text("/models/project-tasks.yaml"))
+                        .jsonObject()
+                        .getAsJsonObject("draft");
+        entityNamed(projectDraft, "todo")
+                .getAsJsonArray("fields")
+                .add(field("status", "string", "open"));
+
+        long version = api.get("/ui/workspace").jsonObject().get("workspaceVersion").getAsLong();
+        CrudUiApiClient.ApiResult preview =
+                api.postJson("/ui/schema/upgrade/preview", upgradeRequest(projectDraft, version));
+        Assertions.assertEquals(200, preview.statusCode(), preview.body());
+        Assertions.assertTrue(preview.jsonObject().get("canApply").getAsBoolean());
+
+        CrudUiApiClient.ApiResult apply =
+                api.postJson("/ui/schema/upgrade/apply", upgradeRequest(projectDraft, version));
+        Assertions.assertEquals(200, apply.statusCode(), apply.body());
+        Assertions.assertTrue(apply.body().contains("\"status\""));
+    }
+
+    @Test
+    public void projectFilePayloadAndCheckEndpointsWorkThroughHttp() {
+        CrudUiApiClient.ApiResult check =
+                api.postJson(
+                        "/ui/project/check",
+                        "{\"action\":\"save\",\"path\":\"target/e2e-project\"}");
+        Assertions.assertEquals(200, check.statusCode(), check.body());
+        Assertions.assertTrue(check.jsonObject().get("canProceed").getAsBoolean());
+
+        CrudUiApiClient.ApiResult exported = api.postJson("/ui/project/export-files", "{}");
+        Assertions.assertEquals(200, exported.statusCode(), exported.body());
+        JsonArray files = exported.jsonObject().getAsJsonArray("files");
+        Assertions.assertTrue(files.toString().contains("projectfile.erproj"));
+
+        JsonObject loadRequest = new JsonObject();
+        loadRequest.addProperty("folderName", "browser-project");
+        loadRequest.add("files", files);
+        CrudUiApiClient.ApiResult loaded =
+                api.postJson("/ui/project/load-files", loadRequest.toString());
+        Assertions.assertEquals(200, loaded.statusCode(), loaded.body());
+        Assertions.assertTrue(loaded.body().contains("Browser folder: browser-project"));
+    }
+
+    @Test
+    public void storageEndpointAndDynamicApiProxySupportCrudAndRelationships() {
+        CrudUiApiClient.ApiResult switched =
+                api.postJson("/ui/storage/switch", "{\"mode\":\"sqlite-memory\"}");
+        Assertions.assertEquals(200, switched.statusCode(), switched.body());
+        Assertions.assertEquals(
+                "sqlite-memory",
+                switched.jsonObject().getAsJsonObject("storage").get("mode").getAsString());
+
+        String projectId = create("/api/projects", "title", "Smoke Project");
+        String todoId = create("/api/todos", "title", "Do this");
+        CrudUiApiClient.ApiResult connected =
+                api.postJson(
+                        "/api/projects/" + projectId + "/tasks", "{\"id\":\"" + todoId + "\"}");
+        Assertions.assertEquals(201, connected.statusCode(), connected.body());
+        Assertions.assertTrue(
+                api.get("/api/projects/" + projectId + "/tasks").body().contains("Do this"));
+
+        CrudUiApiClient.ApiResult disconnected =
+                api.delete("/api/projects/" + projectId + "/tasks/" + todoId);
+        Assertions.assertEquals(200, disconnected.statusCode(), disconnected.body());
+        Assertions.assertTrue(api.get("/api/todos/" + todoId).body().contains("Do this"));
+    }
+
+    private void assertStatusContains(
+            final String path, final int statusCode, final String expectedText) {
+        CrudUiApiClient.ApiResult result = api.get(path);
+        Assertions.assertEquals(statusCode, result.statusCode(), result.body());
+        Assertions.assertTrue(result.body().contains(expectedText), result.body());
+    }
+
+    private String create(final String path, final String field, final String value) {
+        CrudUiApiClient.ApiResult created =
+                api.postJson(path, JsonSupport.map(field, value).toString());
+        Assertions.assertEquals(201, created.statusCode(), created.body());
+        return created.jsonObject().get("id").getAsString();
+    }
+
+    private String upgradeRequest(final JsonObject draft, final long version) {
+        JsonObject request = new JsonObject();
+        request.add("draft", draft);
+        request.addProperty("expectedWorkspaceVersion", version);
+        request.add("mappings", new JsonObject());
+        return request.toString();
+    }
+
+    private JsonObject field(final String name, final String type, final String defaultValue) {
+        JsonObject field = new JsonObject();
+        field.addProperty("name", name);
+        field.addProperty("type", type);
+        field.addProperty("defaultValue", defaultValue);
+        return field;
+    }
+
+    private JsonObject entityNamed(final JsonObject draft, final String name) {
+        for (var entityValue : draft.getAsJsonArray("entities")) {
+            JsonObject entity = entityValue.getAsJsonObject();
+            if (name.equals(entity.get("name").getAsString())) {
+                return entity;
+            }
+        }
+        throw new AssertionError("Missing entity " + name);
+    }
+
+    private static final class JsonSupport {
+
+        private JsonSupport() {}
+
+        static JsonObject map(final String key, final String value) {
+            JsonObject object = new JsonObject();
+            object.addProperty(key, value);
+            return object;
+        }
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/CrudUiTestServer.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/CrudUiTestServer.java
@@ -1,0 +1,57 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import uk.co.compendiumdev.thingifier.crudui.ActiveThingifierWorkspace;
+import uk.co.compendiumdev.thingifier.crudui.adapter.spark.CrudUiApplication;
+
+final class CrudUiTestServer implements AutoCloseable {
+
+    private final int port;
+    private final ActiveThingifierWorkspace workspace;
+    private final CrudUiApplication application;
+    private final CrudUiApiClient api;
+
+    private CrudUiTestServer(final int port) {
+        this.port = port;
+        this.workspace = ActiveThingifierWorkspace.defaultTodoManagerWorkspace();
+        this.application = new CrudUiApplication(workspace, port);
+        this.api = new CrudUiApiClient(baseUrl());
+    }
+
+    static CrudUiTestServer start() {
+        CrudUiTestServer server = new CrudUiTestServer(availablePort());
+        server.application.start();
+        return server;
+    }
+
+    String baseUrl() {
+        return "http://localhost:" + port;
+    }
+
+    CrudUiApiClient api() {
+        return api;
+    }
+
+    void resetToYaml(final String resourcePath) {
+        api.postJson("/ui/storage/switch", "{\"mode\":\"memory\"}");
+        CrudUiApiClient.ApiResult result =
+                api.postText("/ui/model/yaml", E2eResource.text(resourcePath));
+        if (result.statusCode() != 200) {
+            throw new IllegalStateException(result.body());
+        }
+    }
+
+    private static int availablePort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public void close() {
+        application.close();
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/E2eResource.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/E2eResource.java
@@ -1,0 +1,21 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+final class E2eResource {
+
+    private E2eResource() {}
+
+    static String text(final String resourcePath) {
+        try (InputStream stream = E2eResource.class.getResourceAsStream(resourcePath)) {
+            if (stream == null) {
+                throw new IllegalArgumentException("Missing test resource " + resourcePath);
+            }
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/ProjectStorageUiIT.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/ProjectStorageUiIT.java
@@ -1,0 +1,161 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import java.awt.GraphicsEnvironment;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import uk.co.compendiumdev.thingifier.crudui.e2e.pages.WorkspacePage;
+
+public class ProjectStorageUiIT extends BrowserTestBase {
+
+    @TempDir Path temp;
+
+    private WorkspacePage workspace;
+
+    @BeforeEach
+    void resetWorkspace() {
+        resetToProjectTasks();
+    }
+
+    @Test
+    public void typedProjectSaveLoadAndRecentPathWorkFromWorkspace() {
+        workspace = new WorkspacePage(page, server().baseUrl()).open();
+        api().postJson("/api/todos", "{\"title\":\"Saved Task\"}");
+        Path projectFolder = temp.resolve("typed-project");
+
+        workspace.projectDialog().openSave();
+        workspace.projectDialog().fillPath(projectFolder.toString());
+        workspace.projectDialog().validatePath();
+        assertThat(workspace.projectDialog().status())
+                .containsText("Project folder can be created");
+        workspace.projectDialog().confirm();
+        assertThat(workspace.messages().root()).containsText("Project saved.");
+        Assertions.assertTrue(Files.exists(projectFolder.resolve("projectfile.erproj")));
+        Assertions.assertTrue(Files.exists(projectFolder.resolve("schema.yaml")));
+        Assertions.assertTrue(Files.exists(projectFolder.resolve("data.json")));
+
+        api().postText("/ui/model/yaml", E2eResource.text("/models/minimal-todo.yaml"));
+        workspace = new WorkspacePage(page, server().baseUrl()).open();
+        workspace.projectDialog().openLoad();
+        workspace.projectDialog().fillPath(projectFolder.toString());
+        workspace.projectDialog().confirm();
+        assertThat(workspace.messages().root()).containsText("Project loaded.");
+        Assertions.assertTrue(api().get("/api/todos").body().contains("Saved Task"));
+        Assertions.assertTrue(
+                String.valueOf(
+                                page.evaluate(
+                                        "() => localStorage.getItem('thingifier-crud-ui.projectPaths')"))
+                        .contains("typed-project"));
+    }
+
+    @Test
+    public void saveProjectStorageChoiceSwitchesActiveWorkspaceStorage() {
+        workspace = new WorkspacePage(page, server().baseUrl()).open();
+        api().postJson("/api/todos", "{\"title\":\"Saved Storage Task\"}");
+        Path sqliteProject = temp.resolve("save-as-sqlite-project");
+        Path jsonProject = temp.resolve("save-as-json-project");
+
+        workspace.projectDialog().openSave();
+        assertThat(workspace.projectDialog().saveStorageOptions()).isVisible();
+        workspace.projectDialog().chooseSqliteProject();
+        workspace.projectDialog().fillPath(sqliteProject.toString());
+        workspace.projectDialog().confirm();
+
+        assertThat(workspace.messages().root()).containsText("Project saved.");
+        assertThat(workspace.topBar().description()).containsText("SQLite File");
+        Assertions.assertTrue(Files.exists(sqliteProject.resolve("data.sqlite")));
+        Assertions.assertFalse(Files.exists(sqliteProject.resolve("data.json")));
+        Assertions.assertTrue(api().get("/api/todos").body().contains("Saved Storage Task"));
+
+        workspace.projectDialog().openSave();
+        workspace.projectDialog().chooseJsonProject();
+        workspace.projectDialog().fillPath(jsonProject.toString());
+        workspace.projectDialog().confirm();
+
+        assertThat(workspace.messages().root()).containsText("Project saved.");
+        assertThat(workspace.topBar().description()).containsText("In Memory");
+        Assertions.assertTrue(Files.exists(jsonProject.resolve("data.json")));
+        Assertions.assertFalse(Files.exists(jsonProject.resolve("data.sqlite")));
+        Assertions.assertTrue(api().get("/api/todos").body().contains("Saved Storage Task"));
+    }
+
+    @Test
+    public void browserFolderProjectSaveAndLoadUseInjectedFolderPicker() {
+        BrowserFolderPickerStub savePicker = new BrowserFolderPickerStub(page);
+        savePicker.install("browser-project", new LinkedHashMap<>());
+        workspace = new WorkspacePage(page, server().baseUrl()).open();
+        api().postJson("/api/todos", "{\"title\":\"Browser Saved Task\"}");
+
+        workspace.projectDialog().openSave();
+        workspace.projectDialog().browserSave();
+        assertThat(workspace.projectDialog().status()).containsText("Browser project saved");
+        Assertions.assertEquals("browser-project", workspace.projectDialog().pathValue());
+        Map<String, String> savedFiles = savePicker.files();
+        Assertions.assertTrue(savedFiles.containsKey("projectfile.erproj"));
+        Assertions.assertTrue(savedFiles.containsKey("schema.yaml"));
+        Assertions.assertTrue(savedFiles.containsKey("data.json"));
+
+        page.close();
+        page = context.newPage();
+        BrowserFolderPickerStub loadPicker = new BrowserFolderPickerStub(page);
+        loadPicker.install("browser-project", savedFiles);
+        api().postText("/ui/model/yaml", E2eResource.text("/models/minimal-todo.yaml"));
+        workspace = new WorkspacePage(page, server().baseUrl()).open();
+        workspace.projectDialog().openLoad();
+        workspace.projectDialog().browserLoad();
+        assertThat(workspace.messages().root()).containsText("Browser project loaded");
+        Assertions.assertTrue(api().get("/api/todos").body().contains("Browser Saved Task"));
+    }
+
+    @Test
+    public void storageSelectorSwitchesModesAndPreservesData() {
+        workspace = new WorkspacePage(page, server().baseUrl()).open();
+        api().postJson("/api/todos", "{\"title\":\"Stored Task\"}");
+
+        workspace.storage().switchTo("sqlite-memory");
+        assertThat(workspace.messages().root()).containsText("Storage switched.");
+        Assertions.assertTrue(api().get("/api/todos").body().contains("Stored Task"));
+
+        Path database = temp.resolve("workspace.sqlite");
+        workspace.storage().switchToFile(database.toString());
+        assertThat(workspace.messages().root()).containsText("Storage switched.");
+        assertThat(workspace.topBar().description()).containsText("SQLite File");
+        Assertions.assertTrue(api().get("/api/todos").body().contains("Stored Task"));
+        workspace.storage().switchTo("memory");
+        assertThat(workspace.messages().root()).containsText("Storage switched.");
+    }
+
+    @Test
+    public void nativeBrowseReportsHeadlessFallbackWhenRunningHeadless() {
+        Assumptions.assumeTrue(GraphicsEnvironment.isHeadless());
+        workspace = new WorkspacePage(page, server().baseUrl()).open();
+
+        workspace.projectDialog().openSave();
+        workspace.projectDialog().browse();
+        assertThat(workspace.projectDialog().status()).containsText("Native project browsing");
+    }
+
+    @Test
+    public void jsonImportExportRoundTripWorksThroughBrowserControls() {
+        workspace = new WorkspacePage(page, server().baseUrl()).open();
+        api().postJson("/api/todos", "{\"title\":\"Downloaded Task\"}");
+        Path downloadPath = temp.resolve("thingifier-workspace.json");
+
+        com.microsoft.playwright.Download download =
+                page.waitForDownload(() -> page.locator("[data-testid='export-button']").click());
+        download.saveAs(downloadPath);
+
+        api().postText("/ui/model/yaml", E2eResource.text("/models/minimal-todo.yaml"));
+        page.locator("[data-testid='import-file']").setInputFiles(downloadPath);
+        assertThat(workspace.messages().root()).containsText("Workspace imported.");
+        Assertions.assertTrue(api().get("/api/todos").body().contains("Downloaded Task"));
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/RelationshipUiIT.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/RelationshipUiIT.java
@@ -1,0 +1,61 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.co.compendiumdev.thingifier.crudui.e2e.pages.WorkspacePage;
+
+public class RelationshipUiIT extends BrowserTestBase {
+
+    private WorkspacePage workspace;
+
+    @BeforeEach
+    void seedRelationshipWorkspace() {
+        resetToProjectTasks();
+        api().postJson("/api/projects", "{\"title\":\"Smoke Project\"}");
+        api().postJson("/api/todos", "{\"title\":\"Do this\"}");
+        api().postJson("/api/todos", "{\"title\":\"Do that\"}");
+        workspace = new WorkspacePage(page, server().baseUrl()).open();
+    }
+
+    @Test
+    public void relationshipManagerCanConnectCreateAndRemoveRelationshipEdges() {
+        workspace.outline().expandEntity("project");
+        workspace.outline().expandInstance("project", "1");
+        workspace.outline().selectRelationship("project", "1", "tasks");
+        assertThat(workspace.relationships().root()).isVisible();
+        assertThat(workspace.relationships().connectSelect()).isVisible();
+
+        workspace.relationships().connectExisting("1");
+        assertThat(workspace.messages().root()).containsText("todo connected.");
+        assertThat(workspace.grid().row("todo", "1")).containsText("Do this");
+        Assertions.assertTrue(api().get("/api/projects/1/tasks").body().contains("Do this"));
+
+        workspace.relationships().createAndConnect("Do from relationship");
+        assertThat(workspace.messages().root()).containsText("todo created and connected.");
+        assertThat(workspace.grid().row("todo", "3")).containsText("Do from relationship");
+        Assertions.assertTrue(api().get("/api/todos/3").body().contains("Do from relationship"));
+
+        workspace.relationships().removeRow("todo", "1");
+        assertThat(workspace.messages().root()).containsText("todo removed from relationship.");
+        Assertions.assertFalse(api().get("/api/projects/1/tasks").body().contains("Do this"));
+        Assertions.assertTrue(api().get("/api/todos/1").body().contains("Do this"));
+    }
+
+    @Test
+    public void editorRelationshipRemoveDoesNotDeleteTargetInstance() {
+        api().postJson("/api/projects/1/tasks", "{\"id\":\"2\"}");
+        page.reload();
+        workspace.outline().expandEntity("project");
+        workspace.outline().expandInstance("project", "1");
+        workspace.outline().selectRelationship("project", "1", "tasks");
+        workspace.grid().row("todo", "2").click();
+        workspace.editor().removeFromRelationship();
+
+        assertThat(workspace.messages().root()).containsText("todo removed from relationship.");
+        Assertions.assertFalse(api().get("/api/projects/1/tasks").body().contains("Do that"));
+        Assertions.assertTrue(api().get("/api/todos/2").body().contains("Do that"));
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/SchemaApplyUiIT.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/SchemaApplyUiIT.java
@@ -1,0 +1,62 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.co.compendiumdev.thingifier.crudui.e2e.components.TestSelectors;
+import uk.co.compendiumdev.thingifier.crudui.e2e.pages.SchemaEditPage;
+
+public class SchemaApplyUiIT extends BrowserTestBase {
+
+    private SchemaEditPage schema;
+
+    @BeforeEach
+    void openSchemaEditorWithData() {
+        resetToProjectTasks();
+        api().postJson("/api/todos", "{\"title\":\"Migrated Task\"}");
+        schema = new SchemaEditPage(page, server().baseUrl()).open();
+    }
+
+    @Test
+    public void applyDialogOpensOnlyOnApplyCancelLeavesWorkspaceAndConfirmMigratesData() {
+        assertThat(schema.upgrade().root()).isHidden();
+        addTodoStatusField();
+
+        assertThat(TestSelectors.byTestId(page, "schema-apply-workspace-button")).isEnabled();
+        schema.upgrade().open();
+        assertThat(schema.upgrade().root()).isVisible();
+        assertThat(schema.upgrade().report()).containsText("Upgrade can be applied");
+        schema.upgrade().cancel();
+        assertThat(schema.upgrade().root()).isHidden();
+        Assertions.assertFalse(api().get("/api/todos/1").body().contains("status"));
+
+        schema.upgrade().open();
+        assertThat(schema.upgrade().report()).containsText("Upgrade can be applied");
+        schema.upgrade().confirm();
+        assertThat(schema.messages().root()).containsText("Schema upgrade applied");
+        Assertions.assertTrue(api().get("/api/todos/1").body().contains("\"status\":\"open\""));
+    }
+
+    @Test
+    public void staleWorkspaceApplyFailureIsReportedByUi() {
+        addTodoStatusField();
+        schema.upgrade().open();
+        assertThat(schema.upgrade().root()).isVisible();
+        api().postText("/ui/model/yaml", E2eResource.text("/models/minimal-todo.yaml"));
+        schema.upgrade().confirm();
+        assertThat(schema.messages().root()).containsText("Request failed with status 409");
+    }
+
+    private void addTodoStatusField() {
+        schema.tree().selectEntity("todo");
+        schema.detail().clickAction("Add Field");
+        schema.detail().fill("Name", "status");
+        schema.detail().select("Type", "string");
+        schema.detail().fill("Default", "open");
+        schema.validate();
+        assertThat(TestSelectors.byTestId(page, "schema-validation"))
+                .containsText("Schema is valid");
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/SchemaEditorUiIT.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/SchemaEditorUiIT.java
@@ -1,0 +1,121 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import com.microsoft.playwright.Download;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import uk.co.compendiumdev.thingifier.crudui.e2e.components.TestSelectors;
+import uk.co.compendiumdev.thingifier.crudui.e2e.pages.SchemaEditPage;
+
+public class SchemaEditorUiIT extends BrowserTestBase {
+
+    @TempDir Path temp;
+
+    private SchemaEditPage schema;
+
+    @BeforeEach
+    void openSchemaEditor() {
+        resetToProjectTasks();
+        schema = new SchemaEditPage(page, server().baseUrl()).open();
+    }
+
+    @Test
+    public void schemaEditIsSeparateFromWorkspaceAndDiagramControlsWork() {
+        assertThat(TestSelectors.byTestId(page, "schema-page")).isVisible();
+        Assertions.assertEquals(0, page.locator("[data-testid='docs-link']").count());
+        Assertions.assertEquals(0, page.locator("[data-testid='swagger-link']").count());
+        Assertions.assertEquals(0, page.locator("[data-testid='download-openapi-link']").count());
+        assertThat(schema.diagram().key()).containsText("Relationship Key");
+        assertThat(schema.diagram().diagram()).isVisible();
+
+        schema.diagram().zoomIn();
+        assertThat(TestSelectors.byTestId(page, "schema-zoom-reset-button")).containsText("110%");
+        schema.diagram().zoomOut();
+        assertThat(TestSelectors.byTestId(page, "schema-zoom-reset-button")).containsText("100%");
+        schema.diagram().toggleLayout();
+        assertThat(TestSelectors.byTestId(page, "schema-layout-toggle-button"))
+                .containsText("Horizontal Layout");
+        schema.diagram().toggleVisible();
+        assertThat(schema.diagram().content()).isHidden();
+        schema.diagram().toggleVisible();
+        assertThat(schema.diagram().content()).isVisible();
+    }
+
+    @Test
+    public void schemaTreeSupportsEntityFieldValidationAndRelationshipEditing() {
+        schema.tree().addEntity();
+        schema.detail().fill("Name", "note");
+        schema.detail().fill("Plural", "notes");
+        schema.detail().fill("Primary Key", "id");
+        schema.detail().clickAction("Add Field");
+        schema.detail().fill("Name", "id");
+        schema.detail().select("Type", "auto-increment");
+        schema.tree().selectEntity("note");
+        schema.detail().clickAction("Add Field");
+        schema.detail().fill("Name", "body");
+        schema.detail().select("Type", "string");
+        schema.detail().clickAction("Add Validation");
+        assertThat(TestSelectors.byTestId(page, "schema-dirty-status")).isVisible();
+
+        page.locator(
+                        "[data-testid='schema-section-relationships'] [data-testid='schema-action-add']")
+                .click();
+        schema.detail().select("From", "project");
+        schema.detail().fill("Name", "notes");
+        schema.detail().select("To", "note");
+        schema.detail().select("Cardinality", "one-to-many");
+        schema.detail().select("Optionality", "optional");
+        schema.validate();
+        assertThat(TestSelectors.byTestId(page, "schema-validation"))
+                .containsText("Schema is valid");
+    }
+
+    @Test
+    public void yamlParseValidateExportsCopyAndDownloadWorkFromSchemaEdit() throws Exception {
+        schema.toggleYamlDraft();
+        assertThat(TestSelectors.byTestId(page, "schema-yaml-section")).isVisible();
+        TestSelectors.byTestId(page, "schema-yaml-input").fill("formatVersion: 1\nentities: [");
+        TestSelectors.byTestId(page, "schema-parse-yaml-button").click();
+        assertThat(schema.messages().root()).isVisible();
+
+        TestSelectors.byTestId(page, "schema-yaml-input")
+                .fill(E2eResource.text("/models/minimal-todo.yaml"));
+        TestSelectors.byTestId(page, "schema-parse-yaml-button").click();
+        assertThat(schema.tree().root()).containsText("todo");
+        schema.validate();
+
+        schema.exports().toggle();
+        assertThat(schema.exports().root()).isVisible();
+        Assertions.assertTrue(
+                schema.exports().canonicalYaml().inputValue().contains("Minimal Todo"));
+        Assertions.assertTrue(schema.exports().mermaid().inputValue().contains("erDiagram"));
+        Assertions.assertTrue(schema.exports().graphviz().inputValue().contains("digraph"));
+        schema.exports().copyYaml();
+        assertThat(schema.messages().root()).containsText("YAML copied");
+
+        Download download = schema.exports().downloadMermaid();
+        Path mermaidFile = temp.resolve(download.suggestedFilename());
+        download.saveAs(mermaidFile);
+        Assertions.assertTrue(Files.readString(mermaidFile).contains("erDiagram"));
+    }
+
+    @Test
+    public void dirtyResetPromptsBeforeDiscardingDraftChanges() {
+        schema.tree().selectModel();
+        schema.detail().fill("Title", "Changed Title");
+        assertThat(TestSelectors.byTestId(page, "schema-dirty-status")).isVisible();
+
+        page.onDialog(dialog -> dialog.accept());
+        TestSelectors.byTestId(page, "schema-reset-button").click();
+        Assertions.assertEquals(
+                Boolean.TRUE,
+                TestSelectors.byTestId(page, "schema-dirty-status")
+                        .evaluate("element => element.hidden"));
+        assertThat(schema.topBar().description()).containsText("Project Tasks");
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/WorkspaceUiIT.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/WorkspaceUiIT.java
@@ -1,0 +1,136 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.co.compendiumdev.thingifier.crudui.e2e.pages.WorkspacePage;
+
+public class WorkspaceUiIT extends BrowserTestBase {
+
+    private WorkspacePage workspace;
+
+    @BeforeEach
+    void openWorkspace() {
+        resetToProjectTasks();
+        workspace = new WorkspacePage(page, server().baseUrl()).open();
+    }
+
+    @Test
+    public void workspaceLoadsDefaultMetadataAndRelationshipOutlineCanExpand() {
+        assertThat(workspace.topBar().title()).containsText("Project Tasks");
+        assertThat(workspace.outline().entity("project")).isVisible();
+        assertThat(workspace.outline().entity("todo")).isVisible();
+
+        api().postJson("/api/projects", "{\"title\":\"Smoke Project\"}");
+        api().postJson("/api/todos", "{\"title\":\"Do this\"}");
+        api().postJson("/api/todos", "{\"title\":\"Do that\"}");
+        api().postJson("/api/projects/1/tasks", "{\"id\":\"1\"}");
+        api().postJson("/api/projects/1/tasks", "{\"id\":\"2\"}");
+        workspace.grid().refresh();
+
+        workspace.outline().expandEntity("project");
+        assertThat(workspace.outline().instance("project", "1")).containsText("Smoke Project");
+        workspace.outline().expandInstance("project", "1");
+        assertThat(workspace.outline().relationship("project", "1", "tasks")).isVisible();
+        workspace.outline().expandRelationship("project", "1", "tasks");
+        assertThat(workspace.outline().relatedInstance("todo", "1")).containsText("Do this");
+        assertThat(workspace.outline().relatedInstance("todo", "2")).containsText("Do that");
+    }
+
+    @Test
+    public void entityCrudSearchRefreshAndDocumentationLinksWorkFromWorkspace() {
+        workspace.outline().selectEntity("todo");
+        assertThat(workspace.grid().title()).containsText("todos");
+        workspace.grid().clickNew();
+        assertThat(workspace.editor().field("id")).isDisabled();
+        assertThat(workspace.editor().field("id")).hasValue("<auto-assigned>");
+        workspace.editor().fillField("title", "Do this");
+        workspace.editor().save();
+        assertThat(workspace.messages().root()).containsText("todo saved.");
+        assertThat(workspace.grid().row("todo", "1")).containsText("Do this");
+
+        workspace.grid().row("todo", "1").click();
+        workspace.editor().fillField("title", "Do that");
+        workspace.editor().save();
+        assertThat(workspace.grid().row("todo", "1")).containsText("Do that");
+        workspace.grid().globalSearch("Do that");
+        assertThat(workspace.grid().row("todo", "1")).isVisible();
+        Assertions.assertTrue(api().get("/api/todos/1").body().contains("Do that"));
+
+        workspace.grid().row("todo", "1").click();
+        workspace.editor().delete();
+        assertThat(workspace.messages().root()).containsText("todo deleted.");
+        Assertions.assertEquals(404, api().get("/api/todos/1").statusCode());
+
+        workspace.topBar().openApiDocs();
+        page.waitForURL("**/docs");
+        assertThat(page.locator("body")).containsText("Project Tasks API Documentation");
+        page.navigate(server().baseUrl() + "/");
+        workspace.topBar().openSwagger();
+        page.waitForURL("**/swagger");
+        assertThat(page.locator("body")).containsText("Explore");
+        page.navigate(server().baseUrl() + "/");
+        Assertions.assertTrue(
+                workspace.topBar().downloadOpenApi().suggestedFilename().endsWith(".json"));
+    }
+
+    @Test
+    public void booleanFieldsAreSubmittedAsJsonBooleansFromWorkspaceEditor() {
+        api().postText("/ui/model/yaml", E2eResource.text("/models/todo-manager.yaml"));
+        workspace = new WorkspacePage(page, server().baseUrl()).open();
+        List<String> projectPostBodies = new ArrayList<>();
+        page.onRequest(
+                request -> {
+                    if ("POST".equals(request.method())
+                            && request.url().endsWith("/api/projects")) {
+                        projectPostBodies.add(request.postData());
+                    }
+                });
+
+        workspace.outline().selectEntity("project");
+        workspace.grid().clickNew();
+        workspace.editor().fillField("title", "Boolean Smoke Project");
+        workspace.editor().save();
+
+        assertThat(workspace.messages().root()).containsText("project saved.");
+        Assertions.assertFalse(projectPostBodies.isEmpty());
+        Assertions.assertTrue(projectPostBodies.get(0).contains("\"completed\":false"));
+        Assertions.assertTrue(projectPostBodies.get(0).contains("\"active\":false"));
+        String savedProject = api().get("/api/projects/1").body();
+        Assertions.assertTrue(
+                savedProject.matches("(?s).*\"completed\"\\s*:\\s*false.*"), savedProject);
+        Assertions.assertTrue(
+                savedProject.matches("(?s).*\"active\"\\s*:\\s*false.*"), savedProject);
+    }
+
+    @Test
+    public void stringFieldsWithoutMaxLengthRenderAsTextareas() {
+        workspace.outline().selectEntity("project");
+        workspace.grid().clickNew();
+        Assertions.assertEquals("textarea", workspace.editor().fieldTagName("title"));
+
+        api().postText("/ui/model/yaml", E2eResource.text("/models/validations.yaml"));
+        workspace = new WorkspacePage(page, server().baseUrl()).open();
+        workspace.outline().selectEntity("item");
+        workspace.grid().clickNew();
+        Assertions.assertEquals("input", workspace.editor().fieldTagName("title"));
+    }
+
+    @Test
+    public void yamlUploadReplacesSchemaAndClearsData() {
+        api().postJson("/api/projects", "{\"title\":\"Smoke Project\"}");
+        page.locator("[data-testid='yaml-file']")
+                .setInputFiles(
+                        Path.of("src/test/resources/models/minimal-todo.yaml").toAbsolutePath());
+
+        assertThat(workspace.topBar().title()).containsText("Minimal Todo");
+        assertThat(workspace.outline().entity("todo")).isVisible();
+        Assertions.assertEquals(404, api().get("/api/projects").statusCode());
+        Assertions.assertFalse(api().get("/api/todos").body().contains("Smoke Project"));
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/DataGridComponent.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/DataGridComponent.java
@@ -1,0 +1,41 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e.components;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+
+public final class DataGridComponent {
+
+    private final Page page;
+
+    public DataGridComponent(final Page page) {
+        this.page = page;
+    }
+
+    public Locator title() {
+        return TestSelectors.byTestId(page, "grid-title");
+    }
+
+    public Locator context() {
+        return TestSelectors.byTestId(page, "grid-context");
+    }
+
+    public Locator row(final String entityName, final String id) {
+        return TestSelectors.byTestId(page, TestSelectors.id("grid-row", entityName, id));
+    }
+
+    public Locator columnFilter(final String entityName, final String fieldName) {
+        return TestSelectors.byTestId(page, TestSelectors.id("grid-filter", entityName, fieldName));
+    }
+
+    public void globalSearch(final String text) {
+        TestSelectors.byTestId(page, "search-input").fill(text);
+    }
+
+    public void clickNew() {
+        TestSelectors.byTestId(page, "new-button").click();
+    }
+
+    public void refresh() {
+        TestSelectors.byTestId(page, "refresh-button").click();
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/DiagramPanelComponent.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/DiagramPanelComponent.java
@@ -1,0 +1,45 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e.components;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+
+public final class DiagramPanelComponent {
+
+    private final Page page;
+
+    public DiagramPanelComponent(final Page page) {
+        this.page = page;
+    }
+
+    public Locator content() {
+        return TestSelectors.byTestId(page, "schema-diagram-content");
+    }
+
+    public Locator diagram() {
+        return TestSelectors.byTestId(page, "schema-mermaid-diagram");
+    }
+
+    public Locator key() {
+        return TestSelectors.byTestId(page, "schema-diagram-key");
+    }
+
+    public Locator resizer() {
+        return TestSelectors.byTestId(page, "schema-diagram-resizer");
+    }
+
+    public void toggleVisible() {
+        TestSelectors.byTestId(page, "schema-toggle-diagram-button").click();
+    }
+
+    public void zoomIn() {
+        TestSelectors.byTestId(page, "schema-zoom-in-button").click();
+    }
+
+    public void zoomOut() {
+        TestSelectors.byTestId(page, "schema-zoom-out-button").click();
+    }
+
+    public void toggleLayout() {
+        TestSelectors.byTestId(page, "schema-layout-toggle-button").click();
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/EditorPanelComponent.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/EditorPanelComponent.java
@@ -1,0 +1,42 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e.components;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+
+public final class EditorPanelComponent {
+
+    private final Page page;
+
+    public EditorPanelComponent(final Page page) {
+        this.page = page;
+    }
+
+    public Locator root() {
+        return TestSelectors.byTestId(page, "editor-panel");
+    }
+
+    public Locator field(final String fieldName) {
+        return TestSelectors.byTestId(page, TestSelectors.id("field-input", "editor", fieldName));
+    }
+
+    public String fieldTagName(final String fieldName) {
+        return String.valueOf(
+                field(fieldName).evaluate("element => element.tagName.toLowerCase()"));
+    }
+
+    public void fillField(final String fieldName, final String value) {
+        field(fieldName).fill(value);
+    }
+
+    public void save() {
+        TestSelectors.byTestId(page, "editor-save-button").click();
+    }
+
+    public void delete() {
+        TestSelectors.byTestId(page, "editor-delete-button").click();
+    }
+
+    public void removeFromRelationship() {
+        TestSelectors.byTestId(page, "editor-remove-relationship-button").click();
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/MessageBarComponent.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/MessageBarComponent.java
@@ -1,0 +1,17 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e.components;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+
+public final class MessageBarComponent {
+
+    private final Page page;
+
+    public MessageBarComponent(final Page page) {
+        this.page = page;
+    }
+
+    public Locator root() {
+        return TestSelectors.byTestId(page, "message-bar");
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/OutlineTreeComponent.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/OutlineTreeComponent.java
@@ -1,0 +1,61 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e.components;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+
+public final class OutlineTreeComponent {
+
+    private final Page page;
+
+    public OutlineTreeComponent(final Page page) {
+        this.page = page;
+    }
+
+    public Locator root() {
+        return TestSelectors.byTestId(page, "outline-tree");
+    }
+
+    public Locator entity(final String entityName) {
+        return TestSelectors.byTestId(page, TestSelectors.id("outline-entity", entityName));
+    }
+
+    public Locator instance(final String entityName, final String id) {
+        return TestSelectors.byTestId(page, TestSelectors.id("outline-instance", entityName, id));
+    }
+
+    public Locator relationship(final String entityName, final String sourceId, final String name) {
+        return TestSelectors.byTestId(
+                page, TestSelectors.id("outline-relationship", entityName, sourceId, name));
+    }
+
+    public Locator relatedInstance(final String entityName, final String id) {
+        return TestSelectors.byTestId(
+                page, TestSelectors.id("outline-related-instance", entityName, id));
+    }
+
+    public void expandEntity(final String entityName) {
+        entity(entityName).locator(".tree-caret").click();
+    }
+
+    public void expandInstance(final String entityName, final String id) {
+        instance(entityName, id).locator(".tree-caret").click();
+    }
+
+    public void expandRelationship(
+            final String entityName, final String sourceId, final String relationshipName) {
+        relationship(entityName, sourceId, relationshipName).locator(".tree-caret").click();
+    }
+
+    public void selectEntity(final String entityName) {
+        entity(entityName).click();
+    }
+
+    public void selectInstance(final String entityName, final String id) {
+        instance(entityName, id).click();
+    }
+
+    public void selectRelationship(
+            final String entityName, final String sourceId, final String relationshipName) {
+        relationship(entityName, sourceId, relationshipName).click();
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/ProjectDialogComponent.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/ProjectDialogComponent.java
@@ -1,0 +1,69 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e.components;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+
+public final class ProjectDialogComponent {
+
+    private final Page page;
+
+    public ProjectDialogComponent(final Page page) {
+        this.page = page;
+    }
+
+    public Locator root() {
+        return TestSelectors.byTestId(page, "project-dialog");
+    }
+
+    public Locator status() {
+        return TestSelectors.byTestId(page, "project-browser-status");
+    }
+
+    public Locator saveStorageOptions() {
+        return TestSelectors.byTestId(page, "project-save-storage-options");
+    }
+
+    public void openSave() {
+        TestSelectors.byTestId(page, "save-project-button").click();
+    }
+
+    public void openLoad() {
+        TestSelectors.byTestId(page, "load-project-button").click();
+    }
+
+    public void fillPath(final String path) {
+        TestSelectors.byTestId(page, "project-path-input").fill(path);
+    }
+
+    public String pathValue() {
+        return TestSelectors.byTestId(page, "project-path-input").inputValue();
+    }
+
+    public void validatePath() {
+        TestSelectors.byTestId(page, "project-validate-button").click();
+    }
+
+    public void browse() {
+        TestSelectors.byTestId(page, "project-browse-button").click();
+    }
+
+    public void chooseJsonProject() {
+        TestSelectors.byTestId(page, "project-save-storage-json").check();
+    }
+
+    public void chooseSqliteProject() {
+        TestSelectors.byTestId(page, "project-save-storage-sqlite").check();
+    }
+
+    public void confirm() {
+        TestSelectors.byTestId(page, "project-dialog-confirm").click();
+    }
+
+    public void browserSave() {
+        TestSelectors.byTestId(page, "project-browser-save-button").click();
+    }
+
+    public void browserLoad() {
+        TestSelectors.byTestId(page, "project-browser-load-button").click();
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/RelationshipManagerComponent.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/RelationshipManagerComponent.java
@@ -1,0 +1,41 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e.components;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+
+public final class RelationshipManagerComponent {
+
+    private final Page page;
+
+    public RelationshipManagerComponent(final Page page) {
+        this.page = page;
+    }
+
+    public Locator root() {
+        return TestSelectors.byTestId(page, "relationship-manager");
+    }
+
+    public Locator connectSelect() {
+        return TestSelectors.byTestId(page, "relationship-connect-select");
+    }
+
+    public void connectExisting(final String id) {
+        connectSelect().selectOption(id);
+        TestSelectors.byTestId(page, "relationship-connect-submit").click();
+    }
+
+    public Locator createField(final String fieldName) {
+        return TestSelectors.byTestId(
+                page, TestSelectors.id("field-input", "relationship-create", fieldName));
+    }
+
+    public void createAndConnect(final String title) {
+        createField("title").fill(title);
+        TestSelectors.byTestId(page, "relationship-create-submit").click();
+    }
+
+    public void removeRow(final String entityName, final String id) {
+        TestSelectors.byTestId(page, TestSelectors.id("relationship-row-remove", entityName, id))
+                .click();
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/SchemaDetailComponent.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/SchemaDetailComponent.java
@@ -1,0 +1,39 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e.components;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+
+public final class SchemaDetailComponent {
+
+    private final Page page;
+
+    public SchemaDetailComponent(final Page page) {
+        this.page = page;
+    }
+
+    public Locator title() {
+        return TestSelectors.byTestId(page, "schema-detail-title");
+    }
+
+    public Locator input(final String label) {
+        return page.locator("[data-testid='" + TestSelectors.id("schema-input", label) + "']")
+                .first();
+    }
+
+    public Locator action(final String label) {
+        return page.locator("[data-testid='" + TestSelectors.id("schema-action", label) + "']")
+                .first();
+    }
+
+    public void fill(final String label, final String value) {
+        input(label).fill(value);
+    }
+
+    public void select(final String label, final String value) {
+        input(label).selectOption(value);
+    }
+
+    public void clickAction(final String label) {
+        action(label).click();
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/SchemaExportsComponent.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/SchemaExportsComponent.java
@@ -1,0 +1,43 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e.components;
+
+import com.microsoft.playwright.Download;
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+
+public final class SchemaExportsComponent {
+
+    private final Page page;
+
+    public SchemaExportsComponent(final Page page) {
+        this.page = page;
+    }
+
+    public Locator root() {
+        return TestSelectors.byTestId(page, "schema-exports-section");
+    }
+
+    public Locator canonicalYaml() {
+        return TestSelectors.byTestId(page, "schema-canonical-yaml");
+    }
+
+    public Locator mermaid() {
+        return TestSelectors.byTestId(page, "schema-mermaid-output");
+    }
+
+    public Locator graphviz() {
+        return TestSelectors.byTestId(page, "schema-graphviz-output");
+    }
+
+    public void toggle() {
+        TestSelectors.byTestId(page, "schema-toggle-exports-button").click();
+    }
+
+    public void copyYaml() {
+        TestSelectors.byTestId(page, "schema-copy-yaml").click();
+    }
+
+    public Download downloadMermaid() {
+        return page.waitForDownload(
+                () -> TestSelectors.byTestId(page, "schema-download-mermaid").click());
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/SchemaTreeComponent.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/SchemaTreeComponent.java
@@ -1,0 +1,46 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e.components;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+
+public final class SchemaTreeComponent {
+
+    private final Page page;
+
+    public SchemaTreeComponent(final Page page) {
+        this.page = page;
+    }
+
+    public Locator root() {
+        return TestSelectors.byTestId(page, "schema-tree");
+    }
+
+    public void addEntity() {
+        TestSelectors.byTestId(page, "schema-add-entity-button").click();
+    }
+
+    public void selectModel() {
+        page.locator("[data-testid^='schema-tree-model']").click();
+    }
+
+    public void selectEntity(final String label) {
+        page.locator("[data-testid^='schema-tree-entity']")
+                .filter(new Locator.FilterOptions().setHasText(label))
+                .first()
+                .click();
+    }
+
+    public void selectField(final String label) {
+        page.locator("[data-testid^='schema-tree-field']")
+                .filter(new Locator.FilterOptions().setHasText(label))
+                .first()
+                .click();
+    }
+
+    public void selectRelationship(final String label) {
+        page.locator("[data-testid^='schema-tree-relationship']")
+                .filter(new Locator.FilterOptions().setHasText(label))
+                .first()
+                .click();
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/SchemaUpgradeDialogComponent.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/SchemaUpgradeDialogComponent.java
@@ -1,0 +1,37 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e.components;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+
+public final class SchemaUpgradeDialogComponent {
+
+    private final Page page;
+
+    public SchemaUpgradeDialogComponent(final Page page) {
+        this.page = page;
+    }
+
+    public Locator root() {
+        return TestSelectors.byTestId(page, "schema-upgrade-dialog");
+    }
+
+    public Locator report() {
+        return TestSelectors.byTestId(page, "schema-upgrade-report");
+    }
+
+    public void open() {
+        TestSelectors.byTestId(page, "schema-apply-workspace-button").click();
+    }
+
+    public void preview() {
+        TestSelectors.byTestId(page, "schema-upgrade-preview-button").click();
+    }
+
+    public void confirm() {
+        TestSelectors.byTestId(page, "schema-upgrade-confirm-button").click();
+    }
+
+    public void cancel() {
+        TestSelectors.byTestId(page, "schema-upgrade-cancel-button").click();
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/StorageControlsComponent.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/StorageControlsComponent.java
@@ -1,0 +1,32 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e.components;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+
+public final class StorageControlsComponent {
+
+    private final Page page;
+
+    public StorageControlsComponent(final Page page) {
+        this.page = page;
+    }
+
+    public Locator modeSelect() {
+        return TestSelectors.byTestId(page, "storage-mode-select");
+    }
+
+    public Locator sqliteFileInput() {
+        return TestSelectors.byTestId(page, "storage-file-input");
+    }
+
+    public void switchTo(final String mode) {
+        modeSelect().selectOption(mode);
+        TestSelectors.byTestId(page, "switch-storage-button").click();
+    }
+
+    public void switchToFile(final String path) {
+        modeSelect().selectOption("sqlite-file");
+        sqliteFileInput().fill(path);
+        TestSelectors.byTestId(page, "switch-storage-button").click();
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/TestSelectors.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/TestSelectors.java
@@ -1,0 +1,25 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e.components;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+
+public final class TestSelectors {
+
+    private TestSelectors() {}
+
+    public static Locator byTestId(final Page page, final String testId) {
+        return page.locator("[data-testid='" + testId + "']");
+    }
+
+    public static String idPart(final String value) {
+        return value.toLowerCase().replaceAll("[^a-z0-9]+", "-").replaceAll("^-+|-+$", "");
+    }
+
+    public static String id(final String prefix, final String... parts) {
+        StringBuilder builder = new StringBuilder(prefix);
+        for (String part : parts) {
+            builder.append('-').append(idPart(part));
+        }
+        return builder.toString();
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/TopBarComponent.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/components/TopBarComponent.java
@@ -1,0 +1,43 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e.components;
+
+import com.microsoft.playwright.Download;
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+
+public final class TopBarComponent {
+
+    private final Page page;
+
+    public TopBarComponent(final Page page) {
+        this.page = page;
+    }
+
+    public Locator title() {
+        return TestSelectors.byTestId(page, "model-title");
+    }
+
+    public Locator description() {
+        return TestSelectors.byTestId(page, "model-description");
+    }
+
+    public void openWorkspace() {
+        TestSelectors.byTestId(page, "schema-workspace-link").click();
+    }
+
+    public void openSchemaEdit() {
+        TestSelectors.byTestId(page, "schema-link").click();
+    }
+
+    public void openApiDocs() {
+        TestSelectors.byTestId(page, "docs-link").click();
+    }
+
+    public void openSwagger() {
+        TestSelectors.byTestId(page, "swagger-link").click();
+    }
+
+    public Download downloadOpenApi() {
+        return page.waitForDownload(
+                () -> TestSelectors.byTestId(page, "download-openapi-link").click());
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/pages/SchemaEditPage.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/pages/SchemaEditPage.java
@@ -1,0 +1,79 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e.pages;
+
+import com.microsoft.playwright.Page;
+import uk.co.compendiumdev.thingifier.crudui.e2e.components.DiagramPanelComponent;
+import uk.co.compendiumdev.thingifier.crudui.e2e.components.MessageBarComponent;
+import uk.co.compendiumdev.thingifier.crudui.e2e.components.SchemaDetailComponent;
+import uk.co.compendiumdev.thingifier.crudui.e2e.components.SchemaExportsComponent;
+import uk.co.compendiumdev.thingifier.crudui.e2e.components.SchemaTreeComponent;
+import uk.co.compendiumdev.thingifier.crudui.e2e.components.SchemaUpgradeDialogComponent;
+import uk.co.compendiumdev.thingifier.crudui.e2e.components.TestSelectors;
+import uk.co.compendiumdev.thingifier.crudui.e2e.components.TopBarComponent;
+
+public final class SchemaEditPage {
+
+    private final Page page;
+    private final String baseUrl;
+    private final TopBarComponent topBar;
+    private final SchemaTreeComponent tree;
+    private final SchemaDetailComponent detail;
+    private final DiagramPanelComponent diagram;
+    private final SchemaExportsComponent exports;
+    private final SchemaUpgradeDialogComponent upgrade;
+    private final MessageBarComponent messages;
+
+    public SchemaEditPage(final Page page, final String baseUrl) {
+        this.page = page;
+        this.baseUrl = baseUrl;
+        this.topBar = new TopBarComponent(page);
+        this.tree = new SchemaTreeComponent(page);
+        this.detail = new SchemaDetailComponent(page);
+        this.diagram = new DiagramPanelComponent(page);
+        this.exports = new SchemaExportsComponent(page);
+        this.upgrade = new SchemaUpgradeDialogComponent(page);
+        this.messages = new MessageBarComponent(page);
+    }
+
+    public SchemaEditPage open() {
+        page.navigate(baseUrl + "/schema");
+        TestSelectors.byTestId(page, "schema-page").waitFor();
+        TestSelectors.byTestId(page, "schema-tree").waitFor();
+        return this;
+    }
+
+    public TopBarComponent topBar() {
+        return topBar;
+    }
+
+    public SchemaTreeComponent tree() {
+        return tree;
+    }
+
+    public SchemaDetailComponent detail() {
+        return detail;
+    }
+
+    public DiagramPanelComponent diagram() {
+        return diagram;
+    }
+
+    public SchemaExportsComponent exports() {
+        return exports;
+    }
+
+    public SchemaUpgradeDialogComponent upgrade() {
+        return upgrade;
+    }
+
+    public MessageBarComponent messages() {
+        return messages;
+    }
+
+    public void toggleYamlDraft() {
+        TestSelectors.byTestId(page, "schema-toggle-yaml-button").click();
+    }
+
+    public void validate() {
+        TestSelectors.byTestId(page, "schema-validate-button").click();
+    }
+}

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/pages/WorkspacePage.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/pages/WorkspacePage.java
@@ -1,0 +1,78 @@
+package uk.co.compendiumdev.thingifier.crudui.e2e.pages;
+
+import com.microsoft.playwright.Page;
+import uk.co.compendiumdev.thingifier.crudui.e2e.components.DataGridComponent;
+import uk.co.compendiumdev.thingifier.crudui.e2e.components.EditorPanelComponent;
+import uk.co.compendiumdev.thingifier.crudui.e2e.components.MessageBarComponent;
+import uk.co.compendiumdev.thingifier.crudui.e2e.components.OutlineTreeComponent;
+import uk.co.compendiumdev.thingifier.crudui.e2e.components.ProjectDialogComponent;
+import uk.co.compendiumdev.thingifier.crudui.e2e.components.RelationshipManagerComponent;
+import uk.co.compendiumdev.thingifier.crudui.e2e.components.StorageControlsComponent;
+import uk.co.compendiumdev.thingifier.crudui.e2e.components.TestSelectors;
+import uk.co.compendiumdev.thingifier.crudui.e2e.components.TopBarComponent;
+
+public final class WorkspacePage {
+
+    private final Page page;
+    private final String baseUrl;
+    private final TopBarComponent topBar;
+    private final OutlineTreeComponent outline;
+    private final DataGridComponent grid;
+    private final EditorPanelComponent editor;
+    private final RelationshipManagerComponent relationships;
+    private final ProjectDialogComponent projectDialog;
+    private final StorageControlsComponent storage;
+    private final MessageBarComponent messages;
+
+    public WorkspacePage(final Page page, final String baseUrl) {
+        this.page = page;
+        this.baseUrl = baseUrl;
+        this.topBar = new TopBarComponent(page);
+        this.outline = new OutlineTreeComponent(page);
+        this.grid = new DataGridComponent(page);
+        this.editor = new EditorPanelComponent(page);
+        this.relationships = new RelationshipManagerComponent(page);
+        this.projectDialog = new ProjectDialogComponent(page);
+        this.storage = new StorageControlsComponent(page);
+        this.messages = new MessageBarComponent(page);
+    }
+
+    public WorkspacePage open() {
+        page.navigate(baseUrl + "/");
+        TestSelectors.byTestId(page, "workspace-page").waitFor();
+        TestSelectors.byTestId(page, "outline-tree").waitFor();
+        return this;
+    }
+
+    public TopBarComponent topBar() {
+        return topBar;
+    }
+
+    public OutlineTreeComponent outline() {
+        return outline;
+    }
+
+    public DataGridComponent grid() {
+        return grid;
+    }
+
+    public EditorPanelComponent editor() {
+        return editor;
+    }
+
+    public RelationshipManagerComponent relationships() {
+        return relationships;
+    }
+
+    public ProjectDialogComponent projectDialog() {
+        return projectDialog;
+    }
+
+    public StorageControlsComponent storage() {
+        return storage;
+    }
+
+    public MessageBarComponent messages() {
+        return messages;
+    }
+}

--- a/thingifier-crud-ui/src/test/resources/models/todo-manager.yaml
+++ b/thingifier-crud-ui/src/test/resources/models/todo-manager.yaml
@@ -1,0 +1,83 @@
+formatVersion: 1
+model:
+  title: Todo Manager
+  description: A Simple todo manager with categories and projects.
+entities:
+  todo:
+    plural: todos
+    maxInstances: -1
+    primaryKey: id
+    fields:
+      id:
+        type: auto-increment
+      title:
+        type: string
+        required: true
+        validations:
+          - notEmpty
+      doneStatus:
+        type: boolean
+        default: "false"
+      description:
+        type: string
+  project:
+    plural: projects
+    maxInstances: -1
+    primaryKey: id
+    fields:
+      id:
+        type: auto-increment
+      title:
+        type: string
+      completed:
+        type: boolean
+        default: "false"
+      active:
+        type: boolean
+        default: "false"
+      description:
+        type: string
+  category:
+    plural: categories
+    maxInstances: -1
+    primaryKey: id
+    fields:
+      id:
+        type: auto-increment
+      title:
+        type: string
+        required: true
+        validations:
+          - notEmpty
+      description:
+        type: string
+relationships:
+  - from: project
+    name: tasks
+    to: todo
+    cardinality: one-to-many
+    optionality: optional
+    reverse:
+      name: tasksof
+      cardinality: one-to-many
+      optionality: optional
+  - from: project
+    name: categories
+    to: category
+    cardinality: one-to-many
+    optionality: optional
+  - from: category
+    name: todos
+    to: todo
+    cardinality: one-to-many
+    optionality: optional
+  - from: category
+    name: projects
+    to: project
+    cardinality: one-to-many
+    optionality: optional
+  - from: todo
+    name: categories
+    to: category
+    cardinality: one-to-many
+    optionality: optional

--- a/thingifier-yaml/src/main/java/uk/co/compendiumdev/thingifier/yaml/ThingifierProjectManifest.java
+++ b/thingifier-yaml/src/main/java/uk/co/compendiumdev/thingifier/yaml/ThingifierProjectManifest.java
@@ -8,12 +8,18 @@ public final class ThingifierProjectManifest {
     public static final String DEFAULT_MANIFEST_FILE = "projectfile.erproj";
     public static final String DEFAULT_SCHEMA_FILE = "schema.yaml";
     public static final String DEFAULT_DATA_FILE = "data.json";
+    public static final String DEFAULT_SQLITE_FILE = "data.sqlite";
+    public static final String STORAGE_MEMORY = "memory";
+    public static final String STORAGE_SQLITE_MEMORY = "sqlite-memory";
+    public static final String STORAGE_SQLITE_FILE = "sqlite-file";
 
     private final int formatVersion;
     private final String title;
     private final String description;
     private final String schemaFile;
     private final String dataFile;
+    private final String storageMode;
+    private final String sqliteFile;
 
     public ThingifierProjectManifest(
             final int formatVersion,
@@ -21,11 +27,30 @@ public final class ThingifierProjectManifest {
             final String description,
             final String schemaFile,
             final String dataFile) {
+        this(formatVersion, title, description, schemaFile, dataFile, STORAGE_MEMORY, "");
+    }
+
+    public ThingifierProjectManifest(
+            final int formatVersion,
+            final String title,
+            final String description,
+            final String schemaFile,
+            final String dataFile,
+            final String storageMode,
+            final String sqliteFile) {
         this.formatVersion = formatVersion;
         this.title = nullToEmpty(title);
         this.description = nullToEmpty(description);
         this.schemaFile = validatedRelativeFile(schemaFile, "schemaFile");
-        this.dataFile = validatedRelativeFile(dataFile, "dataFile");
+        this.storageMode = resolvedStorageMode(storageMode, dataFile);
+        if (isSqliteFileStorage()) {
+            String sqliteDataFile = firstPresent(sqliteFile, dataFile);
+            this.sqliteFile = validatedRelativeFile(sqliteDataFile, "storage.sqliteFile");
+            this.dataFile = optionalRelativeFile(dataFile, "dataFile");
+        } else {
+            this.sqliteFile = "";
+            this.dataFile = validatedRelativeFile(dataFile, "dataFile");
+        }
         if (formatVersion != SUPPORTED_FORMAT_VERSION) {
             throw new ThingifierYamlException("Unsupported project formatVersion " + formatVersion);
         }
@@ -39,6 +64,23 @@ public final class ThingifierProjectManifest {
                 description,
                 DEFAULT_SCHEMA_FILE,
                 DEFAULT_DATA_FILE);
+    }
+
+    public static ThingifierProjectManifest sqliteFileBackedFor(
+            final String title, final String description) {
+        return sqliteFileBackedFor(title, description, DEFAULT_SQLITE_FILE);
+    }
+
+    public static ThingifierProjectManifest sqliteFileBackedFor(
+            final String title, final String description, final String sqliteFile) {
+        return new ThingifierProjectManifest(
+                SUPPORTED_FORMAT_VERSION,
+                title,
+                description,
+                DEFAULT_SCHEMA_FILE,
+                sqliteFile,
+                STORAGE_SQLITE_FILE,
+                sqliteFile);
     }
 
     public int formatVersion() {
@@ -59,6 +101,23 @@ public final class ThingifierProjectManifest {
 
     public String dataFile() {
         return dataFile;
+    }
+
+    public String storageMode() {
+        return storageMode;
+    }
+
+    public String sqliteFile() {
+        return sqliteFile;
+    }
+
+    public boolean isSqliteFileStorage() {
+        return STORAGE_SQLITE_FILE.equals(storageMode);
+    }
+
+    public boolean hasStorageBlockEquivalent() {
+        return !STORAGE_MEMORY.equals(storageMode)
+                && !(isSqliteFileStorage() && sqliteFile.equals(dataFile));
     }
 
     private String validatedRelativeFile(final String value, final String fieldName) {
@@ -83,6 +142,51 @@ public final class ThingifierProjectManifest {
             throw new ThingifierYamlException(fieldName + " must stay inside the project folder");
         }
         return normalized;
+    }
+
+    private String optionalRelativeFile(final String value, final String fieldName) {
+        String text = nullToEmpty(value).trim();
+        if (text.isEmpty()) {
+            return "";
+        }
+        return validatedRelativeFile(text, fieldName);
+    }
+
+    private String validatedStorageMode(final String value) {
+        String text = nullToEmpty(value).trim();
+        if (text.isEmpty()) {
+            return STORAGE_MEMORY;
+        }
+        String normalized = text.toLowerCase().replace("_", "-");
+        if (STORAGE_MEMORY.equals(normalized)
+                || STORAGE_SQLITE_MEMORY.equals(normalized)
+                || STORAGE_SQLITE_FILE.equals(normalized)) {
+            return normalized;
+        }
+        throw new ThingifierYamlException("Unsupported project storage mode " + value);
+    }
+
+    private String resolvedStorageMode(final String storageMode, final String dataFile) {
+        String validated = validatedStorageMode(storageMode);
+        if (STORAGE_MEMORY.equals(validated) && looksLikeSqliteFile(dataFile)) {
+            return STORAGE_SQLITE_FILE;
+        }
+        return validated;
+    }
+
+    private boolean looksLikeSqliteFile(final String fileName) {
+        String normalized = nullToEmpty(fileName).trim().toLowerCase();
+        return normalized.endsWith(".sqlite")
+                || normalized.endsWith(".sqlite3")
+                || normalized.endsWith(".db");
+    }
+
+    private String firstPresent(final String first, final String second) {
+        String firstText = nullToEmpty(first).trim();
+        if (!firstText.isEmpty()) {
+            return firstText;
+        }
+        return nullToEmpty(second).trim();
     }
 
     private String nullToEmpty(final String value) {

--- a/thingifier-yaml/src/main/java/uk/co/compendiumdev/thingifier/yaml/ThingifierProjectManifestYaml.java
+++ b/thingifier-yaml/src/main/java/uk/co/compendiumdev/thingifier/yaml/ThingifierProjectManifestYaml.java
@@ -44,7 +44,17 @@ public final class ThingifierProjectManifestYaml {
         project.put("description", manifest.description());
         root.put("project", project);
         root.put("schemaFile", manifest.schemaFile());
-        root.put("dataFile", manifest.dataFile());
+        if (!manifest.dataFile().isEmpty()) {
+            root.put("dataFile", manifest.dataFile());
+        }
+        if (manifest.hasStorageBlockEquivalent()) {
+            Map<String, Object> storage = new LinkedHashMap<>();
+            storage.put("mode", manifest.storageMode());
+            if (manifest.isSqliteFileStorage()) {
+                storage.put("sqliteFile", manifest.sqliteFile());
+            }
+            root.put("storage", storage);
+        }
         return dumper().dump(root);
     }
 
@@ -54,12 +64,15 @@ public final class ThingifierProjectManifestYaml {
         }
         Map<?, ?> root = (Map<?, ?>) parsed;
         Map<?, ?> project = mapValue(root.get("project"));
+        Map<?, ?> storage = mapValue(root.get("storage"));
         return new ThingifierProjectManifest(
                 intValue(root.get("formatVersion")),
                 stringValue(project.get("title")),
                 stringValue(project.get("description")),
                 stringValue(root.get("schemaFile")),
-                stringValue(root.get("dataFile")));
+                stringValue(root.get("dataFile")),
+                stringValue(storage.get("mode")),
+                stringValue(storage.get("sqliteFile")));
     }
 
     private int intValue(final Object value) {

--- a/thingifier-yaml/src/main/java/uk/co/compendiumdev/thingifier/yaml/ThingifierYamlLoader.java
+++ b/thingifier-yaml/src/main/java/uk/co/compendiumdev/thingifier/yaml/ThingifierYamlLoader.java
@@ -12,6 +12,7 @@ import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.application.schema.definition.SchemaDefinitionValidationReport;
 import uk.co.compendiumdev.thingifier.application.schema.definition.ThingifierModelAssembler;
 import uk.co.compendiumdev.thingifier.application.schema.definition.ThingifierModelDefinition;
+import uk.co.compendiumdev.thingifier.core.repository.ThingStoreProvider;
 import uk.co.compendiumdev.thingifier.yaml.internal.YamlThingifierDocument;
 import uk.co.compendiumdev.thingifier.yaml.internal.YamlThingifierDocumentMapper;
 
@@ -43,20 +44,40 @@ public final class ThingifierYamlLoader {
         return assemble(loadDefinition(path));
     }
 
+    public Thingifier loadThingifier(final Path path, final ThingStoreProvider storeProvider)
+            throws IOException {
+        return assemble(loadDefinition(path), storeProvider);
+    }
+
     public Thingifier loadThingifier(final InputStream input) {
         return assemble(loadDefinition(input));
+    }
+
+    public Thingifier loadThingifier(
+            final InputStream input, final ThingStoreProvider storeProvider) {
+        return assemble(loadDefinition(input), storeProvider);
     }
 
     public Thingifier loadThingifier(final String yamlText) {
         return assemble(loadDefinition(yamlText));
     }
 
+    public Thingifier loadThingifier(
+            final String yamlText, final ThingStoreProvider storeProvider) {
+        return assemble(loadDefinition(yamlText), storeProvider);
+    }
+
     private Thingifier assemble(final ThingifierModelDefinition definition) {
+        return assemble(definition, null);
+    }
+
+    private Thingifier assemble(
+            final ThingifierModelDefinition definition, final ThingStoreProvider storeProvider) {
         final SchemaDefinitionValidationReport report = assembler.validate(definition);
         if (!report.isValid()) {
             throw new ThingifierYamlException(report.combinedMessages());
         }
-        return assembler.assemble(definition);
+        return assembler.assemble(definition, storeProvider);
     }
 
     private YamlThingifierDocument loadDocument(final InputStream input) {

--- a/thingifier-yaml/src/test/java/uk/co/compendiumdev/thingifier/yaml/ThingifierProjectManifestYamlTest.java
+++ b/thingifier-yaml/src/test/java/uk/co/compendiumdev/thingifier/yaml/ThingifierProjectManifestYamlTest.java
@@ -34,6 +34,61 @@ class ThingifierProjectManifestYamlTest {
     }
 
     @Test
+    void sqliteFileBackedManifestRoundTripsThroughYamlWithDataFile() {
+        ThingifierProjectManifest manifest =
+                ThingifierProjectManifest.sqliteFileBackedFor(
+                        "SQLite Project", "Project data lives in a DB file");
+        ThingifierProjectManifestYaml yaml = new ThingifierProjectManifestYaml();
+
+        String text = yaml.export(manifest);
+        ThingifierProjectManifest loaded = yaml.load(text);
+
+        Assertions.assertTrue(text.contains("dataFile: data.sqlite"));
+        Assertions.assertFalse(text.contains("storage:"));
+        Assertions.assertEquals("sqlite-file", loaded.storageMode());
+        Assertions.assertEquals("data.sqlite", loaded.sqliteFile());
+        Assertions.assertEquals("data.sqlite", loaded.dataFile());
+    }
+
+    @Test
+    void sqliteDataFileWithoutStorageBlockIsDetectedAsSqliteFileStorage() {
+        ThingifierProjectManifest loaded =
+                new ThingifierProjectManifestYaml()
+                        .load(
+                                "formatVersion: 1\n"
+                                        + "schemaFile: schema.yaml\n"
+                                        + "dataFile: todomanager.sqlite\n");
+
+        Assertions.assertEquals("sqlite-file", loaded.storageMode());
+        Assertions.assertEquals("todomanager.sqlite", loaded.sqliteFile());
+        Assertions.assertEquals("todomanager.sqlite", loaded.dataFile());
+    }
+
+    @Test
+    void sqliteFileBackedManifestRejectsEscapingSqliteFile() {
+        ThingifierProjectManifestYaml yaml = new ThingifierProjectManifestYaml();
+
+        Assertions.assertThrows(
+                ThingifierYamlException.class,
+                () ->
+                        yaml.load(
+                                "formatVersion: 1\n"
+                                        + "schemaFile: schema.yaml\n"
+                                        + "storage:\n"
+                                        + "  mode: sqlite-file\n"
+                                        + "  sqliteFile: ../data.sqlite\n"));
+        Assertions.assertThrows(
+                ThingifierYamlException.class,
+                () ->
+                        yaml.load(
+                                "formatVersion: 1\n"
+                                        + "schemaFile: schema.yaml\n"
+                                        + "storage:\n"
+                                        + "  mode: sqlite-file\n"
+                                        + "  sqliteFile: C:\\\\data.sqlite\n"));
+    }
+
+    @Test
     void absoluteAndEscapingPathsAreRejected() {
         ThingifierProjectManifestYaml yaml = new ThingifierProjectManifestYaml();
 

--- a/thingifier-yaml/src/test/java/uk/co/compendiumdev/thingifier/yaml/ThingifierYamlLoaderTest.java
+++ b/thingifier-yaml/src/test/java/uk/co/compendiumdev/thingifier/yaml/ThingifierYamlLoaderTest.java
@@ -20,8 +20,10 @@ import uk.co.compendiumdev.thingifier.application.examples.TodoManagerThingifier
 import uk.co.compendiumdev.thingifier.application.schema.definition.SchemaDefinitionValidationReport;
 import uk.co.compendiumdev.thingifier.application.schema.definition.ThingifierModelAssembler;
 import uk.co.compendiumdev.thingifier.application.schema.definition.ThingifierModelDefinition;
+import uk.co.compendiumdev.thingifier.core.EntityRelModel;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
+import uk.co.compendiumdev.thingifier.core.repository.sqlite.SqliteThingStoreProvider;
 
 class ThingifierYamlLoaderTest {
 
@@ -57,6 +59,18 @@ class ThingifierYamlLoaderTest {
         Assertions.assertNotNull(thingifier.getDefinitionNamed("todo"));
         Assertions.assertEquals(
                 "id", thingifier.getDefinitionNamed("todo").getPrimaryKeyField().getName());
+    }
+
+    @Test
+    void loaderBuildsThingifierWithSuppliedStoreProvider() {
+        try (SqliteThingStoreProvider provider = SqliteThingStoreProvider.inMemory()) {
+            Thingifier thingifier =
+                    new ThingifierYamlLoader()
+                            .loadThingifier(resource("minimal-todo.yaml"), provider);
+
+            Assertions.assertNotNull(thingifier.getStore(EntityRelModel.DEFAULT_DATABASE_NAME));
+            Assertions.assertNotNull(thingifier.getDefinitionNamed("todo"));
+        }
     }
 
     @Test

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/schema/definition/ThingifierModelAssembler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/schema/definition/ThingifierModelAssembler.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.core.EntityRelModel;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.Cardinality;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.Field;
@@ -14,6 +15,7 @@ import uk.co.compendiumdev.thingifier.core.domain.definitions.relationship.Optio
 import uk.co.compendiumdev.thingifier.core.domain.definitions.relationship.RelationshipDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.relationship.RelationshipVectorDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.validation.VRule;
+import uk.co.compendiumdev.thingifier.core.repository.ThingStoreProvider;
 
 public final class ThingifierModelAssembler {
 
@@ -33,12 +35,20 @@ public final class ThingifierModelAssembler {
     }
 
     public Thingifier assemble(final ThingifierModelDefinition definition) {
+        return assemble(definition, null);
+    }
+
+    public Thingifier assemble(
+            final ThingifierModelDefinition definition, final ThingStoreProvider storeProvider) {
         final SchemaDefinitionValidationReport report = validate(definition);
         if (!report.isValid()) {
             throw new IllegalArgumentException(report.combinedMessages());
         }
 
-        final Thingifier thingifier = new Thingifier();
+        final Thingifier thingifier =
+                storeProvider == null
+                        ? new Thingifier()
+                        : new Thingifier(new EntityRelModel(storeProvider));
         thingifier.setDocumentation(
                 emptyIfNull(definition.title()), emptyIfNull(definition.description()));
 


### PR DESCRIPTION
## Summary

Adds file-backed SQLite storage support for CRUD UI projects and rounds out the project save/load workflow.

## What Changed

- Added direct single-file SQLite store provider support and config parsing.
- Added storage-aware model assembly/YAML loading so CRUD UI workspaces can run in memory, SQLite memory, or SQLite file mode.
- Extended project manifests so `dataFile` can point to JSON or SQLite, with SQLite autodetection for human-edited manifests.
- Updated CRUD UI project save/load so JSON projects save `data.json` and SQLite projects save `data.sqlite`.
- Added storage switch controls, project browse/check/load-files/export-files endpoints, and browser/native project folder flows.
- Fixed related CRUD UI behavior discovered during smoke testing, including boolean field payloads, browser folder field feedback, server-side browse focus, and textarea rendering for unconstrained strings.
- Added Playwright/JUnit browser automation with page/component objects for workspace, project, storage, schema, relationship, and API flows.

## Validation

- `node --check thingifier-crud-ui\src\main\resources\public\assets\app.js`
- `mvn -pl thingifier-crud-ui -am verify`

Closes #52