### PR TITLE
Return 204 for delete commands

### DIFF
--- a/standAloneTodoListManagerRestApiAuto/src/test/java/uk/co/compendiumdev/version4/projects/ProjectEntityTest.java
+++ b/standAloneTodoListManagerRestApiAuto/src/test/java/uk/co/compendiumdev/version4/projects/ProjectEntityTest.java
@@ -60,7 +60,7 @@ public class ProjectEntityTest {
 
         // delete the project we just created
         response = RestAssured.delete(Environment.getEnv("/projects/" + created.id));
-        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(204, response.getStatusCode());
 
         // check it has gone
         response = RestAssured.get(Environment.getEnv("/projects/" + created.id));

--- a/standAloneTodoListManagerRestApiAuto/src/test/java/uk/co/compendiumdev/version4/todos/TodoEntityTest.java
+++ b/standAloneTodoListManagerRestApiAuto/src/test/java/uk/co/compendiumdev/version4/todos/TodoEntityTest.java
@@ -92,7 +92,7 @@ public class TodoEntityTest {
 
         // delete the todoinstance we just created
         response = RestAssured.delete(Environment.getEnv("/todos/" + created.id));
-        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(204, response.getStatusCode());
 
         // check it has gone
         response = RestAssured.get(Environment.getEnv("/todos/" + created.id));

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/DynamicThingifierApiProxyTest.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/DynamicThingifierApiProxyTest.java
@@ -43,7 +43,7 @@ public class DynamicThingifierApiProxyTest {
                                             uk.co.compendiumdev.thingifier.adapter.internalhttp
                                                     .InternalHttpMethod.DELETE)
                                     .addHeader("Accept", "application/json"));
-            Assertions.assertEquals(200, delete.statusCode());
+            Assertions.assertEquals(204, delete.statusCode());
         }
     }
 
