### PR TITLE
Rescue delete no-content regression tests

### DIFF
--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/docgen/ApiRoutingDefinitionDocGeneratorTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/docgen/ApiRoutingDefinitionDocGeneratorTest.java
@@ -33,6 +33,9 @@ public class ApiRoutingDefinitionDocGeneratorTest {
         Assertions.assertTrue(
                 statuses(route(definition, RoutingVerb.PUT, "todos/:id"))
                         .containsAll(Set.of(200, 404, 422, 409)));
+        Assertions.assertTrue(
+                statuses(route(definition, RoutingVerb.DELETE, "todos/:id"))
+                        .containsAll(Set.of(204, 404)));
     }
 
     @Test

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/ThingCommandResultApiMapperTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/ThingCommandResultApiMapperTest.java
@@ -97,6 +97,15 @@ public class ThingCommandResultApiMapperTest {
     }
 
     @Test
+    public void mapsSuccessfulDeleteToNoContent() {
+        ApiResponse response =
+                mapper().map(new DeleteThingCommand("task", "1"), ThingCommandResult.success());
+
+        Assertions.assertEquals(204, response.getStatusCode());
+        Assertions.assertFalse(response.hasABody());
+    }
+
+    @Test
     public void mapsInstanceNotFoundWithRouteContextToLegacyPathMessage() {
         ThingCommandResult result =
                 ThingCommandResult.error(ApplicationError.instanceNotFound("task", "missing"));


### PR DESCRIPTION
## Summary
- add API docs coverage that entity DELETE routes document 204/404
- add mapper coverage that successful delete commands return 204 with no body
- drop the stale stash after rescuing the useful assertions

## Verification
- mvn -B -pl thingifier "-Dtest=ApiRoutingDefinitionDocGeneratorTest,ThingCommandResultApiMapperTest" test
- mvn -B spotless:check
- mvn -B -pl thingifier -DskipTests checkstyle:check@project-fqn-check