### PR TITLE
Single-source query content types

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
@@ -31,8 +31,10 @@ public final class ThingifierHttpApi {
     public static final String ACCEPT_QUERY_HEADER = "Accept-Query";
     public static final String QUERY_CONTENT_TYPE = "application/x-www-form-urlencoded";
     public static final String JSONPATH_QUERY_CONTENT_TYPE = "application/jsonpath";
+    public static final List<String> SUPPORTED_QUERY_CONTENT_TYPES_LIST =
+            List.of(QUERY_CONTENT_TYPE, JSONPATH_QUERY_CONTENT_TYPE);
     public static final String SUPPORTED_QUERY_CONTENT_TYPES =
-            QUERY_CONTENT_TYPE + ", " + JSONPATH_QUERY_CONTENT_TYPE;
+            String.join(", ", SUPPORTED_QUERY_CONTENT_TYPES_LIST);
 
     private final Thingifier thingifier;
     private final JsonThing jsonThing;

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/Swaggerizer.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/Swaggerizer.java
@@ -505,9 +505,7 @@ public class Swaggerizer {
                 operation.addExtension("x-http-method", "QUERY");
                 operation.addExtension(
                         "x-query-content-types",
-                        List.of(
-                                ThingifierHttpApi.QUERY_CONTENT_TYPE,
-                                ThingifierHttpApi.JSONPATH_QUERY_CONTENT_TYPE));
+                        ThingifierHttpApi.SUPPORTED_QUERY_CONTENT_TYPES_LIST);
                 path.addExtension("x-query-operation", operation);
                 break;
             case PATCH:


### PR DESCRIPTION
## Summary
- Add `SUPPORTED_QUERY_CONTENT_TYPES_LIST` as the authoritative query media-type set.
- Derive the `Accept-Query` header string with `String.join`.
- Reuse the shared list for OpenAPI `x-query-content-types` generation.

## Verification
- `mvn -pl thingifier '-Dtest=RestApiQueryHandlerTest,SwaggerizerEntityDescriptionTest,OpenApi32FinalizerTest' test` (31 tests, 0 failures)
- `mvn -pl thingifier spotless:check`
- `git diff --check`

Follow-up to #105.