@@ -90,7 +90,7 @@ public class DynamicThingifierApiProxyTest {
 
             UiHttpResponse disconnect =
                     proxy.deleteJson("projects/" + projectId + "/tasks/" + existingTodoId);
-            Assertions.assertEquals(200, disconnect.statusCode());
+            Assertions.assertEquals(204, disconnect.statusCode());
             Assertions.assertFalse(
                     proxy.getJson("projects/" + projectId + "/tasks")
                             .body()

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/ThingCommandResultApiMapper.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/ThingCommandResultApiMapper.java
@@ -75,7 +75,7 @@ public final class ThingCommandResultApiMapper {
 
         if (command instanceof DeleteThingCommand
                 || command instanceof DisconnectRelationshipCommand) {
-            return ApiResponse.success();
+            return ApiResponse.noContent();
         }
 
         return ApiResponse.error(400, result.getErrorMessages());

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/ApiRoutingDefinitionDocGenerator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/ApiRoutingDefinitionDocGenerator.java
@@ -315,7 +315,7 @@ public class ApiRoutingDefinitionDocGenerator {
                     .addRequestUrlParam(entityDefn.getField(uniqueIdFieldName))
                     .addPossibleStatus(
                             RoutingStatus.returnValue(
-                                    200,
+                                    204,
                                     String.format("Deleted a specific %s", entityDefn.getName())))
                     .addPossibleStatus(
                             RoutingStatus.returnValue(
@@ -323,7 +323,6 @@ public class ApiRoutingDefinitionDocGenerator {
                                     String.format(
                                             "Could not find a specific %s", entityDefn.getName())));
 
-            // TODO: API Config to allow 200 to be returned instead of 204
             defn.addRouting(
                             String.format("show all Options for endpoint of %s", aUrlWGuid),
                             RoutingVerb.OPTIONS,
@@ -487,7 +486,7 @@ public class ApiRoutingDefinitionDocGenerator {
                         aUrlDelete,
                         RoutingStatus.returnedFromCall())
                 .addPossibleStatus(
-                        RoutingStatus.returnValue(200, String.format("deleted the relationship")))
+                        RoutingStatus.returnValue(204, String.format("deleted the relationship")))
                 .addPossibleStatus(
                         RoutingStatus.returnValue(
                                 400, String.format("error when deleting the relationship")))

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponse.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponse.java
@@ -64,6 +64,10 @@ public final class ApiResponse {
         return new ApiResponse(200);
     }
 
+    public static ApiResponse noContent() {
+        return new ApiResponse(204);
+    }
+
     public ApiResponse returnSingleInstance(final EntityInstance instance) {
         this.isCollection = false;
         draftToReturn = null;

--- a/thingifier/src/test/java/uk/co/compendiumdev/casestudy/todomanager/api_non_http/RelationshipApiNonHttpTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/casestudy/todomanager/api_non_http/RelationshipApiNonHttpTest.java
@@ -181,7 +181,7 @@ public class RelationshipApiNonHttpTest {
                                         paperwork.getPrimaryKeyValue()),
                                 new HttpHeadersBlock());
 
-        Assertions.assertEquals(200, apiresponse.getStatusCode());
+        Assertions.assertEquals(204, apiresponse.getStatusCode());
 
         Assertions.assertEquals(
                 numberOfTasks - 1,
@@ -255,7 +255,7 @@ public class RelationshipApiNonHttpTest {
                                 String.format("todo/%s", paperwork.getPrimaryKeyValue()),
                                 new HttpHeadersBlock());
 
-        Assertions.assertEquals(200, apiresponse.getStatusCode());
+        Assertions.assertEquals(204, apiresponse.getStatusCode());
         Assertions.assertFalse(apiresponse.hasABody());
         Assertions.assertTrue(apiresponse.getErrorMessages().size() == 0);
 
@@ -630,7 +630,7 @@ public class RelationshipApiNonHttpTest {
                                         relTodo.getPrimaryKeyValue(),
                                         myNewProject.getPrimaryKeyValue()),
                                 new HttpHeadersBlock());
-        Assertions.assertEquals(200, apiresponse.getStatusCode());
+        Assertions.assertEquals(204, apiresponse.getStatusCode());
 
         // project should be related to nothing
         Collection<EntityInstance> items =
@@ -740,7 +740,7 @@ public class RelationshipApiNonHttpTest {
                         .delete(
                                 String.format("todo/%s", relTodo.getPrimaryKeyValue()),
                                 new HttpHeadersBlock());
-        Assertions.assertEquals(200, apiresponse.getStatusCode());
+        Assertions.assertEquals(204, apiresponse.getStatusCode());
 
         Assertions.assertEquals(
                 0,

--- a/thingifier/src/test/java/uk/co/compendiumdev/casestudy/todomanager/api_non_http/RelationshipApiSqliteRepositoryTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/casestudy/todomanager/api_non_http/RelationshipApiSqliteRepositoryTest.java
@@ -443,7 +443,7 @@ public class RelationshipApiSqliteRepositoryTest {
                                             task.getPrimaryKeyValue()),
                                     new HttpHeadersBlock());
 
-            Assertions.assertEquals(200, response.getStatusCode());
+            Assertions.assertEquals(204, response.getStatusCode());
             Assertions.assertTrue(
                     repository.relationships().listRelated(projectInstance, "tasks").isEmpty());
             Assertions.assertNotNull(

--- a/thingifier/src/test/java/uk/co/compendiumdev/casestudy/todomanager/api_non_http/VerbDeleteEntityInstanceApiNonHttpTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/casestudy/todomanager/api_non_http/VerbDeleteEntityInstanceApiNonHttpTest.java
@@ -73,7 +73,7 @@ public class VerbDeleteEntityInstanceApiNonHttpTest {
                         .delete(
                                 String.format("project/%s", officeWork.getPrimaryKeyValue()),
                                 new HttpHeadersBlock());
-        Assertions.assertEquals(200, apiresponse.getStatusCode());
+        Assertions.assertEquals(204, apiresponse.getStatusCode());
         Assertions.assertTrue(apiresponse.getErrorMessages().size() == 0);
 
         Assertions.assertFalse(apiresponse.hasABody());

--- a/thingifier/src/test/java/uk/co/compendiumdev/casestudy/todomanager/http_api/DeleteRequestTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/casestudy/todomanager/http_api/DeleteRequestTest.java
@@ -55,7 +55,7 @@ public class DeleteRequestTest {
         HttpApiRequest request = new HttpApiRequest("/todos/" + instance.getPrimaryKeyValue());
 
         final HttpApiResponse response = new ThingifierHttpApi(todoManager).delete(request);
-        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(204, response.getStatusCode());
         System.out.println(response.getBody());
 
         Assertions.assertEquals(

--- a/thingifier/src/test/java/uk/co/compendiumdev/casestudy/todomanager/http_api/RelationshipHttpTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/casestudy/todomanager/http_api/RelationshipHttpTest.java
@@ -498,7 +498,7 @@ public class RelationshipHttpTest {
                                 + atodo.getPrimaryKeyValue());
 
         final HttpApiResponse response = new ThingifierHttpApi(todoManager).delete(request);
-        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(204, response.getStatusCode());
 
         Assertions.assertEquals(
                 0,
@@ -572,7 +572,7 @@ public class RelationshipHttpTest {
                                 + atodo.getPrimaryKeyValue());
 
         HttpApiResponse response = new ThingifierHttpApi(todoManager).delete(request);
-        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(204, response.getStatusCode());
 
         Assertions.assertEquals(
                 0,
@@ -749,7 +749,7 @@ public class RelationshipHttpTest {
         final HttpApiRequest request = new HttpApiRequest("todos/" + atodo.getPrimaryKeyValue());
 
         HttpApiResponse response = new ThingifierHttpApi(todoManager).delete(request);
-        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(204, response.getStatusCode());
 
         Assertions.assertEquals(
                 0,

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/docgen/ApiRoutingDefinitionDocGeneratorTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/docgen/ApiRoutingDefinitionDocGeneratorTest.java
@@ -45,7 +45,7 @@ public class ApiRoutingDefinitionDocGeneratorTest {
                         .containsAll(Set.of(201, 400, 404, 422, 409)));
         Assertions.assertTrue(
                 statuses(route(definition, RoutingVerb.DELETE, "projects/:id/tasks/:id"))
-                        .containsAll(Set.of(200, 400, 404, 422, 409)));
+                        .containsAll(Set.of(204, 400, 404, 422, 409)));
     }
 
     private Thingifier model() {

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/requests/ThingifierHttpApiRequestHandlingTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/requests/ThingifierHttpApiRequestHandlingTest.java
@@ -172,7 +172,7 @@ public class ThingifierHttpApiRequestHandlingTest {
                 api.delete(
                         new HttpApiRequest("/things/" + anInstance.getPrimaryKeyValue())
                                 .setHeaders(headers));
-        Assertions.assertEquals(200, actualDeleteResponse.getStatusCode());
+        Assertions.assertEquals(204, actualDeleteResponse.getStatusCode());
 
         Assertions.assertEquals(
                 0, thingifier.getStore("other_things").entityQueries().count(thingInstances));


### PR DESCRIPTION
## Summary
- return 204 No Content for successful entity deletes and relationship disconnects
- document delete routes as 204 in generated API docs
- update delete and relationship regression tests to the new status contract

## Verification
- mvn -B -pl thingifier '-Dtest=RelationshipApiNonHttpTest' test
- mvn -B -pl thingifier -am test
- mvn -B -pl thingifier -DskipTests checkstyle:check@project-fqn-check
- mvn -B spotless:check
- mvn -B -pl thingifier -am pmd:check checkstyle:check
- mvn -B -pl challenger '-Dtest=ChallengeApiModelRepositoryTest,CompleteAllChallengesMultiUserTest,CompleteAllChallengesSingleUserTest,SimpleApiModeTest' test, after installing this Thingifier snapshot locally