### PR TITLE
Do not add current request Swagger server

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/Swaggerizer.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/Swaggerizer.java
@@ -559,7 +559,7 @@ public class Swaggerizer {
         }
 
         if (preferredServer == null) {
-            preferredServer = new Server().description("current request").url(preferredUrl);
+            return;
         }
         reorderedServers.add(0, preferredServer);
         api.setServers(reorderedServers);

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerServerPreferenceTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerServerPreferenceTest.java
@@ -30,6 +30,18 @@ class SwaggerizerServerPreferenceTest {
         Assertions.assertFalse(json.contains("\"description\" : \"current request\""));
     }
 
+    @Test
+    void doesNotAddCurrentRequestServerWhenCurrentRequestIsNotConfigured() {
+        final String json =
+                new Swaggerizer(apiDefn()).asJsonWithPreferredServer("http://internal:4567");
+
+        Assertions.assertTrue(
+                json.indexOf("\"url\" : \"https://apichallenges.eviltester.com\"")
+                        < json.indexOf("\"url\" : \"http://localhost:4567\""));
+        Assertions.assertFalse(json.contains("\"url\" : \"http://internal:4567\""));
+        Assertions.assertFalse(json.contains("\"description\" : \"current request\""));
+    }
+
     private ThingifierApiDocumentationDefn apiDefn() {
         final ThingifierApiDocumentationDefn apiDefn = new ThingifierApiDocumentationDefn();
         apiDefn.addServer("https://apichallenges.eviltester.com", "cloud hosted version");


### PR DESCRIPTION
## Summary
- stop Swagger generation from inventing a synthetic current request server when the request origin is not configured
- keep reordering configured servers when the request matches localhost or the configured HTTPS production host
- add a regression proving unknown origins are not added to OpenAPI servers

## Why
Production API Challenges can expose a backend request origin of http://apichallenges.eviltester.com. Swagger UI then defaulted to the generated current request server and made browser calls to HTTP from the HTTPS page. The API definition already declares the intended servers, so generated docs should only use configured servers.

## Verification
- mvn -pl thingifier '-Dtest=uk.co.compendiumdev.thingifier.swaggerizer.SwaggerizerServerPreferenceTest,uk.co.compendiumdev.thingifier.adapter.httpserver.HttpRequestOriginTest' test
- mvn -pl thingifier -DskipTests install
- mvn -pl thingifier -DskipTests checkstyle:check@project-fqn-check
- mvn -pl challenger '-Dtest=uk.co.compendiumdev.uirouting.UiPagesAreReachableTest#canFetchDefaultOpenApiJsonForSwaggerUi+canFetchOpenApiJsonForSwaggerUiBehindHttpsProxy' test (from apichallenges, using locally installed Thingifier snapshot)