### PR TITLE
Fix PATCH route documentation

### DIFF
--- a/standAloneConfiguredWriteMethodsRestApi/src/test/java/uk/co/compendiumdev/configuredwritemethods/application/ConfiguredWriteMethodsDocumentationTest.java
+++ b/standAloneConfiguredWriteMethodsRestApi/src/test/java/uk/co/compendiumdev/configuredwritemethods/application/ConfiguredWriteMethodsDocumentationTest.java
@@ -7,6 +7,7 @@ import static uk.co.compendiumdev.configuredwritemethods.application.ConfiguredW
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import uk.co.compendiumdev.thingifier.api.docgen.ApiRoutingDefinition;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingDefinition;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 
 class ConfiguredWriteMethodsDocumentationTest {
@@ -39,9 +40,12 @@ class ConfiguredWriteMethodsDocumentationTest {
     @Test
     void exposesPatchAndPutUpdateOnTheInstanceRoute() {
         final ApiRoutingDefinition definition = documentation();
+        final RoutingDefinition patchRoute = route(definition, RoutingVerb.PATCH, "notes/:id");
 
-        Assertions.assertTrue(
-                route(definition, RoutingVerb.PATCH, "notes/:id").status().isReturnedFromCall());
+        Assertions.assertTrue(patchRoute.status().isReturnedFromCall());
+        Assertions.assertEquals(
+                "patch a specific instance of note with a body containing the patch details",
+                patchRoute.getDocumentation());
         Assertions.assertTrue(
                 route(definition, RoutingVerb.PUT, "notes/:id").status().isReturnedFromCall());
     }

--- a/standAloneConfiguredWriteMethodsRestApi/src/test/java/uk/co/compendiumdev/configuredwritemethods/application/ConfiguredWriteMethodsSwaggerTest.java
+++ b/standAloneConfiguredWriteMethodsRestApi/src/test/java/uk/co/compendiumdev/configuredwritemethods/application/ConfiguredWriteMethodsSwaggerTest.java
@@ -30,6 +30,12 @@ class ConfiguredWriteMethodsSwaggerTest {
         Assertions.assertNull(instance.getPost());
         Assertions.assertNotNull(instance.getPatch());
         Assertions.assertNotNull(instance.getPut());
+        Assertions.assertEquals(
+                "patch a specific instance of note with a body containing the patch details",
+                instance.getPatch().getSummary());
+        Assertions.assertEquals(
+                "patch a specific instance of note with a body containing the patch details",
+                instance.getPatch().getDescription());
     }
 
     @Test

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/WriteMethodRoutePolicy.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/WriteMethodRoutePolicy.java
@@ -122,6 +122,11 @@ public final class WriteMethodRoutePolicy {
         ensureStatus(route, 409);
         route.returnPayload(200, entityName);
         route.requestPayload(entityName);
+        replaceMethodNotAllowedDocumentation(
+                route,
+                String.format(
+                        "patch a specific instance of %s with a body containing the patch details",
+                        entityName));
     }
 
     private void returnedEntityPutRoute(
@@ -196,6 +201,13 @@ public final class WriteMethodRoutePolicy {
 
     private void methodNotAllowed(final RoutingDefinition route) {
         route.replaceStatus(RoutingStatus.returnValue(405));
+    }
+
+    private void replaceMethodNotAllowedDocumentation(
+            final RoutingDefinition route, final String documentation) {
+        if ("method not allowed".equals(route.getDocumentation())) {
+            route.addDocumentation(documentation);
+        }
     }
 
     private void ensureStatus(final RoutingDefinition route, final int statusCode) {

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGeneratorTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGeneratorTest.java
@@ -1,5 +1,7 @@
 package uk.co.compendiumdev.thingifier.htmlgui.htmlgen;
 
+import static uk.co.compendiumdev.thingifier.apiconfig.EntityPatchUpdateStyle.PARTIAL_JSON_UPDATE;
+
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -96,6 +98,35 @@ class RestApiDocumentationGeneratorTest {
                 docs.contains(
                         "<li>Whether the task has been completed.</li>\n"
                                 + "<li>Value must be a Boolean (true, false) value</li>"));
+    }
+
+    @Test
+    void apiDocumentationShowsConfiguredPatchInstanceRouteAsSupported() {
+        final Thingifier thingifier = new Thingifier();
+        thingifier.setDocumentation("Task API", "Task API docs.");
+        final EntityDefinition task = thingifier.defineThing("task", "tasks");
+        task.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT));
+        task.addField(Field.is("title", FieldType.STRING));
+        thingifier.apiConfig().writeMethods().entities().patchCan(PARTIAL_JSON_UPDATE);
+
+        final String docs =
+                new RestApiDocumentationGenerator(thingifier, new DefaultGUIHTML())
+                        .getApiDocumentation(
+                                new ApiRoutingDefinitionDocGenerator(thingifier).generate("/api"),
+                                List.of(),
+                                new ThingifierApiDocumentationDefn(),
+                                "/api",
+                                "https://example.com/api/docs");
+
+        Assertions.assertTrue(docs.contains("<strong>PATCH /api/tasks/:id</strong>"));
+        Assertions.assertTrue(
+                docs.contains(
+                        "patch a specific instance of task with a body containing the patch"
+                                + " details"));
+        Assertions.assertFalse(
+                docs.contains(
+                        "<strong>PATCH /api/tasks/:id</strong><ul><li class='normal'>method not"
+                                + " allowed</li></ul>"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Replace the generated `method not allowed` documentation text when a configured entity instance `PATCH` route is promoted to a supported route.
- Add coverage for the Thingifier route definition, rendered HTML docs, and generated OpenAPI PATCH summary/description.

## Validation

- `mvn -q -pl thingifier,standAloneConfiguredWriteMethodsRestApi "-Dtest=RestApiDocumentationGeneratorTest,ConfiguredWriteMethodsDocumentationTest,ConfiguredWriteMethodsSwaggerTest" test`