### PR TITLE
Allow API docs to hide Swagger UI link

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/ThingifierApiDocumentationDefn.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/ThingifierApiDocumentationDefn.java
@@ -28,6 +28,7 @@ public class ThingifierApiDocumentationDefn {
     private String ogType = "";
     private String twitterCard = "";
     private String twitterSite = "";
+    private boolean showSwaggerUiLink = true;
     private Map<String, HeaderMatch> customHeadersForRoutesThatDoNotMatch;
 
     // todo: convert internal documentation to use a ThingifierApiDefn rather than a direct
@@ -180,6 +181,15 @@ public class ThingifierApiDocumentationDefn {
 
     public ThingifierApiDocumentationDefn setTwitterSite(final String twitterSite) {
         this.twitterSite = twitterSite;
+        return this;
+    }
+
+    public boolean willShowSwaggerUiLink() {
+        return showSwaggerUiLink;
+    }
+
+    public ThingifierApiDocumentationDefn setShowSwaggerUiLink(final boolean showSwaggerUiLink) {
+        this.showSwaggerUiLink = showSwaggerUiLink;
         return this;
     }
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGenerator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGenerator.java
@@ -438,7 +438,9 @@ public class RestApiDocumentationGenerator {
             }
         }
 
-        output.append(paragraph(href("Open Swagger UI", prependPath + "/docs/swagger-ui")));
+        if (apiDocDefn.willShowSwaggerUiLink()) {
+            output.append(paragraph(href("Open Swagger UI", prependPath + "/docs/swagger-ui")));
+        }
         output.append(
                 paragraph(href("[download normal swagger file]", prependPath + "/docs/swagger")));
         output.append(

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGeneratorTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGeneratorTest.java
@@ -1,0 +1,49 @@
+package uk.co.compendiumdev.thingifier.htmlgui.htmlgen;
+
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.api.docgen.ApiRoutingDefinition;
+import uk.co.compendiumdev.thingifier.api.docgen.ThingifierApiDocumentationDefn;
+
+class RestApiDocumentationGeneratorTest {
+
+    @Test
+    void apiDocumentationShowsSwaggerUiLinkByDefault() {
+        final Thingifier thingifier = new Thingifier();
+        final ThingifierApiDocumentationDefn apiDocDefn = new ThingifierApiDocumentationDefn();
+
+        final String docs =
+                new RestApiDocumentationGenerator(thingifier, new DefaultGUIHTML())
+                        .getApiDocumentation(
+                                new ApiRoutingDefinition(),
+                                List.of(),
+                                apiDocDefn,
+                                "/mirror",
+                                "https://example.com/mirror/docs");
+
+        Assertions.assertTrue(docs.contains("href='/mirror/docs/swagger-ui'"));
+        Assertions.assertTrue(docs.contains("Open Swagger UI"));
+    }
+
+    @Test
+    void apiDocumentationCanHideSwaggerUiLink() {
+        final Thingifier thingifier = new Thingifier();
+        final ThingifierApiDocumentationDefn apiDocDefn =
+                new ThingifierApiDocumentationDefn().setShowSwaggerUiLink(false);
+
+        final String docs =
+                new RestApiDocumentationGenerator(thingifier, new DefaultGUIHTML())
+                        .getApiDocumentation(
+                                new ApiRoutingDefinition(),
+                                List.of(),
+                                apiDocDefn,
+                                "/mirror",
+                                "https://example.com/mirror/docs");
+
+        Assertions.assertFalse(docs.contains("href='/mirror/docs/swagger-ui'"));
+        Assertions.assertFalse(docs.contains("Open Swagger UI"));
+        Assertions.assertTrue(docs.contains("href='/mirror/docs/swagger'"));
+    }
+}


### PR DESCRIPTION
Adds a default-on documentation option to hide generated Swagger UI links while keeping OpenAPI download links. Includes focused generator coverage.