### PR TITLE
Clarify QUERY body format docs

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGenerator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGenerator.java
@@ -528,11 +528,18 @@ public class RestApiDocumentationGenerator {
                     if (routingDefn.verb() == RoutingVerb.QUERY) {
                         output.append(
                                 paragraph(
-                                        "QUERY content uses <i>Content-Type: "
-                                                + ThingifierHttpApi.SUPPORTED_QUERY_CONTENT_TYPES
+                                        "QUERY form content uses <i>Content-Type: "
+                                                + ThingifierHttpApi.QUERY_CONTENT_TYPE
                                                 + "</i> with fields such as <i>title=Task&amp;"
                                                 + SortByFieldName.PARAMETER_NAME
                                                 + "=-id</i>."));
+                        output.append(
+                                paragraph(
+                                        "QUERY JSONPath content uses <i>Content-Type: "
+                                                + ThingifierHttpApi.JSONPATH_QUERY_CONTENT_TYPE
+                                                + "</i> with an expression such as <i>"
+                                                + jsonPathQueryExampleFor(routingDefn)
+                                                + "</i>."));
                     }
                 }
             }
@@ -965,6 +972,43 @@ public class RestApiDocumentationGenerator {
 
     private String acceptHeaderExample(final AcceptHeaderParser.ACCEPT_TYPE responseType) {
         return String.format("<i>Accept: %s</i>", responseType.mediaType());
+    }
+
+    private String jsonPathQueryExampleFor(final RoutingDefinition routingDefn) {
+        final EntityDefinition entity = routingDefn.getFilterableEntity();
+        if (entity == null) {
+            return "$[*]";
+        }
+
+        final String fieldName =
+                entity.getField("title") == null ? exampleFieldNameFor(entity) : "title";
+        return "$."
+                + entity.getPlural()
+                + "[?@."
+                + fieldName
+                + " == '"
+                + exampleValueFor(fieldName)
+                + "']";
+    }
+
+    private String exampleFieldNameFor(final EntityDefinition entity) {
+        final Field primaryKeyField = entity.getPrimaryKeyField();
+        if (primaryKeyField != null) {
+            return primaryKeyField.getName();
+        }
+
+        for (String fieldName : entity.getFieldNames()) {
+            return fieldName;
+        }
+
+        return "field";
+    }
+
+    private String exampleValueFor(final String fieldName) {
+        if ("title".equals(fieldName)) {
+            return "Task";
+        }
+        return "value";
     }
 
     private String paragraph(final String initialParagraph) {

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGeneratorTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGeneratorTest.java
@@ -233,8 +233,19 @@ class RestApiDocumentationGeneratorTest {
         Assertions.assertTrue(docs.contains("<i>_sortBy=-field</i>"));
         Assertions.assertTrue(docs.contains("<i>_sortBy=+field,-other</i>"));
         Assertions.assertTrue(docs.contains("/api/tasks?_sortBy=+id"));
+        Assertions.assertTrue(
+                docs.contains(
+                        "QUERY form content uses <i>Content-Type:"
+                                + " application/x-www-form-urlencoded</i>"));
         Assertions.assertTrue(docs.contains("title=Task&amp;_sortBy=-id"));
+        Assertions.assertTrue(
+                docs.contains(
+                        "QUERY JSONPath content uses <i>Content-Type: application/jsonpath</i>"));
+        Assertions.assertTrue(docs.contains("$.tasks[?@.title == 'Task']"));
         Assertions.assertFalse(docs.contains("&amp;sortBy=-id"));
+        Assertions.assertFalse(
+                docs.contains(
+                        "application/x-www-form-urlencoded, application/jsonpath</i> with fields"));
         Assertions.assertTrue(docs.contains("<i>_limit=limit</i>"));
         Assertions.assertTrue(docs.contains("<i>_offset=offset</i>"));
         Assertions.assertTrue(docs.contains("default limit is 10"));


### PR DESCRIPTION
## Summary
- Split QUERY documentation examples by body format.
- Keep the `title=Task&_sortBy=-id` example tied to `application/x-www-form-urlencoded` only.
- Add a separate JSONPath expression example for `application/jsonpath` bodies.

## Verification
- `mvn -pl thingifier '-Dtest=RestApiDocumentationGeneratorTest' test` (12 tests, 0 failures)
- `mvn -pl thingifier spotless:check`
- `git diff --check`

Follow-up to #105.