### PR TITLE
Add JSONPath query support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <swagger-models-version>2.2.52</swagger-models-version>
         <gson-version>2.8.6</gson-version>
         <jackson-version>2.21.1</jackson-version>
+        <jsonpath-version>3.0.0</jsonpath-version>
         <zjsonpatch-version>0.6.3</zjsonpatch-version>
         <sqlite-jdbc-version>3.53.2.0</sqlite-jdbc-version>
         <snakeyaml-version>2.6</snakeyaml-version>

--- a/thingifier/pom.xml
+++ b/thingifier/pom.xml
@@ -79,6 +79,11 @@
           <version>${jackson-version}</version>
       </dependency>
       <dependency>
+          <groupId>com.jayway.jsonpath</groupId>
+          <artifactId>json-path</artifactId>
+          <version>${jsonpath-version}</version>
+      </dependency>
+      <dependency>
           <groupId>io.github.vishwakarma</groupId>
           <artifactId>zjsonpatch</artifactId>
           <version>${zjsonpatch-version}</version>

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/httpserver/ThingifierHttpApiRoutings.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/httpserver/ThingifierHttpApiRoutings.java
@@ -394,7 +394,8 @@ public class ThingifierHttpApiRoutings {
         }
         if (defn.headerValue().contains("QUERY")) {
             response.header(
-                    ThingifierHttpApi.ACCEPT_QUERY_HEADER, ThingifierHttpApi.QUERY_CONTENT_TYPE);
+                    ThingifierHttpApi.ACCEPT_QUERY_HEADER,
+                    ThingifierHttpApi.SUPPORTED_QUERY_CONTENT_TYPES);
         }
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/ThingifierRestAPIHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/ThingifierRestAPIHandler.java
@@ -76,7 +76,13 @@ public class ThingifierRestAPIHandler {
     public ApiResponse query(final ApiRequestEnvelope request) {
         ThingifierRequestContext context = contextFrom(request.headers());
         return withRepository(
-                query.handle(request.path(), request.queryParams(), context), context);
+                query.handle(
+                        request.path(),
+                        request.queryParams(),
+                        request.queryBodyFormat(),
+                        request.body(),
+                        context),
+                context);
     }
 
     public ApiResponse delete(final String url, HttpHeadersBlock headers) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/ApiRoutingDefinitionDocGenerator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/ApiRoutingDefinitionDocGenerator.java
@@ -3,6 +3,7 @@ package uk.co.compendiumdev.thingifier.api.docgen;
 import java.util.HashMap;
 import java.util.Map;
 import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.api.http.ThingifierHttpApi;
 import uk.co.compendiumdev.thingifier.api.response.ResponseHeader;
 import uk.co.compendiumdev.thingifier.apiconfig.ThingifierApiConfig;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
@@ -111,8 +112,9 @@ public class ApiRoutingDefinitionDocGenerator {
 
             defn.addRouting(
                             String.format(
-                                    "query all the instances of %s using application/x-www-form-urlencoded query content",
-                                    entityDefn.getName()),
+                                    "query all the instances of %s using %s query content",
+                                    entityDefn.getName(),
+                                    ThingifierHttpApi.SUPPORTED_QUERY_CONTENT_TYPES),
                             RoutingVerb.QUERY,
                             pluralUrl,
                             RoutingStatus.returnedFromCall())
