### PR TITLE
Add HTTP response controls for edge-case APIs

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/httpserver/HttpServerResponse.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/httpserver/HttpServerResponse.java
@@ -7,6 +7,8 @@ public interface HttpServerResponse {
 
     void body(String body);
 
+    void forceBody(String body);
+
     boolean containsHeader(String name);
 
     void header(String name, String value);
@@ -20,6 +22,8 @@ public interface HttpServerResponse {
     int status();
 
     void status(int statusCode);
+
+    void suppressContentType();
 
     String type();
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/javalin/JavalinHttpServer.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/javalin/JavalinHttpServer.java
@@ -4,11 +4,20 @@ import io.javalin.Javalin;
 import io.javalin.http.Context;
 import io.javalin.http.HandlerType;
 import io.javalin.http.staticfiles.Location;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLConnection;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import org.eclipse.jetty.ee10.servlet.ServletApiRequest;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.util.Blocker;
 import uk.co.compendiumdev.thingifier.adapter.httpserver.HaltRequestException;
 import uk.co.compendiumdev.thingifier.adapter.httpserver.HttpAfterHandler;
 import uk.co.compendiumdev.thingifier.adapter.httpserver.HttpBeforeHandler;
@@ -59,8 +68,9 @@ public final class JavalinHttpServer implements AutoCloseable {
                             for (HttpAfterHandler afterHandler : registry.afterHandlers()) {
                                 config.routes.after(ctx -> runAfter(ctx, afterHandler));
                             }
-                            config.routes.after(this::removeContentTypeFromEmptyNotFound);
+                            config.routes.after(this::removeContentTypeFromEmptyStatusResponses);
                             config.routes.after(this::restoreExactContentType);
+                            config.routes.after(this::removeSuppressedContentType);
                             config.routes.exception(
                                     HaltRequestException.class,
                                     (e, ctx) -> {
@@ -190,10 +200,92 @@ public final class JavalinHttpServer implements AutoCloseable {
         JavalinServerRequest request = new JavalinServerRequest(ctx);
         JavalinServerResponse response = new JavalinServerResponse(ctx);
         String body = route.handler().handle(request, response);
+        if (forceBodyIfRequested(ctx)) {
+            return;
+        }
         if (body != null && !response.wasBodySet()) {
             ctx.attribute(JavalinServerResponse.RESPONSE_BODY_ATTRIBUTE, body);
             ctx.result(body.getBytes(StandardCharsets.UTF_8));
         }
+    }
+
+    private boolean forceBodyIfRequested(final Context ctx) throws IOException {
+        Boolean forceBody = ctx.attribute(JavalinServerResponse.FORCE_BODY_ATTRIBUTE);
+        if (!Boolean.TRUE.equals(forceBody)) {
+            return false;
+        }
+
+        String body = ctx.attribute(JavalinServerResponse.RESPONSE_BODY_ATTRIBUTE);
+        byte[] bodyBytes = (body == null ? "" : body).getBytes(StandardCharsets.UTF_8);
+        writeRawResponse(ctx, bodyBytes);
+        ctx.skipRemainingHandlers();
+        return true;
+    }
+
+    private void writeRawResponse(final Context ctx, final byte[] bodyBytes) throws IOException {
+        ServletApiRequest servletRequest = jettyServletRequest(ctx.req());
+        if (servletRequest == null) {
+            throw new IOException(
+                    "Forced raw response requires Jetty ServletApiRequest but found "
+                            + ctx.req().getClass().getName());
+        }
+
+        byte[] responseBytes = rawResponseBytes(ctx, bodyBytes);
+        EndPoint endPoint =
+                servletRequest.getRequest().getConnectionMetaData().getConnection().getEndPoint();
+        try (Blocker.Callback callback = Blocker.callback()) {
+            endPoint.write(callback, ByteBuffer.wrap(responseBytes));
+            callback.block();
+        }
+        endPoint.close();
+        ctx.attribute(JavalinServerResponse.FORCE_BODY_ATTRIBUTE, Boolean.FALSE);
+    }
+
+    private byte[] rawResponseBytes(final Context ctx, final byte[] bodyBytes) {
+        StringBuilder response = new StringBuilder();
+        int status = ctx.statusCode();
+        response.append("HTTP/1.1 ")
+                .append(status)
+                .append(" ")
+                .append(HttpStatus.getMessage(status))
+                .append("\r\n");
+
+        Map<String, String> headers = new LinkedHashMap<>();
+        for (String name : ctx.res().getHeaderNames()) {
+            headers.put(name, ctx.res().getHeader(name));
+        }
+        headers.put("Content-Length", String.valueOf(bodyBytes.length));
+        headers.put("Connection", "close");
+
+        for (Map.Entry<String, String> header : headers.entrySet()) {
+            if (header.getValue() != null) {
+                response.append(header.getKey())
+                        .append(": ")
+                        .append(header.getValue())
+                        .append("\r\n");
+            }
+        }
+        response.append("\r\n");
+
+        byte[] headerBytes = response.toString().getBytes(StandardCharsets.ISO_8859_1);
+        byte[] responseBytes = new byte[headerBytes.length + bodyBytes.length];
+        System.arraycopy(headerBytes, 0, responseBytes, 0, headerBytes.length);
+        System.arraycopy(bodyBytes, 0, responseBytes, headerBytes.length, bodyBytes.length);
+        return responseBytes;
+    }
+
+    private ServletApiRequest jettyServletRequest(final HttpServletRequest request) {
+        HttpServletRequest current = request;
+        while (current instanceof HttpServletRequestWrapper wrapper) {
+            if (current instanceof ServletApiRequest servletRequest) {
+                return servletRequest;
+            }
+            current = (HttpServletRequest) wrapper.getRequest();
+        }
+        if (current instanceof ServletApiRequest servletRequest) {
+            return servletRequest;
+        }
+        return null;
     }
 
     private void runBefore(final Context ctx, final HttpBeforeHandler beforeHandler)
@@ -216,12 +308,24 @@ public final class JavalinHttpServer implements AutoCloseable {
         }
     }
 
-    private void removeContentTypeFromEmptyNotFound(final Context ctx) {
-        if (ctx.statusCode() != 404) {
+    private void removeContentTypeFromEmptyStatusResponses(final Context ctx) {
+        if (ctx.statusCode() != 204 && ctx.statusCode() != 404) {
             return;
         }
 
         if (!hasEmptyBody(ctx)) {
+            return;
+        }
+
+        ctx.res().setCharacterEncoding(null);
+        ctx.res().setContentType(null);
+        ctx.res().setHeader("Content-Type", null);
+    }
+
+    private void removeSuppressedContentType(final Context ctx) {
+        Boolean suppressContentType =
+                ctx.attribute(JavalinServerResponse.SUPPRESS_CONTENT_TYPE_ATTRIBUTE);
+        if (!Boolean.TRUE.equals(suppressContentType)) {
             return;
         }
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/javalin/JavalinServerResponse.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/javalin/JavalinServerResponse.java
@@ -8,6 +8,8 @@ import uk.co.compendiumdev.thingifier.adapter.httpserver.HttpServerResponse;
 
 final class JavalinServerResponse implements HttpServerResponse {
     static final String RESPONSE_BODY_ATTRIBUTE = "thingifier.response.body";
+    static final String SUPPRESS_CONTENT_TYPE_ATTRIBUTE = "thingifier.suppress.content.type";
+    static final String FORCE_BODY_ATTRIBUTE = "thingifier.force.body";
 
     private final Context context;
     private boolean bodySet;
@@ -27,6 +29,13 @@ final class JavalinServerResponse implements HttpServerResponse {
         bodySet = true;
         context.attribute(RESPONSE_BODY_ATTRIBUTE, body == null ? "" : body);
         context.result((body == null ? "" : body).getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public void forceBody(final String body) {
+        bodySet = true;
+        context.attribute(RESPONSE_BODY_ATTRIBUTE, body == null ? "" : body);
+        context.attribute(FORCE_BODY_ATTRIBUTE, Boolean.TRUE);
     }
 
     @Override
@@ -67,6 +76,13 @@ final class JavalinServerResponse implements HttpServerResponse {
     @Override
     public void status(final int statusCode) {
         context.status(statusCode);
+    }
+
+    @Override
+    public void suppressContentType() {
+        context.attribute(SUPPRESS_CONTENT_TYPE_ATTRIBUTE, Boolean.TRUE);
+        context.res().setContentType(null);
+        context.res().setHeader("Content-Type", null);
     }
 
     @Override

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/adapter/javalin/JavalinHttpServerTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/adapter/javalin/JavalinHttpServerTest.java
@@ -1,10 +1,12 @@
 package uk.co.compendiumdev.thingifier.adapter.javalin;
 
 import java.net.ServerSocket;
+import java.net.Socket;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import uk.co.compendiumdev.thingifier.adapter.httpserver.HttpRouteRegistry;
@@ -20,9 +22,83 @@ class JavalinHttpServerTest {
     }
 
     @Test
+    void emptyNoContentDoesNotReturnContentTypeHeader() throws Exception {
+        int port = availablePort();
+        HttpRouteRegistry registry = new HttpRouteRegistry();
+        registry.add(
+                HttpRouteVerb.GET,
+                "/empty-no-content",
+                (request, response) -> {
+                    response.type("application/json");
+                    response.status(204);
+                    return "";
+                });
+
+        try (JavalinHttpServer server = new JavalinHttpServer(port, "/public", registry)) {
+            server.start();
+
+            HttpResponse<String> response = get("http://localhost:" + port + "/empty-no-content");
+
+            Assertions.assertEquals(204, response.statusCode());
+            Assertions.assertEquals("", response.body());
+            Assertions.assertTrue(response.headers().firstValue("Content-Type").isEmpty());
+        }
+    }
+
+    @Test
     void keepsSingleLegacyPathParamNamesReadable() {
         Assertions.assertEquals(
                 "/challenger/{id}", JavalinHttpServer.javalinPath("/challenger/:id"));
+    }
+
+    @Test
+    void contentTypeCanBeSuppressedForResponseWithBody() throws Exception {
+        int port = availablePort();
+        HttpRouteRegistry registry = new HttpRouteRegistry();
+        registry.add(
+                HttpRouteVerb.GET,
+                "/no-content-type",
+                (request, response) -> {
+                    response.suppressContentType();
+                    response.status(200);
+                    return "{\"version\":\"6\"}";
+                });
+
+        try (JavalinHttpServer server = new JavalinHttpServer(port, "/public", registry)) {
+            server.start();
+
+            HttpResponse<String> response = get("http://localhost:" + port + "/no-content-type");
+
+            Assertions.assertEquals(200, response.statusCode());
+            Assertions.assertEquals("{\"version\":\"6\"}", response.body());
+            Assertions.assertTrue(response.headers().firstValue("Content-Type").isEmpty());
+        }
+    }
+
+    @Test
+    void forcedBodyCanBeSentWithNoContentStatus() throws Exception {
+        int port = availablePort();
+        HttpRouteRegistry registry = new HttpRouteRegistry();
+        registry.add(
+                HttpRouteVerb.DELETE,
+                "/forced-no-content",
+                (request, response) -> {
+                    response.type("application/json");
+                    response.status(204);
+                    response.forceBody("{\"message\":\"forced\"}");
+                    return "";
+                });
+
+        try (JavalinHttpServer server = new JavalinHttpServer(port, "/public", registry)) {
+            server.start();
+
+            String response = rawHttp("DELETE", "/forced-no-content", port);
+
+            Assertions.assertTrue(response.startsWith("HTTP/1.1 204 No Content"));
+            Assertions.assertTrue(response.contains("Content-Type: application/json"));
+            Assertions.assertTrue(response.contains("Content-Length: 20"));
+            Assertions.assertTrue(response.endsWith("{\"message\":\"forced\"}"));
+        }
     }
 
     @Test
@@ -84,6 +160,23 @@ class JavalinHttpServerTest {
     private int availablePort() throws Exception {
         try (ServerSocket socket = new ServerSocket(0)) {
             return socket.getLocalPort();
+        }
+    }
+
+    private String rawHttp(final String method, final String path, final int port)
+            throws Exception {
+        try (Socket socket = new Socket("localhost", port)) {
+            socket.setSoTimeout(5000);
+            socket.getOutputStream()
+                    .write(
+                            (method
+                                            + " "
+                                            + path
+                                            + " HTTP/1.1\r\nHost: localhost:"
+                                            + port
+                                            + "\r\nConnection: close\r\n\r\n")
+                                    .getBytes(StandardCharsets.ISO_8859_1));
+            return new String(socket.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add explicit HTTP server response controls for suppressing framework-added Content-Type headers
- add explicit forced-body response support for deliberately awkward edge-case API examples
- cover empty 204 responses, suppressed content type, and raw forced bodies in Javalin adapter tests

## Verification
- mvn -B -pl thingifier '-Dtest=JavalinHttpServerTest' test
- mvn -B -pl thingifier -DskipTests checkstyle:check@project-fqn-check
- mvn -B -pl thingifier -am test
- mvn -B spotless:check
- mvn -B -pl thingifier -am pmd:check checkstyle:check
- API Challenges focused From Hell tests against this local Thingifier snapshot