### PR TITLE
Honor proxy headers for Swagger server origin

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/httpserver/HttpRequestOrigin.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/httpserver/HttpRequestOrigin.java
@@ -1,0 +1,74 @@
+package uk.co.compendiumdev.thingifier.adapter.httpserver;
+
+final class HttpRequestOrigin {
+
+    private HttpRequestOrigin() {}
+
+    static String from(final HttpServerRequest request) {
+        return "%s://%s".formatted(schemeFrom(request), hostFrom(request));
+    }
+
+    private static String schemeFrom(final HttpServerRequest request) {
+        final String forwardedProto = forwardedHeaderValue(request.header("Forwarded"), "proto");
+        if (hasText(forwardedProto)) {
+            return forwardedProto;
+        }
+
+        final String proxyProto = firstHeaderValue(request.header("X-Forwarded-Proto"));
+        if (hasText(proxyProto)) {
+            return proxyProto;
+        }
+
+        return request.scheme();
+    }
+
+    private static String hostFrom(final HttpServerRequest request) {
+        final String forwardedHost = forwardedHeaderValue(request.header("Forwarded"), "host");
+        if (hasText(forwardedHost)) {
+            return forwardedHost;
+        }
+
+        final String proxyHost = firstHeaderValue(request.header("X-Forwarded-Host"));
+        if (hasText(proxyHost)) {
+            return proxyHost;
+        }
+
+        return request.host();
+    }
+
+    private static String forwardedHeaderValue(final String header, final String key) {
+        final String firstValue = firstHeaderValue(header);
+        if (!hasText(firstValue)) {
+            return "";
+        }
+
+        final String prefix = "%s=".formatted(key);
+        final String[] parts = firstValue.split(";");
+        for (final String part : parts) {
+            final String trimmed = part.trim();
+            if (trimmed.toLowerCase().startsWith(prefix)) {
+                return unquote(trimmed.substring(prefix.length()).trim());
+            }
+        }
+
+        return "";
+    }
+
+    private static String firstHeaderValue(final String header) {
+        if (!hasText(header)) {
+            return "";
+        }
+        return header.split(",", 2)[0].trim();
+    }
+
+    private static String unquote(final String value) {
+        if (value.length() >= 2 && value.startsWith("\"") && value.endsWith("\"")) {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
+    }
+
+    private static boolean hasText(final String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/httpserver/ThingifierAutoDocGenRouting.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/httpserver/ThingifierAutoDocGenRouting.java
@@ -52,7 +52,7 @@ public class ThingifierAutoDocGenRouting {
                     response.type("application/json");
                     response.status(200);
                     return new Swaggerizer(apiDefn)
-                            .asJsonWithPreferredServer(requestOrigin(request));
+                            .asJsonWithPreferredServer(HttpRequestOrigin.from(request));
                 });
 
         get(
@@ -99,11 +99,8 @@ public class ThingifierAutoDocGenRouting {
                     // TODO: the swaggerizer could be stored at a class level and allow caching to
                     // be used for the output
                     return new Swaggerizer(apiDefn)
-                            .asJsonWithPreferredServer(permissive != null, requestOrigin(request));
+                            .asJsonWithPreferredServer(
+                                    permissive != null, HttpRequestOrigin.from(request));
                 });
-    }
-
-    private String requestOrigin(final HttpServerRequest request) {
-        return "%s://%s".formatted(request.scheme(), request.host());
     }
 }

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/adapter/httpserver/HttpRequestOriginTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/adapter/httpserver/HttpRequestOriginTest.java
@@ -1,0 +1,87 @@
+package uk.co.compendiumdev.thingifier.adapter.httpserver;
+
+import java.lang.reflect.Proxy;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class HttpRequestOriginTest {
+
+    @Test
+    void usesDirectRequestOriginWhenProxyHeadersAreAbsent() {
+        final HttpServerRequest request = request("http", "localhost:4567");
+
+        Assertions.assertEquals("http://localhost:4567", HttpRequestOrigin.from(request));
+    }
+
+    @Test
+    void usesForwardedProtoAndHostWhenPresent() {
+        final HttpServerRequest request =
+                request(
+                        "http",
+                        "internal:4567",
+                        "X-Forwarded-Proto",
+                        "https",
+                        "X-Forwarded-Host",
+                        "apichallenges.eviltester.com");
+
+        Assertions.assertEquals(
+                "https://apichallenges.eviltester.com", HttpRequestOrigin.from(request));
+    }
+
+    @Test
+    void usesStandardForwardedHeaderWhenPresent() {
+        final HttpServerRequest request =
+                request(
+                        "http",
+                        "internal:4567",
+                        "Forwarded",
+                        "for=192.0.2.60;proto=https;host=\"apichallenges.eviltester.com\"");
+
+        Assertions.assertEquals(
+                "https://apichallenges.eviltester.com", HttpRequestOrigin.from(request));
+    }
+
+    private HttpServerRequest request(final String scheme, final String host) {
+        return request(scheme, host, "", "");
+    }
+
+    private HttpServerRequest request(
+            final String scheme,
+            final String host,
+            final String firstHeaderName,
+            final String firstHeaderValue) {
+        return request(scheme, host, firstHeaderName, firstHeaderValue, "", "");
+    }
+
+    private HttpServerRequest request(
+            final String scheme,
+            final String host,
+            final String firstHeaderName,
+            final String firstHeaderValue,
+            final String secondHeaderName,
+            final String secondHeaderValue) {
+        return (HttpServerRequest)
+                Proxy.newProxyInstance(
+                        getClass().getClassLoader(),
+                        new Class<?>[] {HttpServerRequest.class},
+                        (proxy, method, args) -> {
+                            if ("scheme".equals(method.getName())) {
+                                return scheme;
+                            }
+                            if ("host".equals(method.getName())) {
+                                return host;
+                            }
+                            if ("header".equals(method.getName())) {
+                                final String requestedHeader = (String) args[0];
+                                if (requestedHeader.equals(firstHeaderName)) {
+                                    return firstHeaderValue;
+                                }
+                                if (requestedHeader.equals(secondHeaderName)) {
+                                    return secondHeaderValue;
+                                }
+                                return null;
+                            }
+                            throw new UnsupportedOperationException(method.getName());
+                        });
+    }
+}


### PR DESCRIPTION
## Summary
- prefer Forwarded / X-Forwarded-Proto / X-Forwarded-Host when generating OpenAPI server origin
- keep localhost as the preferred server when running locally without proxy headers
- add tests for local and proxy/TLS production origin handling

## Why
API Challenges production Swagger UI was generating http://apichallenges.eviltester.com as the request server while the UI is served over HTTPS, causing browser fetch/CORS failures. The production proxy supplies forwarded headers, so generated OpenAPI docs should use those before falling back to the direct Javalin request scheme/host.

## Verification
- mvn -pl thingifier '-Dtest=uk.co.compendiumdev.thingifier.adapter.httpserver.HttpRequestOriginTest' test
- mvn -pl thingifier -DskipTests checkstyle:check@project-fqn-check
- mvn -pl challenger '-Dtest=uk.co.compendiumdev.uirouting.UiPagesAreReachableTest#canFetchDefaultOpenApiJsonForSwaggerUi' test (from apichallenges, using locally installed Thingifier snapshot)