### PR TITLE
Configure data explorer response views

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/Thingifier.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/Thingifier.java
@@ -14,6 +14,7 @@ import uk.co.compendiumdev.thingifier.core.domain.definitions.*;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.relationship.RelationshipDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
 import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
+import uk.co.compendiumdev.thingifier.htmlgui.ThingifierGuiConfig;
 import uk.co.compendiumdev.thingifier.reporting.ThingReporter;
 
 /* Thingifier
@@ -33,6 +34,7 @@ public final class Thingifier implements AutoCloseable {
     private final ThingifierApiConfig apiConfig;
     private final ThingifierApiConfigProfiles apiConfigProfiles;
     private final ThingifierApiSpec apiSpec;
+    private final ThingifierGuiConfig guiConfig;
 
     public Thingifier() {
         this(new EntityRelModel());
@@ -45,6 +47,7 @@ public final class Thingifier implements AutoCloseable {
         apiConfig = new ThingifierApiConfig("");
         apiConfigProfiles = new ThingifierApiConfigProfiles();
         apiSpec = new ThingifierApiSpec();
+        guiConfig = new ThingifierGuiConfig();
         apiDocsConfig = new ApiDocsConfig();
     }
 
@@ -62,6 +65,7 @@ public final class Thingifier implements AutoCloseable {
         this.apiConfig = apiConfig;
         this.apiConfigProfiles = apiConfigProfiles;
         this.apiSpec = new ThingifierApiSpec();
+        this.guiConfig = new ThingifierGuiConfig();
         this.apiDocsConfig = apiDocsConfig;
     }
 
@@ -214,6 +218,10 @@ public final class Thingifier implements AutoCloseable {
 
     public ThingifierApiSpec apiSpec() {
         return apiSpec;
+    }
+
+    public ThingifierGuiConfig guiConfig() {
+        return guiConfig;
     }
 
     public void configureWithProfile(final ThingifierApiConfigProfile profileToUse) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/ApiRoutingDefinition.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/ApiRoutingDefinition.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import uk.co.compendiumdev.thingifier.api.response.ResponseHeader;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityViewDefinition;
 
 public final class ApiRoutingDefinition {
 
@@ -58,6 +59,11 @@ public final class ApiRoutingDefinition {
 
         // and as plural for array responses
         objectSchemas.put(entityDefn.getPlural(), entityDefn);
+
+        for (EntityViewDefinition view : entityDefn.getViews()) {
+            objectSchemas.put(view.getName(), entityDefn);
+            objectSchemas.put("create_" + view.getName(), entityDefn);
+        }
     }
 
     public boolean hasObjectSchemaNamed(String aName) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/ermodelconversion/JsonThing.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/ermodelconversion/JsonThing.java
@@ -96,10 +96,17 @@ public class JsonThing {
 
     public JsonObject asJsonObjectTypedDraftArrayWithContentsUntyped(
             final List<EntityInstanceDraft> things, String typeName) {
+        return asJsonObjectTypedDraftArrayWithContentsUntyped(things, typeName, null);
+    }
+
+    public JsonObject asJsonObjectTypedDraftArrayWithContentsUntyped(
+            final List<EntityInstanceDraft> things,
+            String typeName,
+            final EntityViewDefinition view) {
         final JsonObject arrayObj = new JsonObject();
         JsonArray drafts = new JsonArray();
         for (EntityInstanceDraft draft : things) {
-            drafts.add(asJsonObject(draft));
+            drafts.add(asJsonObject(draft, view));
         }
         arrayObj.add(typeName, drafts);
         return arrayObj;
@@ -252,6 +259,11 @@ public class JsonThing {
     }
 
     public JsonObject asJsonObject(final EntityInstanceDraft draft) {
+        return asJsonObject(draft, null);
+    }
+
+    public JsonObject asJsonObject(
+            final EntityInstanceDraft draft, final EntityViewDefinition view) {
         final JsonObject jsonobj = new JsonObject();
 
         if (draft == null) {
@@ -268,6 +280,9 @@ public class JsonThing {
         }
 
         for (String fieldName : entity.getFieldNames()) {
+            if (view != null && !view.isResponseVisible(fieldName)) {
+                continue;
+            }
             Field field = entity.getField(fieldName);
             String fieldValue = draftValueFor(field, values.get(fieldName.toLowerCase()));
             if (fieldValue == null) {
@@ -524,8 +539,13 @@ public class JsonThing {
     }
 
     public JsonObject asNamedJsonObject(final EntityInstanceDraft draft) {
+        return asNamedJsonObject(draft, null);
+    }
+
+    public JsonObject asNamedJsonObject(
+            final EntityInstanceDraft draft, final EntityViewDefinition view) {
         final JsonObject retObj = new JsonObject();
-        retObj.add(draft.getEntity().getName(), asJsonObject(draft));
+        retObj.add(draft.getEntity().getName(), asJsonObject(draft, view));
         return retObj;
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/ermodelconversion/XmlThing.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/ermodelconversion/XmlThing.java
@@ -37,7 +37,12 @@ public class XmlThing {
     }
 
     public String getSingleObjectXml(final EntityInstanceDraft draft) {
-        String parseForXMLOutput = jsonConvertor.asNamedJsonObject(draft).toString();
+        return getSingleObjectXml(draft, null);
+    }
+
+    public String getSingleObjectXml(
+            final EntityInstanceDraft draft, final EntityViewDefinition view) {
+        String parseForXMLOutput = jsonConvertor.asNamedJsonObject(draft, view).toString();
         return XML.toString(new JSONObject(parseForXMLOutput));
     }
 
@@ -78,10 +83,17 @@ public class XmlThing {
     public String getCollectionOfDrafts(
             final List<EntityInstanceDraft> thingsToReturn,
             final EntityDefinition typeOfThingReturned) {
+        return getCollectionOfDrafts(thingsToReturn, typeOfThingReturned, null);
+    }
+
+    public String getCollectionOfDrafts(
+            final List<EntityInstanceDraft> thingsToReturn,
+            final EntityDefinition typeOfThingReturned,
+            final EntityViewDefinition view) {
         String parseForXMLOutput =
                 jsonConvertor
                         .asJsonObjectTypedDraftArrayWithContentsUntyped(
-                                thingsToReturn, typeOfThingReturned.getPlural())
+                                thingsToReturn, typeOfThingReturned.getPlural(), view)
                         .toString();
 
         String output = XML.toString(new JSONObject(parseForXMLOutput));

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/htmlgui/ThingifierGuiConfig.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/htmlgui/ThingifierGuiConfig.java
@@ -1,0 +1,66 @@
+package uk.co.compendiumdev.thingifier.htmlgui;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityViewDefinition;
+
+public final class ThingifierGuiConfig {
+
+    private final DataExplorerConfig dataExplorer;
+
+    public ThingifierGuiConfig() {
+        dataExplorer = new DataExplorerConfig();
+    }
+
+    public DataExplorerConfig dataExplorer() {
+        return dataExplorer;
+    }
+
+    public static final class DataExplorerConfig {
+        private final Map<String, String> responseViewNamesByEntity;
+
+        private DataExplorerConfig() {
+            responseViewNamesByEntity = new HashMap<>();
+        }
+
+        public DataExplorerConfig responseView(final String entityName, final String viewName) {
+            final String normalizedEntityName = normalize(entityName);
+            final String normalizedViewName = viewName == null ? "" : viewName.trim();
+            if (normalizedEntityName.isEmpty()) {
+                throw new IllegalArgumentException("Entity name is required");
+            }
+            if (normalizedViewName.isEmpty()) {
+                throw new IllegalArgumentException("View name is required");
+            }
+            responseViewNamesByEntity.put(normalizedEntityName, normalizedViewName);
+            return this;
+        }
+
+        public Optional<String> responseViewNameFor(final EntityDefinition definition) {
+            if (definition == null) {
+                return Optional.empty();
+            }
+            String viewName = responseViewNamesByEntity.get(normalize(definition.getName()));
+            if (viewName == null) {
+                viewName = responseViewNamesByEntity.get(normalize(definition.getPlural()));
+            }
+            return Optional.ofNullable(viewName);
+        }
+
+        public EntityViewDefinition responseViewFor(final EntityDefinition definition) {
+            if (definition == null) {
+                return null;
+            }
+            return responseViewNameFor(definition)
+                    .filter(definition::hasViewNamed)
+                    .map(definition::getViewNamed)
+                    .orElse(null);
+        }
+
+        private static String normalize(final String value) {
+            return value == null ? "" : value.trim().toLowerCase();
+        }
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/DefaultGuiHtmlPages.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/DefaultGuiHtmlPages.java
@@ -5,12 +5,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.api.ermodelconversion.JsonThing;
 import uk.co.compendiumdev.thingifier.api.ermodelconversion.XmlThing;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.xml.GenericXMLPrettyPrinter;
 import uk.co.compendiumdev.thingifier.apiconfig.ThingifierApiConfig;
 import uk.co.compendiumdev.thingifier.core.EntityRelModel;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityViewDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.Field;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldType;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.relationship.RelationshipVectorDefinition;
@@ -38,10 +40,7 @@ public class DefaultGuiHtmlPages {
         this.jsonThing = new JsonThing(apiConfig.jsonOutput());
         this.xmlThing = new XmlThing(jsonThing);
         this.urlPathPrefix = urlPathPrefix;
-        String firstEntity =
-                ((EntityDefinition)
-                                this.thingifier.getERmodel().getEntityDefinitions().toArray()[0])
-                        .getName();
+        String firstEntity = firstVisibleThingName();
         String database = EntityRelModel.DEFAULT_DATABASE_NAME;
         this.tryDefault =
                 " [<a href='%s/instances?entity=%s&database=%s'>explore default data</a>]"
@@ -88,7 +87,7 @@ public class DefaultGuiHtmlPages {
         StringBuilder html = new StringBuilder();
         html.append("<div class='entity-instances-menu menu'>");
         html.append("<ul>");
-        for (String thing : thingifier.getThingNames()) {
+        for (String thing : visibleThingNames()) {
             html.append(
                     String.format(
                             "<li><a href='%3$s/instances?entity=%1$s%2$s'>%1$s</a></li>",
@@ -212,28 +211,8 @@ public class DefaultGuiHtmlPages {
                         .formatted(definition.getPlural()));
         html.append("<thead>");
         html.append("<tr>");
-        // guid first
-        if (definition.hasPrimaryKeyField()) {
-            html.append(String.format("<th>%s</th>", definition.getPrimaryKeyField().getName()));
-        }
-        // then any ids
-        for (String field : definition.getFieldNames()) {
-            Field theField = definition.getField(field);
-            if (theField != definition.getPrimaryKeyField()) {
-                if (theField.getType() == FieldType.AUTO_INCREMENT
-                        || theField.getType() == FieldType.AUTO_GUID) {
-                    html.append(String.format("<th>%s</th>", field));
-                }
-            }
-        }
-        // then the normal fields
-        for (String field : definition.getFieldNames()) {
-            Field theField = definition.getField(field);
-            if (theField != definition.getPrimaryKeyField()
-                    && theField.getType() != FieldType.AUTO_INCREMENT
-                    && theField.getType() != FieldType.AUTO_GUID) {
-                html.append(String.format("<th>%s</th>", field));
-            }
+        for (String field : responseFieldNamesForTable(definition)) {
+            html.append(String.format("<th>%s</th>", HtmlUtils.sanitise(field)));
         }
         html.append("</tr>");
         html.append("</thead>");
@@ -247,44 +226,22 @@ public class DefaultGuiHtmlPages {
         final EntityDefinition definition = instance.getEntity();
 
         html.append("<tr>");
-        // show keys first
-        if (definition.hasPrimaryKeyField()) {
-            html.append(
-                    String.format(
-                            "<td><a href='%5$s/instance?entity=%1$s&%2$s=%3$s%4$s'>%3$s</a></td>",
-                            definition.getName(),
-                            definition.getPrimaryKeyField().getName(),
-                            instance.getPrimaryKeyValue(),
-                            databaseParam(database),
-                            urlPathPrefix));
-        }
-
-        // show any clickable id fields
-        for (String field : definition.getFieldNames()) {
+        for (String field : responseFieldNamesForTable(definition)) {
             Field theField = definition.getField(field);
-            if (theField != definition.getPrimaryKeyField()) {
-                if (theField.getType() == FieldType.AUTO_INCREMENT
-                        || theField.getType() == FieldType.AUTO_GUID) {
-                    // make ids clickable
-                    String renderAs =
-                            String.format(
-                                    "<a href='%5$s/instance?entity=%1$s&%2$s=%3$s%4$s'>%3$s</a>",
-                                    definition.getName(),
-                                    theField.getName(),
-                                    instance.getFieldValue(field).asString(),
-                                    databaseParam(database),
-                                    urlPathPrefix);
-                    html.append(String.format("<td>%s</td>", renderAs));
-                }
-            }
-        }
-
-        // show any normal fields
-        for (String field : definition.getFieldNames()) {
-            Field theField = definition.getField(field);
-            if (theField != definition.getPrimaryKeyField()
-                    && theField.getType() != FieldType.AUTO_INCREMENT
-                    && theField.getType() != FieldType.AUTO_GUID) {
+            if (theField == definition.getPrimaryKeyField()
+                    || theField.getType() == FieldType.AUTO_INCREMENT
+                    || theField.getType() == FieldType.AUTO_GUID) {
+                String value = instance.getFieldValue(field).asString();
+                String renderAs =
+                        String.format(
+                                "<a href='%5$s/instance?entity=%1$s&%2$s=%3$s%4$s'>%3$s</a>",
+                                definition.getName(),
+                                theField.getName(),
+                                HtmlUtils.sanitise(value),
+                                databaseParam(database),
+                                urlPathPrefix);
+                html.append(String.format("<td>%s</td>", renderAs));
+            } else {
                 html.append(
                         String.format(
                                 "<td>%s</td>",
@@ -294,6 +251,104 @@ public class DefaultGuiHtmlPages {
         html.append("</tr>");
 
         return html.toString();
+    }
+
+    private List<String> visibleThingNames() {
+        final List<String> visible = new ArrayList<>();
+        for (String thingName : thingifier.getThingNames()) {
+            final EntityDefinition definition = thingifier.getDefinitionNamed(thingName);
+            if (definition != null && isEntityCollectionVisible(definition)) {
+                visible.add(thingName);
+            }
+        }
+        return visible;
+    }
+
+    private String firstVisibleThingName() {
+        final List<String> visibleNames = visibleThingNames();
+        if (!visibleNames.isEmpty()) {
+            return visibleNames.get(0);
+        }
+        if (!thingifier.getThingNames().isEmpty()) {
+            return thingifier.getThingNames().get(0);
+        }
+        return "";
+    }
+
+    private boolean isEntityCollectionVisible(final EntityDefinition definition) {
+        return isRouteVisible(RoutingVerb.GET, apiPathForCollection(definition));
+    }
+
+    private boolean isRelationshipCollectionVisible(
+            final RelationshipVectorDefinition relationship) {
+        return isRouteVisible(RoutingVerb.GET, apiPathForRelationship(relationship));
+    }
+
+    private boolean isRouteVisible(final RoutingVerb verb, final String path) {
+        return thingifier
+                .apiSpec()
+                .ruleFor(verb, path, apiConfig.getApiEndPointPrefix())
+                .map(rule -> !rule.isHidden() && !rule.isDisabled())
+                .orElse(true);
+    }
+
+    private String apiPathForCollection(final EntityDefinition definition) {
+        final String entityRouteName =
+                apiConfig.willUrlShowInstancesAsPlural()
+                        ? definition.getPlural()
+                        : definition.getName();
+        return "/" + entityRouteName.toLowerCase();
+    }
+
+    private String apiPathForRelationship(final RelationshipVectorDefinition relationship) {
+        return apiPathForCollection(relationship.getFrom()) + "/{id}/" + relationship.getName();
+    }
+
+    private EntityViewDefinition responseViewFor(final EntityDefinition definition) {
+        return thingifier.guiConfig().dataExplorer().responseViewFor(definition);
+    }
+
+    private boolean isResponseFieldVisible(
+            final EntityDefinition definition, final String fieldName) {
+        final EntityViewDefinition view = responseViewFor(definition);
+        return view == null || view.isResponseVisible(fieldName);
+    }
+
+    private List<String> responseFieldNames(final EntityDefinition definition) {
+        final List<String> fields = new ArrayList<>();
+        for (String fieldName : definition.getFieldNames()) {
+            if (isResponseFieldVisible(definition, fieldName)) {
+                fields.add(fieldName);
+            }
+        }
+        return fields;
+    }
+
+    private List<String> responseFieldNamesForTable(final EntityDefinition definition) {
+        final List<String> fields = new ArrayList<>();
+        if (definition.hasPrimaryKeyField()
+                && isResponseFieldVisible(definition, definition.getPrimaryKeyField().getName())) {
+            fields.add(definition.getPrimaryKeyField().getName());
+        }
+        for (String fieldName : definition.getFieldNames()) {
+            Field field = definition.getField(fieldName);
+            if (field != definition.getPrimaryKeyField()
+                    && (field.getType() == FieldType.AUTO_INCREMENT
+                            || field.getType() == FieldType.AUTO_GUID)
+                    && isResponseFieldVisible(definition, fieldName)) {
+                fields.add(fieldName);
+            }
+        }
+        for (String fieldName : definition.getFieldNames()) {
+            Field field = definition.getField(fieldName);
+            if (field != definition.getPrimaryKeyField()
+                    && field.getType() != FieldType.AUTO_INCREMENT
+                    && field.getType() != FieldType.AUTO_GUID
+                    && isResponseFieldVisible(definition, fieldName)) {
+                fields.add(fieldName);
+            }
+        }
+        return fields;
     }
 
     private String heading(final int level, final String text) {
@@ -426,6 +481,9 @@ public class DefaultGuiHtmlPages {
 
                     for (RelationshipVectorDefinition relationship :
                             definition.related().getRelationships()) {
+                        if (!isRelationshipCollectionVisible(relationship)) {
+                            continue;
+                        }
                         final List<EntityInstance> relatedItems =
                                 store.relationships().listRelated(instance, relationship.getName());
                         html.append("<h3>" + relationship.getName() + "</h3>");
@@ -457,7 +515,9 @@ public class DefaultGuiHtmlPages {
                             new GsonBuilder()
                                     .setPrettyPrinting()
                                     .create()
-                                    .toJson(jsonThing.asJsonObject(instance)));
+                                    .toJson(
+                                            jsonThing.asJsonObject(
+                                                    instance, null, responseViewFor(definition))));
                     html.append("</code>");
                     html.append("</pre>");
                 }
@@ -469,7 +529,8 @@ public class DefaultGuiHtmlPages {
                     // pretty print the json
                     html.append(
                             this.XMLPrettyPrinter.prettyPrintHtml(
-                                    xmlThing.getSingleObjectXml(instance)));
+                                    xmlThing.getSingleObjectXml(
+                                            instance, null, responseViewFor(definition))));
                     html.append("</code>");
                     html.append("</pre>");
                 }
@@ -495,7 +556,7 @@ public class DefaultGuiHtmlPages {
         final EntityDefinition definition = instance.getEntity();
         StringBuilder html = new StringBuilder();
         html.append("<ul>");
-        for (String field : definition.getFieldNames()) {
+        for (String field : responseFieldNames(definition)) {
             html.append(
                     String.format(
                             "<li>%s<ul><li>%s</li></ul></li>",
@@ -517,7 +578,7 @@ public class DefaultGuiHtmlPages {
                 "<table  aria-label='%s Instance Details' aria-describedby='instancetabledescription'>"
                         .formatted(instance.getEntity().getName().toUpperCase()));
         html.append("<thead><tr>");
-        for (String fieldName : definition.getFieldNames()) {
+        for (String fieldName : responseFieldNames(definition)) {
             Field field = definition.getField(fieldName);
             if (field.getType() == FieldType.AUTO_GUID) {
                 if (apiConfig.willResponsesShowPrimaryKeyHeader()) {
@@ -529,7 +590,7 @@ public class DefaultGuiHtmlPages {
         }
         html.append("</tr></thead>");
         html.append("<tbody><tr>");
-        for (String fieldName : definition.getFieldNames()) {
+        for (String fieldName : responseFieldNames(definition)) {
             Field field = definition.getField(fieldName);
             if (field.getType() == FieldType.AUTO_GUID) {
                 if (apiConfig.willResponsesShowPrimaryKeyHeader()) {

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/DefaultGuiHtmlPagesRepositoryTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/DefaultGuiHtmlPagesRepositoryTest.java
@@ -67,4 +67,96 @@ public class DefaultGuiHtmlPagesRepositoryTest {
             Assertions.assertTrue(detailHtml.contains("Repository&nbsp;Todo"), detailHtml);
         }
     }
+
+    @Test
+    public void guiInstancePagesApplyConfiguredExplorerViewsAndApiSpecVisibility() {
+        try (Thingifier thingifier =
+                new Thingifier(new EntityRelModel(SqliteThingStoreProvider.inMemory()))) {
+
+            EntityDefinition cart = thingifier.defineThing("cart", "carts");
+            cart.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT));
+            cart.addField(Field.is("token", FieldType.AUTO_GUID));
+            cart.addField(Field.is("state", FieldType.STRING));
+            cart.defineView("PublicCart").hideResponseFields("token");
+
+            EntityDefinition project = thingifier.defineThing("project", "projects");
+            project.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT));
+            project.addField(Field.is("title", FieldType.STRING));
+
+            EntityDefinition todo = thingifier.defineThing("todo", "todos");
+            todo.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT));
+            todo.addField(Field.is("title", FieldType.STRING));
+            todo.addField(Field.is("secret", FieldType.STRING));
+            todo.defineView("PublicTodo").hideResponseFields("secret");
+
+            EntityDefinition internal =
+                    thingifier.defineThing("internalentity", "internalentities");
+            internal.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT));
+
+            thingifier
+                    .defineRelationship(project, todo, "tasks", Cardinality.ONE_TO_MANY())
+                    .whenReversed(Cardinality.ONE_TO_ONE(), "project");
+            thingifier.defineRelationship(project, todo, "secretTasks", Cardinality.ONE_TO_MANY());
+            thingifier.apiSpec().disableEntityRoutes("/internalentities");
+            thingifier.apiSpec().hideRelationshipRoutes("/projects", "secretTasks");
+            thingifier.guiConfig().dataExplorer().responseView("cart", "PublicCart");
+            thingifier.guiConfig().dataExplorer().responseView("todo", "PublicTodo");
+
+            ThingStore repository = thingifier.getStore(EntityRelModel.DEFAULT_DATABASE_NAME);
+
+            EntityInstance cartInstance =
+                    repository
+                            .entities()
+                            .create(EntityInstanceDraft.forEntity(cart).withField("state", "open"));
+            String token = cartInstance.getFieldValue("token").asString();
+
+            EntityInstance projectInstance =
+                    repository
+                            .entities()
+                            .create(
+                                    EntityInstanceDraft.forEntity(project)
+                                            .withField("title", "Public Project"));
+            EntityInstance todoInstance =
+                    repository
+                            .entities()
+                            .create(
+                                    EntityInstanceDraft.forEntity(todo)
+                                            .withField("title", "Visible Todo")
+                                            .withField("secret", "Hidden Note"));
+
+            repository.relationships().connect(projectInstance, "tasks", todoInstance);
+            repository.relationships().connect(projectInstance, "secretTasks", todoInstance);
+
+            DefaultGuiHtmlPages pages =
+                    new DefaultGuiHtmlPages(new DefaultGUIHTML(), thingifier, "/gui");
+
+            String entitiesHtml = pages.getEntitiesListPage(EntityRelModel.DEFAULT_DATABASE_NAME);
+            Assertions.assertFalse(entitiesHtml.contains("entity=internalentity"), entitiesHtml);
+
+            String cartListHtml =
+                    pages.getInstancesListPage(EntityRelModel.DEFAULT_DATABASE_NAME, "cart");
+            Assertions.assertFalse(cartListHtml.contains("token"), cartListHtml);
+            Assertions.assertFalse(cartListHtml.contains(token), cartListHtml);
+
+            String cartDetailHtml =
+                    pages.getInstanceDetailsPage(
+                            EntityRelModel.DEFAULT_DATABASE_NAME,
+                            "cart",
+                            Map.of("id", cartInstance.getPrimaryKeyValue()));
+            Assertions.assertFalse(cartDetailHtml.contains("token"), cartDetailHtml);
+            Assertions.assertFalse(cartDetailHtml.contains(token), cartDetailHtml);
+
+            String projectDetailHtml =
+                    pages.getInstanceDetailsPage(
+                            EntityRelModel.DEFAULT_DATABASE_NAME,
+                            "project",
+                            Map.of("id", projectInstance.getPrimaryKeyValue()));
+            Assertions.assertTrue(
+                    projectDetailHtml.contains("Visible&nbsp;Todo"), projectDetailHtml);
+            Assertions.assertFalse(projectDetailHtml.contains("secret"), projectDetailHtml);
+            Assertions.assertFalse(
+                    projectDetailHtml.contains("Hidden&nbsp;Note"), projectDetailHtml);
+            Assertions.assertFalse(projectDetailHtml.contains("secretTasks"), projectDetailHtml);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Add Thingifier GUI configuration for Data Explorer response views.
- Project Data Explorer list/detail/relationship output through configured public views.
- Keep entity definitions decoupled from UI/default response-view concerns.

## Validation
- mvn -q -pl ercoremodel,thingifier test
- mvn -q -pl challenger "-Dtest=ShoppingCartApiTest,ShoppingCartDefaultGuiTest,ShoppingCartModelTest" test
