### PR TITLE
Fix restored auto increment ids

### DIFF
--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/repository/inmemory/InMemoryEntityInstanceCollection.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/repository/inmemory/InMemoryEntityInstanceCollection.java
@@ -147,7 +147,7 @@ final class InMemoryEntityInstanceCollection {
             // should only do this if we actually add the item
             AutoIncrement counter = counters.get(autoIncrementFieldSet);
             if (counter.peekNextValue()
-                    < instance.getFieldValue(autoIncrementFieldSet).asInteger()) {
+                    <= instance.getFieldValue(autoIncrementFieldSet).asInteger()) {
                 counter.incrementToNextAbove(
                         instance.getFieldValue(autoIncrementFieldSet).asInteger());
             }

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/repository/inmemory/InMemoryThingStore.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/repository/inmemory/InMemoryThingStore.java
@@ -282,7 +282,10 @@ public class InMemoryThingStore implements ThingStore {
             if (field != null && field.getType() == FieldType.AUTO_INCREMENT) {
                 AutoIncrement counter = countersFor(entity).get(field.getName());
                 if (counter != null) {
-                    counter.incrementToNextAbove(Integer.parseInt(fieldNameValue.value));
+                    int value = Integer.parseInt(fieldNameValue.value);
+                    if (counter.peekNextValue() <= value) {
+                        counter.incrementToNextAbove(value);
+                    }
                 }
             }
         }

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/repository/sqlite/SqliteThingStore.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/repository/sqlite/SqliteThingStore.java
@@ -518,7 +518,10 @@ public class SqliteThingStore implements ThingStore {
             Field field = entity.getField(fieldNameValue.getName());
             if (field != null && field.getType() == FieldType.AUTO_INCREMENT) {
                 AutoIncrement counter = counterFor(entity, field);
-                counter.incrementToNextAbove(Integer.parseInt(fieldNameValue.value));
+                int value = Integer.parseInt(fieldNameValue.value);
+                if (counter.peekNextValue() <= value) {
+                    counter.incrementToNextAbove(value);
+                }
             }
         }
         ensureSchemaReady();
@@ -600,7 +603,7 @@ public class SqliteThingStore implements ThingStore {
         for (String fieldName : explicitAutoIncrementFields) {
             AutoIncrement counter = countersFor(entity).get(fieldName);
             int value = instance.getFieldValue(fieldName).asInteger();
-            if (counter.peekNextValue() < value) {
+            if (counter.peekNextValue() <= value) {
                 counter.incrementToNextAbove(value);
             }
         }

--- a/ercoremodel/src/test/java/uk/co/compendiumdev/thingifier/core/repository/ThingStoreContractTest.java
+++ b/ercoremodel/src/test/java/uk/co/compendiumdev/thingifier/core/repository/ThingStoreContractTest.java
@@ -209,6 +209,21 @@ public class ThingStoreContractTest {
     }
 
     @Test
+    public void inMemoryRepositoryAccommodatesRestoredAutoIdsInAnyOrder() {
+        ThingStore repository = new InMemoryThingStore(EntityRelModel.DEFAULT_DATABASE_NAME);
+
+        exerciseRestoredAutoIdAccommodation(repository);
+    }
+
+    @Test
+    public void sqliteRepositoryAccommodatesRestoredAutoIdsInAnyOrder() {
+        try (ThingStore repository =
+                SqliteThingStore.inMemory(EntityRelModel.DEFAULT_DATABASE_NAME)) {
+            exerciseRestoredAutoIdAccommodation(repository);
+        }
+    }
+
+    @Test
     public void sqliteRepositoryThrowsTypedMaxInstanceLimitFailure() {
         ERSchema schema = ticketSchema(1);
         EntityDefinition ticket = schema.getEntityDefinitionNamed("ticket");
@@ -829,6 +844,26 @@ public class ThingStoreContractTest {
 
         Assertions.assertEquals("25", explicitTicket.getPrimaryKeyValue());
         Assertions.assertEquals("26", ticketAfterExplicit.getPrimaryKeyValue());
+    }
+
+    private void exerciseRestoredAutoIdAccommodation(final ThingStore repository) {
+        ERSchema schema = autoIdSchema();
+        repository.administration().initializeFrom(schema);
+
+        EntityDefinition ticket = schema.getEntityDefinitionNamed("ticket");
+        String[] restoredIds = {"4", "9", "8", "3", "6", "2", "10", "5", "7", "1"};
+        for (String restoredId : restoredIds) {
+            repository
+                    .entities()
+                    .create(
+                            EntityInstanceDraft.forEntity(ticket)
+                                    .withProtectedField("id", restoredId));
+        }
+
+        EntityInstance ticketAfterRestore =
+                repository.entities().create(EntityInstanceDraft.forEntity(ticket));
+
+        Assertions.assertEquals("11", ticketAfterRestore.getPrimaryKeyValue());
     }
 
     private void exerciseMandatoryRelationshipValidationAndCascade(final ThingStore repository) {

--- a/thingifier/src/test/java/uk/co/compendiumdev/casestudy/todomanager/http_api/JsonRequestResponseTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/casestudy/todomanager/http_api/JsonRequestResponseTest.java
@@ -208,6 +208,7 @@ public class JsonRequestResponseTest {
 
         // header should give me the guid
         String guid = response.getHeaders().get(ApiResponse.PRIMARY_KEY_HEADER);
+        String location = response.getHeaders().get("Location");
 
         final EntityInstance aTodo =
                 todoManager
@@ -216,6 +217,7 @@ public class JsonRequestResponseTest {
                         .findByPrimaryKey(todo, guid);
 
         Assertions.assertEquals("title from json", aTodo.getFieldValue("title").asString());
+        Assertions.assertEquals("/todos/" + guid, location);
 
         Assertions.assertTrue(
                 response.getBody().startsWith("{\"guid\":\""), "Should have returned json");


### PR DESCRIPTION
## Summary
- advance in-memory and SQLite auto-increment counters when restored/protected IDs are equal to the next generated value
- add store contract coverage for restored auto IDs imported in non-sorted order
- add an HTTP create regression asserting 201 responses include the Location header

## Verification
- mvn -B spotless:check
- mvn -B -pl ercoremodel,thingifier -am -DskipTests checkstyle:check@project-fqn-check
- mvn -B -pl ercoremodel -Dtest=ThingStoreContractTest test
- mvn -B -pl thingifier -Dtest=JsonRequestResponseTest#canPostAndCreateAnItemWithJson test
- mvn -B -pl ercoremodel,thingifier -am -DskipTests package