### PR TITLE
Add configurable Swagger UI page titles

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/ThingifierApiDocumentationDefn.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/ThingifierApiDocumentationDefn.java
@@ -22,6 +22,7 @@ public class ThingifierApiDocumentationDefn {
     private String description = "";
     private String pathPrefix = "";
     private String seoTitle = "";
+    private String swaggerUiTitle = "";
     private String seoDescription = "";
     private String metaRobots = "";
     private String ogImage = "";
@@ -127,6 +128,15 @@ public class ThingifierApiDocumentationDefn {
 
     public ThingifierApiDocumentationDefn setSeoTitle(final String seoTitle) {
         this.seoTitle = seoTitle;
+        return this;
+    }
+
+    public String getSwaggerUiTitle() {
+        return swaggerUiTitle;
+    }
+
+    public ThingifierApiDocumentationDefn setSwaggerUiTitle(final String swaggerUiTitle) {
+        this.swaggerUiTitle = swaggerUiTitle;
         return this;
     }
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerUiPage.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerUiPage.java
@@ -130,6 +130,11 @@ public final class SwaggerUiPage {
     }
 
     private String resolveTitle() {
+        final String swaggerUiTitle = firstNonBlank(apiDefn.getSwaggerUiTitle(), "");
+        if (!swaggerUiTitle.isEmpty()) {
+            return swaggerUiTitle;
+        }
+
         final String configuredTitle = firstNonBlank(apiDefn.getSeoTitle(), apiDefn.getTitle());
         if (!configuredTitle.isEmpty()) {
             return configuredTitle + " Swagger UI";


### PR DESCRIPTION
Adds an optional Swagger UI page title to Thingifier API documentation definitions so apps can keep long SEO titles for docs pages while using shorter Swagger UI headings.\n\nThis is needed by API Challenges to render concise headings for Simple API, API Challenges, and API Simulator Swagger UI pages.