### PR TITLE
Prefer configured HTTPS Swagger server for same host

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/Swaggerizer.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/Swaggerizer.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import uk.co.compendiumdev.thingifier.Thingifier;
@@ -541,7 +542,8 @@ public class Swaggerizer {
             return;
         }
 
-        final String preferredUrl = preferredServerUrl.trim();
+        final String preferredUrl =
+                configuredHttpsUrlForSameHost(preferredServerUrl.trim(), api.getServers());
         final List<Server> existingServers = api.getServers();
         final List<Server> reorderedServers = new ArrayList<>();
         Server preferredServer = null;
@@ -561,6 +563,73 @@ public class Swaggerizer {
         }
         reorderedServers.add(0, preferredServer);
         api.setServers(reorderedServers);
+    }
+
+    private String configuredHttpsUrlForSameHost(
+            final String preferredUrl, final List<Server> configuredServers) {
+        final URI preferredUri = uriFrom(preferredUrl);
+        if (preferredUri == null || !"http".equalsIgnoreCase(preferredUri.getScheme())) {
+            return preferredUrl;
+        }
+
+        if (configuredServers == null) {
+            return preferredUrl;
+        }
+
+        for (Server server : configuredServers) {
+            if (server.getUrl() == null) {
+                continue;
+            }
+
+            final String configuredUrl = server.getUrl().trim();
+            final URI configuredUri = uriFrom(configuredUrl);
+            if (configuredUri == null || !"https".equalsIgnoreCase(configuredUri.getScheme())) {
+                continue;
+            }
+
+            if (sameHostAndPort(preferredUri, configuredUri)) {
+                return configuredUrl;
+            }
+        }
+
+        return preferredUrl;
+    }
+
+    private boolean sameHostAndPort(final URI preferredUri, final URI configuredUri) {
+        if (!sameHost(preferredUri, configuredUri)) {
+            return false;
+        }
+        if (preferredUri.getPort() == -1 && configuredUri.getPort() == -1) {
+            return true;
+        }
+        return effectivePort(preferredUri) == effectivePort(configuredUri);
+    }
+
+    private boolean sameHost(final URI preferredUri, final URI configuredUri) {
+        return preferredUri.getHost() != null
+                && configuredUri.getHost() != null
+                && preferredUri.getHost().equalsIgnoreCase(configuredUri.getHost());
+    }
+
+    private int effectivePort(final URI uri) {
+        if (uri.getPort() != -1) {
+            return uri.getPort();
+        }
+        if ("https".equalsIgnoreCase(uri.getScheme())) {
+            return 443;
+        }
+        if ("http".equalsIgnoreCase(uri.getScheme())) {
+            return 80;
+        }
+        return -1;
+    }
+
+    private URI uriFrom(final String url) {
+        try {
+            return URI.create(url);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 
     private boolean sameServerUrl(final String preferredUrl, final String configuredUrl) {

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerServerPreferenceTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerServerPreferenceTest.java
@@ -1,0 +1,39 @@
+package uk.co.compendiumdev.thingifier.swaggerizer;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import uk.co.compendiumdev.thingifier.api.docgen.ThingifierApiDocumentationDefn;
+
+class SwaggerizerServerPreferenceTest {
+
+    @Test
+    void keepsLocalhostFirstWhenCurrentRequestIsLocalhost() {
+        final String json =
+                new Swaggerizer(apiDefn()).asJsonWithPreferredServer("http://localhost:4567");
+
+        Assertions.assertTrue(
+                json.indexOf("\"url\" : \"http://localhost:4567\"")
+                        < json.indexOf("\"url\" : \"https://apichallenges.eviltester.com\""));
+        Assertions.assertFalse(json.contains("\"description\" : \"current request\""));
+    }
+
+    @Test
+    void prefersConfiguredHttpsServerForSameHostWhenCurrentRequestIsHttp() {
+        final String json =
+                new Swaggerizer(apiDefn())
+                        .asJsonWithPreferredServer("http://apichallenges.eviltester.com");
+
+        Assertions.assertTrue(
+                json.indexOf("\"url\" : \"https://apichallenges.eviltester.com\"")
+                        < json.indexOf("\"url\" : \"http://localhost:4567\""));
+        Assertions.assertFalse(json.contains("\"url\" : \"http://apichallenges.eviltester.com\""));
+        Assertions.assertFalse(json.contains("\"description\" : \"current request\""));
+    }
+
+    private ThingifierApiDocumentationDefn apiDefn() {
+        final ThingifierApiDocumentationDefn apiDefn = new ThingifierApiDocumentationDefn();
+        apiDefn.addServer("https://apichallenges.eviltester.com", "cloud hosted version");
+        apiDefn.addServer("http://localhost:4567", "local execution");
+        return apiDefn;
+    }
+}


### PR DESCRIPTION
## Summary
- when Swagger generation is asked to prefer an http current request, reuse a configured https server for the same host instead of adding an http current-request server
- keep localhost first for local development
- add server ordering regression tests for localhost and production host behavior

## Why
Production API Challenges is served over HTTPS, but its reverse proxy can leave the app seeing http://apichallenges.eviltester.com as the request origin. The API definition already declares https://apichallenges.eviltester.com, so Swagger should prefer that configured secure server and avoid generating a browser-breaking HTTP server URL.

## Verification
- mvn -pl thingifier '-Dtest=uk.co.compendiumdev.thingifier.swaggerizer.SwaggerizerServerPreferenceTest,uk.co.compendiumdev.thingifier.adapter.httpserver.HttpRequestOriginTest' test
- mvn -pl thingifier -DskipTests install
- mvn -pl challenger '-Dtest=uk.co.compendiumdev.uirouting.UiPagesAreReachableTest#canFetchDefaultOpenApiJsonForSwaggerUi+canFetchOpenApiJsonForSwaggerUiBehindHttpsProxy' test (from apichallenges, using locally installed Thingifier snapshot)