@@ -123,6 +125,7 @@ public class ApiRoutingDefinitionDocGenerator {
                     .addPossibleStatus(RoutingStatus.returnValue(400))
                     .addPossibleStatus(RoutingStatus.returnValue(413))
                     .addPossibleStatus(RoutingStatus.returnValue(415))
+                    .addPossibleStatus(RoutingStatus.returnValue(422))
                     .setAsFilterableFrom(entityDefn)
                     .returnPayload(200, entityDefn.getPlural());
 
@@ -474,8 +477,12 @@ public class ApiRoutingDefinitionDocGenerator {
 
         defn.addRouting(
                         String.format(
-                                "query all the %s items related to %s, with given %s, by the relationship named %s using application/x-www-form-urlencoded query content",
-                                toName, fromName, uniqueIdFieldName, relationshipName),
+                                "query all the %s items related to %s, with given %s, by the relationship named %s using %s query content",
+                                toName,
+                                fromName,
+                                uniqueIdFieldName,
+                                relationshipName,
+                                ThingifierHttpApi.SUPPORTED_QUERY_CONTENT_TYPES),
                         RoutingVerb.QUERY,
                         aUrl,
                         RoutingStatus.returnedFromCall())
@@ -486,6 +493,7 @@ public class ApiRoutingDefinitionDocGenerator {
                 .addPossibleStatus(RoutingStatus.returnValue(400))
                 .addPossibleStatus(RoutingStatus.returnValue(413))
                 .addPossibleStatus(RoutingStatus.returnValue(415))
+                .addPossibleStatus(RoutingStatus.returnValue(422))
                 .setAsFilterableFrom(relationship.getTo())
                 .returnPayload(200, relationship.getTo().getPlural());
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ApiRequestEnvelope.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ApiRequestEnvelope.java
@@ -4,9 +4,15 @@ import java.util.List;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.BodyParser;
 import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
+import uk.co.compendiumdev.thingifier.api.http.headers.headerparser.ContentTypeHeaderParser;
 import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
 
 public final class ApiRequestEnvelope {
+
+    public enum QueryBodyFormat {
+        URL_ENCODED,
+        JSONPATH
+    }
 
     private final ThingifierHttpApi.HttpVerb verb;
     private final String path;
@@ -14,6 +20,7 @@ public final class ApiRequestEnvelope {
     private final HttpHeadersBlock headers;
     private final ApiBodyFields bodyFields;
     private final String body;
+    private final QueryBodyFormat queryBodyFormat;
 
     private ApiRequestEnvelope(
             final ThingifierHttpApi.HttpVerb verb,
@@ -21,13 +28,15 @@ public final class ApiRequestEnvelope {
             final QueryFilterParams queryParams,
             final HttpHeadersBlock headers,
             final ApiBodyFields bodyFields,
-            final String body) {
+            final String body,
+            final QueryBodyFormat queryBodyFormat) {
         this.verb = verb;
         this.path = path;
         this.queryParams = queryParams;
         this.headers = headers;
         this.bodyFields = bodyFields;
         this.body = body == null ? "" : body;
+        this.queryBodyFormat = queryBodyFormat;
     }
 
     public static ApiRequestEnvelope from(
@@ -39,8 +48,12 @@ public final class ApiRequestEnvelope {
             bodyFields = new BodyParser(request, thingNames).bodyFields();
         }
         QueryFilterParams queryParams = request.getFilterableQueryParams();
+        QueryBodyFormat queryBodyFormat = QueryBodyFormat.URL_ENCODED;
         if (verb == ThingifierHttpApi.HttpVerb.QUERY) {
-            queryParams = queryContentAndUriQueryParams(request);
+            queryBodyFormat = queryBodyFormatFor(request);
+            if (queryBodyFormat == QueryBodyFormat.URL_ENCODED) {
+                queryParams = queryContentAndUriQueryParams(request);
+            }
         }
         return new ApiRequestEnvelope(
                 verb,
@@ -48,7 +61,17 @@ public final class ApiRequestEnvelope {
                 queryParams,
                 request.getHeaders(),
                 bodyFields,
-                request.getBody());
+                request.getBody(),
+                queryBodyFormat);
+    }
+
+    private static QueryBodyFormat queryBodyFormatFor(final HttpApiRequest request) {
+        final ContentTypeHeaderParser contentType =
+                new ContentTypeHeaderParser(request.getContentTypeHeader());
+        if (contentType.isJsonPath()) {
+            return QueryBodyFormat.JSONPATH;
+        }
+        return QueryBodyFormat.URL_ENCODED;
     }
 
     private static QueryFilterParams queryContentAndUriQueryParams(final HttpApiRequest request) {
@@ -80,5 +103,9 @@ public final class ApiRequestEnvelope {
 
     public String body() {
         return body;
+    }
+
+    public QueryBodyFormat queryBodyFormat() {
+        return queryBodyFormat;
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/HttpApiRequestValidator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/HttpApiRequestValidator.java
@@ -1,5 +1,7 @@
 package uk.co.compendiumdev.thingifier.api.http;
 
+import com.jayway.jsonpath.InvalidPathException;
+import com.jayway.jsonpath.JsonPath;
 import java.util.ArrayList;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.BodyParser;
 import uk.co.compendiumdev.thingifier.api.http.headers.headerparser.ContentTypeHeaderParser;
@@ -84,29 +86,40 @@ public class HttpApiRequestValidator {
             return queryContentError(400, "Missing Content-Type for QUERY request");
         }
 
-        if (!contentType.isFormUrlEncoded()) {
+        if (!contentType.isFormUrlEncoded() && !contentType.isJsonPath()) {
             ApiResponse response =
                     queryContentError(
                             this.apiConfig.statusCodes().contentTypeNotSupported(),
                             "Unsupported QUERY Content Type - " + request.getContentTypeHeader());
-            response.setHeader("Accept", ThingifierHttpApi.QUERY_CONTENT_TYPE);
+            response.setHeader("Accept", ThingifierHttpApi.SUPPORTED_QUERY_CONTENT_TYPES);
             return response;
         }
 
         try {
-            new UrlQueryParamParser().parseStrict(request.getBody());
-        } catch (IllegalArgumentException e) {
+            if (contentType.isJsonPath()) {
+                validateJsonPath(request.getBody());
+            } else {
+                new UrlQueryParamParser().parseStrict(request.getBody());
+            }
+        } catch (IllegalArgumentException | InvalidPathException e) {
             return queryContentError(400, e.getMessage());
         }
 
         return null;
     }
 
+    private void validateJsonPath(final String body) {
+        if (body == null || body.trim().isEmpty()) {
+            throw new IllegalArgumentException("Missing JSONPath expression for QUERY request");
+        }
+        JsonPath.compile(body.trim());
+    }
+
     private ApiResponse queryContentError(final int statusCode, final String message) {
         return ApiResponse.error(statusCode, message)
                 .setHeader(
                         ThingifierHttpApi.ACCEPT_QUERY_HEADER,
-                        ThingifierHttpApi.QUERY_CONTENT_TYPE);
+                        ThingifierHttpApi.SUPPORTED_QUERY_CONTENT_TYPES);
     }
 
     public ApiResponse getErrorApiResponse() {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
@@ -30,6 +30,9 @@ public final class ThingifierHttpApi {
     public static final String HTTP_SESSION_HEADER_NAME = "X-THING-HTTP-SESSION-GUID";
     public static final String ACCEPT_QUERY_HEADER = "Accept-Query";
     public static final String QUERY_CONTENT_TYPE = "application/x-www-form-urlencoded";
+    public static final String JSONPATH_QUERY_CONTENT_TYPE = "application/jsonpath";
+    public static final String SUPPORTED_QUERY_CONTENT_TYPES =
+            QUERY_CONTENT_TYPE + ", " + JSONPATH_QUERY_CONTENT_TYPE;
 
     private final Thingifier thingifier;
     private final JsonThing jsonThing;

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/ContentTypeHeaderParser.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/ContentTypeHeaderParser.java
@@ -32,6 +32,10 @@ public class ContentTypeHeaderParser {
         return isMediaType("application/x-www-form-urlencoded");
     }
 
+    public boolean isJsonPath() {
+        return isMediaType("application/jsonpath");
+    }
+
     public boolean isMissing() {
         return (header.isEmpty());
     }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/JsonPathQueryFilter.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/JsonPathQueryFilter.java
@@ -1,0 +1,186 @@
+package uk.co.compendiumdev.thingifier.api.restapihandlers;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.InvalidPathException;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.JsonPathException;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.PathNotFoundException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import uk.co.compendiumdev.thingifier.api.ermodelconversion.JsonThing;
+import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
+import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
+import uk.co.compendiumdev.thingifier.core.query.RepositoryQueryResult;
+
+final class JsonPathQueryFilter {
+
+    private final JsonThing jsonThing;
+
+    JsonPathQueryFilter(final JsonThing jsonThing) {
+        this.jsonThing = jsonThing;
+    }
+
+    ApiResponse filter(
+            final RepositoryQueryResult queryResults,
+            final ThingifierRequestContext context,
+            final String expression) {
+        final EntityDefinition entity = queryResults.resultContainsDefn();
+        if (entity == null || entity.getPrimaryKeyField() == null) {
+            return unsafeSelection();
+        }
+
+        final String json =
+                jsonThing
+                        .asJsonObjectTypedArrayWithContentsUntyped(
+                                queryResults.getListEntityInstances(),
+                                entity.getPlural(),
+                                context.store().relationships())
+                        .toString();
+
+        final Configuration configuration =
+                Configuration.defaultConfiguration().addOptions(Option.ALWAYS_RETURN_LIST);
+        final Object document = configuration.jsonProvider().parse(json);
+
+        try {
+            final Map<String, EntityInstance> instancesByPrimaryKey =
+                    instancesByPrimaryKey(queryResults.getListEntityInstances());
+            final Map<String, Map<?, ?>> jsonResourcesByPrimaryKey =
+                    jsonResourcesByPrimaryKey(configuration, document, entity);
+
+            final Object rawSelected =
+                    JsonPath.using(configuration).parse(document).read(expression.trim());
+            final List<?> selectedResources = normalizeSelectedResources(rawSelected, entity);
+            final List<EntityInstance> matchingInstances = new ArrayList<>();
+
+            for (Object selectedResource : selectedResources) {
+                if (!(selectedResource instanceof Map<?, ?>)) {
+                    return unsafeSelection();
+                }
+
+                final Map<?, ?> selectedResourceMap = (Map<?, ?>) selectedResource;
+                final String primaryKey =
+                        primaryKeyValueFrom(
+                                selectedResourceMap, entity.getPrimaryKeyField().getName());
+                if (primaryKey == null) {
+                    return unsafeSelection();
+                }
+
+                final Map<?, ?> fullResourceMap = jsonResourcesByPrimaryKey.get(primaryKey);
+                final EntityInstance matchingInstance = instancesByPrimaryKey.get(primaryKey);
+                if (fullResourceMap == null
+                        || matchingInstance == null
+                        || !fullResourceMap.equals(selectedResourceMap)) {
+                    return unsafeSelection();
+                }
+
+                matchingInstances.add(matchingInstance);
+            }
+
+            return ApiResponse.success()
+                    .returnInstanceCollection(matchingInstances)
+                    .resultContainsType(entity);
+        } catch (PathNotFoundException e) {
+            return unsafeSelection();
+        } catch (InvalidPathException e) {
+            return ApiResponse.error(400, e.getMessage());
+        } catch (JsonPathException | IllegalArgumentException e) {
+            return unsafeSelection();
+        }
+    }
+
+    private Map<String, EntityInstance> instancesByPrimaryKey(
+            final List<EntityInstance> instances) {
+        final Map<String, EntityInstance> instancesByPrimaryKey = new LinkedHashMap<>();
+        for (EntityInstance instance : instances) {
+            instancesByPrimaryKey.put(instance.getPrimaryKeyValue(), instance);
+        }
+        return instancesByPrimaryKey;
+    }
+
+    private Map<String, Map<?, ?>> jsonResourcesByPrimaryKey(
+            final Configuration configuration,
+            final Object document,
+            final EntityDefinition entity) {
+        final List<?> jsonResources =
+                JsonPath.using(configuration)
+                        .parse(document)
+                        .read("$['" + escapedJsonPathName(entity.getPlural()) + "'][*]");
+        final Map<String, Map<?, ?>> jsonResourcesByPrimaryKey = new LinkedHashMap<>();
+
+        for (Object jsonResource : jsonResources) {
+            if (jsonResource instanceof Map<?, ?>) {
+                final Map<?, ?> jsonResourceMap = (Map<?, ?>) jsonResource;
+                final String primaryKey =
+                        primaryKeyValueFrom(jsonResourceMap, entity.getPrimaryKeyField().getName());
+                if (primaryKey != null) {
+                    jsonResourcesByPrimaryKey.put(primaryKey, jsonResourceMap);
+                }
+            }
+        }
+
+        return jsonResourcesByPrimaryKey;
+    }
+
+    private List<?> normalizeSelectedResources(
+            final Object rawSelected, final EntityDefinition entity) {
+        final List<?> selectedList = asList(rawSelected);
+        final List<Object> resources = new ArrayList<>();
+
+        for (Object selectedItem : selectedList) {
+            if (selectedItem instanceof List<?>) {
+                resources.addAll((List<?>) selectedItem);
+                continue;
+            }
+
+            if (selectedItem instanceof Map<?, ?>) {
+                final Map<?, ?> selectedMap = (Map<?, ?>) selectedItem;
+                Object wrappedCollection = selectedMap.get(entity.getPlural());
+                if (wrappedCollection instanceof List<?>) {
+                    resources.addAll((List<?>) wrappedCollection);
+                    continue;
+                }
+            }
+
+            resources.add(selectedItem);
+        }
+
+        return resources;
+    }
+
+    private List<?> asList(final Object rawSelected) {
+        if (rawSelected instanceof List<?>) {
+            return (List<?>) rawSelected;
+        }
+        return List.of(rawSelected);
+    }
+
+    private String primaryKeyValueFrom(final Map<?, ?> resource, final String primaryKeyName) {
+        if (!resource.containsKey(primaryKeyName)) {
+            return null;
+        }
+
+        final Object value = resource.get(primaryKeyName);
+        if (value instanceof Number) {
+            return new BigDecimal(value.toString()).stripTrailingZeros().toPlainString();
+        }
+        if (value == null) {
+            return null;
+        }
+        return value.toString();
+    }
+
+    private String escapedJsonPathName(final String name) {
+        return name.replace("\\", "\\\\").replace("'", "\\'");
+    }
+
+    private ApiResponse unsafeSelection() {
+        return ApiResponse.error(
+                422, "JSONPath query must select complete resource objects from the collection");
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiGetHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiGetHandler.java
@@ -61,7 +61,8 @@ public class RestApiGetHandler {
         ApiResponse response = apiMapper.map(url, queryResults);
         if (route instanceof CollectionRoute || route instanceof RelationshipCollectionRoute) {
             response.setHeader(
-                    ThingifierHttpApi.ACCEPT_QUERY_HEADER, ThingifierHttpApi.QUERY_CONTENT_TYPE);
+                    ThingifierHttpApi.ACCEPT_QUERY_HEADER,
+                    ThingifierHttpApi.SUPPORTED_QUERY_CONTENT_TYPES);
         }
         return response;
     }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandler.java
@@ -11,6 +11,8 @@ import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.Relationshi
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.RelationshipInstanceRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRouteMapper;
+import uk.co.compendiumdev.thingifier.api.ermodelconversion.JsonThing;
+import uk.co.compendiumdev.thingifier.api.http.ApiRequestEnvelope;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierHttpApi;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
@@ -28,6 +30,16 @@ public final class RestApiQueryHandler {
     public ApiResponse handle(
             final String url,
             final QueryFilterParams queryParams,
+            final ThingifierRequestContext context) {
+        return handle(
+                url, queryParams, ApiRequestEnvelope.QueryBodyFormat.URL_ENCODED, "", context);
+    }
+
+    public ApiResponse handle(
+            final String url,
+            final QueryFilterParams queryParams,
+            final ApiRequestEnvelope.QueryBodyFormat queryBodyFormat,
+            final String queryBody,
             final ThingifierRequestContext context) {
         ThingReadResultApiMapper apiMapper = new ThingReadResultApiMapper(runtime.apiConfig());
         ThingRoute route = new ThingRouteMapper(runtime.schema()).map(url);
@@ -61,14 +73,27 @@ public final class RestApiQueryHandler {
 
         RepositoryQueryResult queryResults =
                 runtime.queryService().execute(mapping.getQuery(), context.store(), false);
-        return apiMapper
-                .map(url, queryResults)
-                .setHeader(
-                        ThingifierHttpApi.ACCEPT_QUERY_HEADER,
-                        ThingifierHttpApi.QUERY_CONTENT_TYPE);
+        ApiResponse response = apiMapper.map(url, queryResults);
+        if (response.isErrorResponse()) {
+            return advertiseQuery(response);
+        }
+
+        if (queryBodyFormat == ApiRequestEnvelope.QueryBodyFormat.JSONPATH) {
+            response =
+                    new JsonPathQueryFilter(new JsonThing(runtime.apiConfig().jsonOutput()))
+                            .filter(queryResults, context, queryBody);
+        }
+
+        return advertiseQuery(response);
     }
 
     private ApiResponse methodNotAllowed(final String allowHeader) {
         return ApiResponse.error(405, "Method Not Allowed").setHeader("Allow", allowHeader);
+    }
+
+    private ApiResponse advertiseQuery(final ApiResponse response) {
+        return response.setHeader(
+                ThingifierHttpApi.ACCEPT_QUERY_HEADER,
+                ThingifierHttpApi.SUPPORTED_QUERY_CONTENT_TYPES);
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGenerator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGenerator.java
@@ -529,7 +529,7 @@ public class RestApiDocumentationGenerator {
                         output.append(
                                 paragraph(
                                         "QUERY content uses <i>Content-Type: "
-                                                + ThingifierHttpApi.QUERY_CONTENT_TYPE
+                                                + ThingifierHttpApi.SUPPORTED_QUERY_CONTENT_TYPES
                                                 + "</i> with fields such as <i>title=Task&amp;"
                                                 + SortByFieldName.PARAMETER_NAME
                                                 + "=-id</i>."));

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/OpenApi32Finalizer.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/OpenApi32Finalizer.java
@@ -69,6 +69,17 @@ public final class OpenApi32Finalizer {
         if (!formMediaType.has("schema") || !formMediaType.get("schema").isJsonObject()) {
             formMediaType.add("schema", permissiveFormSchema());
         }
+
+        JsonObject jsonPathMediaType =
+                objectAt(content, ThingifierHttpApi.JSONPATH_QUERY_CONTENT_TYPE);
+        if (jsonPathMediaType == null) {
+            jsonPathMediaType = new JsonObject();
+            content.add(ThingifierHttpApi.JSONPATH_QUERY_CONTENT_TYPE, jsonPathMediaType);
+        }
+
+        if (!jsonPathMediaType.has("schema") || !jsonPathMediaType.get("schema").isJsonObject()) {
+            jsonPathMediaType.add("schema", stringSchema());
+        }
     }
 
     private JsonObject permissiveFormSchema() {
@@ -77,6 +88,12 @@ public final class OpenApi32Finalizer {
         final JsonObject additionalProperties = new JsonObject();
         additionalProperties.addProperty("type", "string");
         schema.add("additionalProperties", additionalProperties);
+        return schema;
+    }
+
+    private JsonObject stringSchema() {
+        final JsonObject schema = new JsonObject();
+        schema.addProperty("type", "string");
         return schema;
     }
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/Swaggerizer.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/Swaggerizer.java
@@ -504,7 +504,10 @@ public class Swaggerizer {
             case QUERY:
                 operation.addExtension("x-http-method", "QUERY");
                 operation.addExtension(
-                        "x-query-content-types", List.of(ThingifierHttpApi.QUERY_CONTENT_TYPE));
+                        "x-query-content-types",
+                        List.of(
+                                ThingifierHttpApi.QUERY_CONTENT_TYPE,
+                                ThingifierHttpApi.JSONPATH_QUERY_CONTENT_TYPE));
                 path.addExtension("x-query-operation", operation);
                 break;
             case PATCH:

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/docgen/ApiRoutingDefinitionDocGeneratorTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/docgen/ApiRoutingDefinitionDocGeneratorTest.java
@@ -30,7 +30,8 @@ public class ApiRoutingDefinitionDocGeneratorTest {
         RoutingDefinition query = route(definition, RoutingVerb.QUERY, "todos");
         RoutingDefinition options = route(definition, RoutingVerb.OPTIONS, "todos");
 
-        Assertions.assertTrue(statuses(query).containsAll(Set.of(200, 400, 413, 415)));
+        Assertions.assertTrue(statuses(query).containsAll(Set.of(200, 400, 413, 415, 422)));
+        Assertions.assertTrue(query.getDocumentation().contains("application/jsonpath"));
         Assertions.assertEquals("OPTIONS, GET, HEAD, POST, QUERY", options.headerValue());
     }
 
@@ -93,7 +94,7 @@ public class ApiRoutingDefinitionDocGeneratorTest {
                 route(definition, RoutingVerb.QUERY, "todos/:id/tasksof").getReturnPayloadFor(200));
         Assertions.assertTrue(
                 statuses(route(definition, RoutingVerb.QUERY, "projects/:id/tasks"))
-                        .containsAll(Set.of(200, 400, 413, 415)));
+                        .containsAll(Set.of(200, 400, 413, 415, 422)));
         Assertions.assertEquals(
                 "OPTIONS, GET, HEAD, POST, QUERY",
                 route(definition, RoutingVerb.OPTIONS, "projects/:id/tasks").headerValue());

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/requests/ThingifierHttpApiAdditionalRepresentationsTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/requests/ThingifierHttpApiAdditionalRepresentationsTest.java
@@ -54,6 +54,27 @@ class ThingifierHttpApiAdditionalRepresentationsTest {
         }
     }
 
+    @Test
+    void jsonPathQuerySelectsAdditionalResponseRepresentationsFromAcceptHeader() {
+        Thingifier thingifier = taskThingifier();
+        createTask(thingifier, "Task");
+        ThingifierHttpApi api = new ThingifierHttpApi(thingifier);
+
+        for (Map.Entry<String, String> expected : expectedBodies().entrySet()) {
+            HttpApiRequest request =
+                    new HttpApiRequest("tasks")
+                            .addHeader(
+                                    "Content-Type", ThingifierHttpApi.JSONPATH_QUERY_CONTENT_TYPE)
+                            .addHeader("Accept", expected.getKey())
+                            .setBody("$.tasks[?(@.title == 'Task')]");
+            HttpApiResponse response = api.queryRequest(request);
+
+            Assertions.assertEquals(200, response.getStatusCode());
+            Assertions.assertEquals(expected.getKey(), response.getType());
+            Assertions.assertEquals(expected.getValue(), response.getBody());
+        }
+    }
+
     private Map<String, String> expectedBodies() {
         Map<String, String> expectedBodies = new LinkedHashMap<>();
         expectedBodies.put("text/csv", "id,title\n1,Task");

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandlerTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandlerTest.java
@@ -32,7 +32,7 @@ public class RestApiQueryHandlerTest {
         Assertions.assertEquals(
                 matching, response.apiResponse().getReturnedInstanceCollection().get(0));
         Assertions.assertEquals(
-                ThingifierHttpApi.QUERY_CONTENT_TYPE,
+                ThingifierHttpApi.SUPPORTED_QUERY_CONTENT_TYPES,
                 response.getHeaders().get(ThingifierHttpApi.ACCEPT_QUERY_HEADER));
     }
 
@@ -153,7 +153,7 @@ public class RestApiQueryHandlerTest {
 
         Assertions.assertEquals(400, response.getStatusCode());
         Assertions.assertEquals(
-                ThingifierHttpApi.QUERY_CONTENT_TYPE,
+                ThingifierHttpApi.SUPPORTED_QUERY_CONTENT_TYPES,
                 response.getHeaders().get(ThingifierHttpApi.ACCEPT_QUERY_HEADER));
     }
 
@@ -169,9 +169,10 @@ public class RestApiQueryHandlerTest {
 
         Assertions.assertEquals(415, response.getStatusCode());
         Assertions.assertEquals(
-                ThingifierHttpApi.QUERY_CONTENT_TYPE, response.getHeaders().get("Accept"));
+                ThingifierHttpApi.SUPPORTED_QUERY_CONTENT_TYPES,
+                response.getHeaders().get("Accept"));
         Assertions.assertEquals(
-                ThingifierHttpApi.QUERY_CONTENT_TYPE,
+                ThingifierHttpApi.SUPPORTED_QUERY_CONTENT_TYPES,
                 response.getHeaders().get(ThingifierHttpApi.ACCEPT_QUERY_HEADER));
     }
 
@@ -237,8 +238,163 @@ public class RestApiQueryHandlerTest {
 
         Assertions.assertEquals(200, response.getStatusCode());
         Assertions.assertEquals(
-                ThingifierHttpApi.QUERY_CONTENT_TYPE,
+                ThingifierHttpApi.SUPPORTED_QUERY_CONTENT_TYPES,
                 response.getHeaders().get(ThingifierHttpApi.ACCEPT_QUERY_HEADER));
+    }
+
+    @Test
+    public void jsonPathQueryEntityCollectionFiltersByDoneStatus() {
+        Thingifier thingifier = todoThingifier();
+        EntityInstance matching = createTodo(thingifier, "Keep", "false", "Open item");
+        createTodo(thingifier, "Skip", "true", "Closed item");
+
+        HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .queryRequest(jsonPathQuery("todos", "$.todos[?(@.doneStatus == false)]"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertTrue(response.apiResponse().isCollection());
+        Assertions.assertEquals(1, response.apiResponse().getReturnedInstanceCollection().size());
+        Assertions.assertEquals(
+                matching, response.apiResponse().getReturnedInstanceCollection().get(0));
+        Assertions.assertEquals(
+                ThingifierHttpApi.SUPPORTED_QUERY_CONTENT_TYPES,
+                response.getHeaders().get(ThingifierHttpApi.ACCEPT_QUERY_HEADER));
+    }
+
+    @Test
+    public void jsonPathQueryEntityCollectionFiltersById() {
+        Thingifier thingifier = todoThingifier();
+        createTodo(thingifier, "First", "false", "One");
+        EntityInstance matching = createTodo(thingifier, "Second", "true", "Two");
+
+        HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .queryRequest(jsonPathQuery("todos", "$.todos[?(@.id == 2)]"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(1, response.apiResponse().getReturnedInstanceCollection().size());
+        Assertions.assertEquals(
+                matching, response.apiResponse().getReturnedInstanceCollection().get(0));
+    }
+
+    @Test
+    public void jsonPathQueryEntityCollectionFiltersByTitleAndDescription() {
+        Thingifier thingifier = todoThingifier();
+        EntityInstance matching = createTodo(thingifier, "Keep", "false", "Detailed");
+        createTodo(thingifier, "Keep", "false", "Other");
+        createTodo(thingifier, "Skip", "false", "Detailed");
+
+        HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .queryRequest(
+                                jsonPathQuery(
+                                        "todos",
+                                        "$.todos[?(@.title == 'Keep' && @.description == 'Detailed')]"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(1, response.apiResponse().getReturnedInstanceCollection().size());
+        Assertions.assertEquals(
+                matching, response.apiResponse().getReturnedInstanceCollection().get(0));
+    }
+
+    @Test
+    public void jsonPathQueryCanSelectCollectionArray() {
+        Thingifier thingifier = todoThingifier();
+        EntityInstance first = createTodo(thingifier, "First", "false", "One");
+        EntityInstance second = createTodo(thingifier, "Second", "true", "Two");
+
+        HttpApiResponse response =
+                new ThingifierHttpApi(thingifier).queryRequest(jsonPathQuery("todos", "$.todos"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(2, response.apiResponse().getReturnedInstanceCollection().size());
+        Assertions.assertTrue(
+                response.apiResponse().getReturnedInstanceCollection().contains(first));
+        Assertions.assertTrue(
+                response.apiResponse().getReturnedInstanceCollection().contains(second));
+    }
+
+    @Test
+    public void jsonPathQueryWithNoMatchesReturnsEmptyCollection() {
+        Thingifier thingifier = todoThingifier();
+        createTodo(thingifier, "One", "false", "Open item");
+
+        HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .queryRequest(jsonPathQuery("todos", "$.todos[?(@.title == 'Missing')]"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertTrue(response.apiResponse().isCollection());
+        Assertions.assertEquals(0, response.apiResponse().getReturnedInstanceCollection().size());
+    }
+
+    @Test
+    public void jsonPathQueryRelationshipCollectionFiltersRelatedInstancesOnly() {
+        Thingifier thingifier = taskProjectThingifier();
+        ThingStore store = storeFor(thingifier);
+        EntityInstance project = createProject(thingifier, "Project");
+        EntityInstance matching = createTask(thingifier, "Keep", "Open");
+        EntityInstance relatedButFilteredOut = createTask(thingifier, "Skip", "Open");
+        createTask(thingifier, "Keep", "Open");
+        store.relationships().connect(project, "tasks", matching);
+        store.relationships().connect(project, "tasks", relatedButFilteredOut);
+
+        HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .queryRequest(
+                                jsonPathQuery(
+                                        "projects/" + project.getPrimaryKeyValue() + "/tasks",
+                                        "$.tasks[?(@.title == 'Keep')]"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(1, response.apiResponse().getReturnedInstanceCollection().size());
+        Assertions.assertEquals(
+                matching, response.apiResponse().getReturnedInstanceCollection().get(0));
+    }
+
+    @Test
+    public void malformedJsonPathQueryContentIsBadRequest() {
+        Thingifier thingifier = todoThingifier();
+
+        HttpApiResponse response =
+                new ThingifierHttpApi(thingifier).queryRequest(jsonPathQuery("todos", "$[?"));
+
+        Assertions.assertEquals(400, response.getStatusCode());
+    }
+
+    @Test
+    public void emptyJsonPathQueryContentIsBadRequest() {
+        Thingifier thingifier = todoThingifier();
+
+        HttpApiResponse response =
+                new ThingifierHttpApi(thingifier).queryRequest(jsonPathQuery("todos", ""));
+
+        Assertions.assertEquals(400, response.getStatusCode());
+    }
+
+    @Test
+    public void jsonPathQueryProjectionIsUnprocessable() {
+        Thingifier thingifier = todoThingifier();
+        createTodo(thingifier, "Task", "false", "Open item");
+
+        HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .queryRequest(jsonPathQuery("todos", "$.todos[*].title"));
+
+        Assertions.assertEquals(422, response.getStatusCode());
+    }
+
+    @Test
+    public void jsonPathQueryPartialObjectProjectionIsUnprocessable() {
+        Thingifier thingifier = todoThingifier();
+        createTodo(thingifier, "Task", "false", "Open item");
+
+        HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .queryRequest(jsonPathQuery("todos", "$.todos[*]['id','title']"));
+
+        Assertions.assertEquals(422, response.getStatusCode());
     }
 
     private Thingifier taskProjectThingifier() {
@@ -255,6 +411,16 @@ public class RestApiQueryHandlerTest {
         thingifier
                 .defineRelationship(project, task, "tasks", Cardinality.ONE_TO_MANY())
                 .whenReversed(Cardinality.ONE_TO_ONE(), "task-of");
+        return thingifier;
+    }
+
+    private Thingifier todoThingifier() {
+        Thingifier thingifier = new Thingifier();
+        EntityDefinition todo = thingifier.defineThing("todo", "todos");
+        todo.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT));
+        todo.addField(Field.is("title", FieldType.STRING));
+        todo.addField(Field.is("doneStatus", FieldType.BOOLEAN));
+        todo.addField(Field.is("description", FieldType.STRING));
         return thingifier;
     }
 
@@ -276,6 +442,21 @@ public class RestApiQueryHandlerTest {
                 .create(EntityInstanceDraft.forEntity(project).withField("title", title));
     }
 
+    private EntityInstance createTodo(
+            final Thingifier thingifier,
+            final String title,
+            final String doneStatus,
+            final String description) {
+        EntityDefinition todo = thingifier.getDefinitionNamed("todo");
+        return storeFor(thingifier)
+                .entities()
+                .create(
+                        EntityInstanceDraft.forEntity(todo)
+                                .withField("title", title)
+                                .withField("doneStatus", doneStatus)
+                                .withField("description", description));
+    }
+
     private ThingStore storeFor(final Thingifier thingifier) {
         return thingifier.getStore(EntityRelModel.DEFAULT_DATABASE_NAME);
     }
@@ -283,6 +464,12 @@ public class RestApiQueryHandlerTest {
     private HttpApiRequest query(final String path, final String body) {
         return new HttpApiRequest(path)
                 .addHeader("Content-Type", ThingifierHttpApi.QUERY_CONTENT_TYPE)
+                .setBody(body);
+    }
+
+    private HttpApiRequest jsonPathQuery(final String path, final String body) {
+        return new HttpApiRequest(path)
+                .addHeader("Content-Type", ThingifierHttpApi.JSONPATH_QUERY_CONTENT_TYPE)
                 .setBody(body);
     }
 }

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/OpenApi32FinalizerTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/OpenApi32FinalizerTest.java
@@ -26,7 +26,8 @@ class OpenApi32FinalizerTest {
                         "summary": "query todos",
                         "x-http-method": "QUERY",
                         "x-query-content-types": [
-                          "application/x-www-form-urlencoded"
+                          "application/x-www-form-urlencoded",
+                          "application/jsonpath"
                         ],
                         "responses": {
                           "200": {
@@ -48,6 +49,10 @@ class OpenApi32FinalizerTest {
                 query.getAsJsonObject("requestBody")
                         .getAsJsonObject("content")
                         .getAsJsonObject("application/x-www-form-urlencoded");
+        final JsonObject jsonPathMediaType =
+                query.getAsJsonObject("requestBody")
+                        .getAsJsonObject("content")
+                        .getAsJsonObject("application/jsonpath");
 
         Assertions.assertEquals("3.2.0", document.get("openapi").getAsString());
         Assertions.assertTrue(todos.has("get"));
@@ -66,6 +71,8 @@ class OpenApi32FinalizerTest {
                         .getAsJsonObject("additionalProperties")
                         .get("type")
                         .getAsString());
+        Assertions.assertEquals(
+                "string", jsonPathMediaType.getAsJsonObject("schema").get("type").getAsString());
     }
 
     @Test
@@ -118,5 +125,13 @@ class OpenApi32FinalizerTest {
                         .getAsJsonObject("schema")
                         .getAsJsonObject("properties")
                         .has("title"));
+        Assertions.assertEquals(
+                "string",
+                query.getAsJsonObject("requestBody")
+                        .getAsJsonObject("content")
+                        .getAsJsonObject("application/jsonpath")
+                        .getAsJsonObject("schema")
+                        .get("type")
+                        .getAsString());
     }
 }

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerEntityDescriptionTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerEntityDescriptionTest.java
@@ -124,10 +124,12 @@ class SwaggerizerEntityDescriptionTest {
         assertPagingParameters(openApi.getPaths().get("/projects").getGet());
         assertSortByParameter(queryOperation(openApi.getPaths().get("/projects")));
         assertPagingParameters(queryOperation(openApi.getPaths().get("/projects")));
+        assertQueryContentTypes(queryOperation(openApi.getPaths().get("/projects")));
         assertSortByParameter(openApi.getPaths().get("/projects/{id}/tasks").getGet());
         assertPagingParameters(openApi.getPaths().get("/projects/{id}/tasks").getGet());
         assertSortByParameter(queryOperation(openApi.getPaths().get("/projects/{id}/tasks")));
         assertPagingParameters(queryOperation(openApi.getPaths().get("/projects/{id}/tasks")));
+        assertQueryContentTypes(queryOperation(openApi.getPaths().get("/projects/{id}/tasks")));
 
         Operation singleTargetRelationshipGet =
                 openApi.getPaths().get("/todos/{id}/project").getGet();
@@ -221,5 +223,12 @@ class SwaggerizerEntityDescriptionTest {
         Assertions.assertFalse(offset.getRequired());
         Assertions.assertEquals(0, offset.getExample());
         Assertions.assertTrue(offset.getDescription().contains("Zero-based"));
+    }
+
+    private void assertQueryContentTypes(final Operation operation) {
+        Object contentTypes = operation.getExtensions().get("x-query-content-types");
+        Assertions.assertTrue(contentTypes instanceof List<?>);
+        Assertions.assertEquals(
+                List.of("application/x-www-form-urlencoded", "application/jsonpath"), contentTypes);
     }
 }


### PR DESCRIPTION
## Summary
- Add `application/jsonpath` as a supported `QUERY` body format alongside URL-encoded query bodies.
- Evaluate JSONPath against the same collection-shaped JSON returned by `GET`, returning complete entity collections only.
- Advertise both query content types through `Accept-Query`, docs, and OpenAPI query metadata.

## Verification
- `mvn -pl thingifier spotless:check`
- `mvn -pl thingifier test` (513 tests, 0 failures)

diff checks passed locally before merge.