### PR TITLE
Expose OpenAPI version selector in Swagger UI

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/httpserver/ThingifierAutoDocGenRouting.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/httpserver/ThingifierAutoDocGenRouting.java
@@ -68,7 +68,6 @@ public class ThingifierAutoDocGenRouting {
                                     openApi31Path,
                                     openApi32Path,
                                     docsPath,
-                                    swaggerDownloadPath,
                                     swaggerUiPath)
                             .html();
                 });

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerUiPage.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerUiPage.java
@@ -21,7 +21,6 @@ public final class SwaggerUiPage {
     private final String openApi31Url;
     private final String openApi32Url;
     private final String docsUrl;
-    private final String downloadUrl;
     private final String canonicalUrl;
 
     public SwaggerUiPage(
@@ -32,7 +31,6 @@ public final class SwaggerUiPage {
             final String openApi31Url,
             final String openApi32Url,
             final String docsUrl,
-            final String downloadUrl,
             final String canonicalUrl) {
         this.apiDefn = apiDefn;
         this.guiManagement = guiManagement;
@@ -41,7 +39,6 @@ public final class SwaggerUiPage {
         this.openApi31Url = openApi31Url;
         this.openApi32Url = openApi32Url;
         this.docsUrl = docsUrl;
-        this.downloadUrl = downloadUrl;
         this.canonicalUrl = canonicalUrl;
     }
 
@@ -56,10 +53,6 @@ public final class SwaggerUiPage {
         html.append("<h1>").append(escapeHtml(title)).append("</h1>");
         html.append("<p>");
         html.append("<a href='").append(escapeHtmlAttribute(docsUrl)).append("'>API Docs</a>");
-        html.append(" | ");
-        html.append("<a href='")
-                .append(escapeHtmlAttribute(downloadUrl))
-                .append("'>Download OpenAPI JSON</a>");
         html.append(" | ");
         html.append("<a href='")
                 .append(escapeHtmlAttribute(openApi31Url))
@@ -146,7 +139,10 @@ public final class SwaggerUiPage {
                 ".swagger-ui-page h1{margin-bottom:.25em;}",
                 ".swagger-ui-page #swagger-ui{margin-top:1em;}",
                 ".swagger-ui{background:#fff;color:#222;color-scheme:light;}",
-                ".swagger-ui .topbar{display:none;}",
+                ".swagger-ui .topbar{background:#f7f7f7!important;border:1px solid #d7d7d7;"
+                        + "border-radius:4px;margin:1em 0;padding:8px 0;}",
+                ".swagger-ui .topbar-wrapper{align-items:center;}",
+                ".swagger-ui .topbar a span{color:#222!important;}",
                 ".swagger-ui .wrapper,.swagger-ui .scheme-container,"
                         + ".swagger-ui section.models,.swagger-ui .model-box,"
                         + ".swagger-ui .opblock,.swagger-ui .opblock .opblock-summary,"

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerUiPageTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerUiPageTest.java
@@ -21,7 +21,6 @@ class SwaggerUiPageTest {
                                 "/mirror/docs/openapi-3.1.json",
                                 "/mirror/docs/openapi-3.2.json",
                                 "/mirror/docs",
-                                "/mirror/docs/swagger",
                                 "/mirror/docs/swagger-ui")
                         .html();
 
@@ -33,5 +32,7 @@ class SwaggerUiPageTest {
         Assertions.assertTrue(html.contains("/mirror/docs/openapi-3.1.json"));
         Assertions.assertTrue(html.contains("/mirror/docs/openapi-3.2.json"));
         Assertions.assertTrue(html.contains("\"urls.primaryName\": \"OpenAPI 3.1 default\""));
+        Assertions.assertFalse(html.contains("Download OpenAPI JSON"));
+        Assertions.assertFalse(html.contains(".swagger-ui .topbar{display:none;}"));
     }
 }


### PR DESCRIPTION
## Summary
- remove the redundant Download OpenAPI JSON link from Swagger UI pages
- expose Swagger UI's built-in OpenAPI spec selector for 3.0, 3.1, and 3.2
- keep direct versioned OpenAPI JSON links in the page nav

## Tests
- mvn -B -q -pl thingifier test '-Dtest=SwaggerUiPageTest'