### PR TITLE
Apply response views to JSONPath queries

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/JsonPathQueryFilter.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/JsonPathQueryFilter.java
@@ -6,15 +6,14 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.Option;
 import com.jayway.jsonpath.PathNotFoundException;
-import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import uk.co.compendiumdev.thingifier.api.ermodelconversion.JsonThing;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityViewDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
 import uk.co.compendiumdev.thingifier.core.query.RepositoryQueryResult;
 
@@ -29,7 +28,8 @@ final class JsonPathQueryFilter {
     ApiResponse filter(
             final RepositoryQueryResult queryResults,
             final ThingifierRequestContext context,
-            final String expression) {
+            final String expression,
+            final EntityViewDefinition responseView) {
         final EntityDefinition entity = queryResults.resultContainsDefn();
         if (entity == null || entity.getPrimaryKeyField() == null) {
             return unsafeSelection();
@@ -40,7 +40,8 @@ final class JsonPathQueryFilter {
                         .asJsonObjectTypedArrayWithContentsUntyped(
                                 queryResults.getListEntityInstances(),
                                 entity.getPlural(),
-                                context.store().relationships())
+                                context.store().relationships(),
+                                responseView)
                         .toString();
 
         final Configuration configuration =
@@ -48,10 +49,9 @@ final class JsonPathQueryFilter {
         final Object document = configuration.jsonProvider().parse(json);
 
         try {
-            final Map<String, EntityInstance> instancesByPrimaryKey =
-                    instancesByPrimaryKey(queryResults.getListEntityInstances());
-            final Map<String, Map<?, ?>> jsonResourcesByPrimaryKey =
-                    jsonResourcesByPrimaryKey(configuration, document, entity);
+            final List<ProjectedResource> projectedResources =
+                    projectedResources(
+                            configuration, document, entity, queryResults.getListEntityInstances());
 
             final Object rawSelected =
                     JsonPath.using(configuration).parse(document).read(expression.trim());
@@ -64,27 +64,23 @@ final class JsonPathQueryFilter {
                 }
 
                 final Map<?, ?> selectedResourceMap = (Map<?, ?>) selectedResource;
-                final String primaryKey =
-                        primaryKeyValueFrom(
-                                selectedResourceMap, entity.getPrimaryKeyField().getName());
-                if (primaryKey == null) {
-                    return unsafeSelection();
-                }
-
-                final Map<?, ?> fullResourceMap = jsonResourcesByPrimaryKey.get(primaryKey);
-                final EntityInstance matchingInstance = instancesByPrimaryKey.get(primaryKey);
-                if (fullResourceMap == null
-                        || matchingInstance == null
-                        || !fullResourceMap.equals(selectedResourceMap)) {
+                final EntityInstance matchingInstance =
+                        matchingInstanceFor(selectedResourceMap, projectedResources);
+                if (matchingInstance == null) {
                     return unsafeSelection();
                 }
 
                 matchingInstances.add(matchingInstance);
             }
 
-            return ApiResponse.success()
-                    .returnInstanceCollection(matchingInstances)
-                    .resultContainsType(entity);
+            final ApiResponse response =
+                    ApiResponse.success()
+                            .returnInstanceCollection(matchingInstances)
+                            .resultContainsType(entity);
+            if (responseView != null) {
+                response.usingEntityView(responseView);
+            }
+            return response;
         } catch (PathNotFoundException e) {
             return unsafeSelection();
         } catch (InvalidPathException e) {
@@ -94,37 +90,47 @@ final class JsonPathQueryFilter {
         }
     }
 
-    private Map<String, EntityInstance> instancesByPrimaryKey(
-            final List<EntityInstance> instances) {
-        final Map<String, EntityInstance> instancesByPrimaryKey = new LinkedHashMap<>();
-        for (EntityInstance instance : instances) {
-            instancesByPrimaryKey.put(instance.getPrimaryKeyValue(), instance);
-        }
-        return instancesByPrimaryKey;
-    }
-
-    private Map<String, Map<?, ?>> jsonResourcesByPrimaryKey(
+    private List<ProjectedResource> projectedResources(
             final Configuration configuration,
             final Object document,
-            final EntityDefinition entity) {
+            final EntityDefinition entity,
+            final List<EntityInstance> instances) {
         final List<?> jsonResources =
                 JsonPath.using(configuration)
                         .parse(document)
                         .read("$['" + escapedJsonPathName(entity.getPlural()) + "'][*]");
-        final Map<String, Map<?, ?>> jsonResourcesByPrimaryKey = new LinkedHashMap<>();
+        if (jsonResources.size() != instances.size()) {
+            throw new IllegalArgumentException("Projected resource count did not match instances");
+        }
 
-        for (Object jsonResource : jsonResources) {
-            if (jsonResource instanceof Map<?, ?>) {
-                final Map<?, ?> jsonResourceMap = (Map<?, ?>) jsonResource;
-                final String primaryKey =
-                        primaryKeyValueFrom(jsonResourceMap, entity.getPrimaryKeyField().getName());
-                if (primaryKey != null) {
-                    jsonResourcesByPrimaryKey.put(primaryKey, jsonResourceMap);
-                }
+        final List<ProjectedResource> projectedResources = new ArrayList<>();
+
+        for (int index = 0; index < jsonResources.size(); index++) {
+            final Object jsonResource = jsonResources.get(index);
+            if (!(jsonResource instanceof Map<?, ?>)) {
+                throw new IllegalArgumentException("Projected resource was not an object");
+            }
+            projectedResources.add(
+                    new ProjectedResource((Map<?, ?>) jsonResource, instances.get(index)));
+        }
+
+        return projectedResources;
+    }
+
+    private EntityInstance matchingInstanceFor(
+            final Map<?, ?> selectedResourceMap, final List<ProjectedResource> resources) {
+        for (ProjectedResource resource : resources) {
+            if (resource.isSameObjectAs(selectedResourceMap)) {
+                return resource.instance();
             }
         }
 
-        return jsonResourcesByPrimaryKey;
+        for (ProjectedResource resource : resources) {
+            if (resource.matches(selectedResourceMap)) {
+                return resource.instance();
+            }
+        }
+        return null;
     }
 
     private List<?> normalizeSelectedResources(
@@ -160,21 +166,6 @@ final class JsonPathQueryFilter {
         return List.of(rawSelected);
     }
 
-    private String primaryKeyValueFrom(final Map<?, ?> resource, final String primaryKeyName) {
-        if (!resource.containsKey(primaryKeyName)) {
-            return null;
-        }
-
-        final Object value = resource.get(primaryKeyName);
-        if (value instanceof Number) {
-            return new BigDecimal(value.toString()).stripTrailingZeros().toPlainString();
-        }
-        if (value == null) {
-            return null;
-        }
-        return value.toString();
-    }
-
     private String escapedJsonPathName(final String name) {
         return name.replace("\\", "\\\\").replace("'", "\\'");
     }
@@ -182,5 +173,28 @@ final class JsonPathQueryFilter {
     private ApiResponse unsafeSelection() {
         return ApiResponse.error(
                 422, "JSONPath query must select complete resource objects from the collection");
+    }
+
+    private static final class ProjectedResource {
+
+        private final Map<?, ?> resource;
+        private final EntityInstance instance;
+
+        private ProjectedResource(final Map<?, ?> resource, final EntityInstance instance) {
+            this.resource = resource;
+            this.instance = instance;
+        }
+
+        private boolean isSameObjectAs(final Map<?, ?> selectedResource) {
+            return resource == selectedResource;
+        }
+
+        private boolean matches(final Map<?, ?> selectedResource) {
+            return resource.equals(selectedResource);
+        }
+
+        private EntityInstance instance() {
+            return instance;
+        }
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandler.java
@@ -11,11 +11,14 @@ import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.Relationshi
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.RelationshipInstanceRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRouteMapper;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.api.ermodelconversion.JsonThing;
 import uk.co.compendiumdev.thingifier.api.http.ApiRequestEnvelope;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierHttpApi;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityViewDefinition;
 import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
 import uk.co.compendiumdev.thingifier.core.query.RepositoryQueryResult;
 
@@ -79,9 +82,10 @@ public final class RestApiQueryHandler {
         }
 
         if (queryBodyFormat == ApiRequestEnvelope.QueryBodyFormat.JSONPATH) {
+            final EntityViewDefinition responseView = responseViewFor(url, response);
             response =
                     new JsonPathQueryFilter(new JsonThing(runtime.apiConfig().jsonOutput()))
-                            .filter(queryResults, context, queryBody);
+                            .filter(queryResults, context, queryBody, responseView);
         }
 
         return advertiseQuery(response);
@@ -89,6 +93,23 @@ public final class RestApiQueryHandler {
 
     private ApiResponse methodNotAllowed(final String allowHeader) {
         return ApiResponse.error(405, "Method Not Allowed").setHeader("Allow", allowHeader);
+    }
+
+    private EntityViewDefinition responseViewFor(final String url, final ApiResponse response) {
+        if (response == null
+                || response.isErrorResponse()
+                || response.hasABodyOverride()
+                || response.getTypeOfThingReturned() == null) {
+            return null;
+        }
+
+        final EntityDefinition entity = response.getTypeOfThingReturned();
+        return runtime.apiSpec()
+                .ruleFor(RoutingVerb.QUERY, url, runtime.apiConfig().getApiEndPointPrefix())
+                .map(rule -> rule.responseEntityViewFor(response.getStatusCode()))
+                .filter(entity::hasViewNamed)
+                .map(entity::getViewNamed)
+                .orElse(null);
     }
 
     private ApiResponse advertiseQuery(final ApiResponse response) {

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandlerTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandlerTest.java
@@ -299,6 +299,53 @@ public class RestApiQueryHandlerTest {
     }
 
     @Test
+    public void jsonPathQueryUsesResponseEntityViewBeforeFiltering() {
+        Thingifier thingifier = todoThingifier();
+        EntityDefinition todo = thingifier.getDefinitionNamed("todo");
+        todo.addField(Field.is("secret", FieldType.STRING));
+        todo.defineView("PublicTodo").hideResponseFields("id", "secret");
+        thingifier.apiSpec().route("QUERY", "/todos").entityView("PublicTodo");
+        EntityInstance matching =
+                storeFor(thingifier)
+                        .entities()
+                        .create(
+                                EntityInstanceDraft.forEntity(todo)
+                                        .withField("title", "Visible")
+                                        .withField("doneStatus", "false")
+                                        .withField("description", "Open item")
+                                        .withField("secret", "alpha"));
+        storeFor(thingifier)
+                .entities()
+                .create(
+                        EntityInstanceDraft.forEntity(todo)
+                                .withField("title", "Hidden")
+                                .withField("doneStatus", "false")
+                                .withField("description", "Other item")
+                                .withField("secret", "beta"));
+
+        HttpApiResponse hiddenFieldResponse =
+                new ThingifierHttpApi(thingifier)
+                        .queryRequest(jsonPathQuery("todos", "$.todos[?(@.secret == 'alpha')]"));
+
+        Assertions.assertEquals(200, hiddenFieldResponse.getStatusCode());
+        Assertions.assertEquals(
+                0, hiddenFieldResponse.apiResponse().getReturnedInstanceCollection().size());
+
+        HttpApiResponse visibleFieldResponse =
+                new ThingifierHttpApi(thingifier)
+                        .queryRequest(jsonPathQuery("todos", "$.todos[?(@.title == 'Visible')]"));
+
+        Assertions.assertEquals(200, visibleFieldResponse.getStatusCode());
+        Assertions.assertEquals(
+                1, visibleFieldResponse.apiResponse().getReturnedInstanceCollection().size());
+        Assertions.assertEquals(
+                matching,
+                visibleFieldResponse.apiResponse().getReturnedInstanceCollection().get(0));
+        Assertions.assertFalse(visibleFieldResponse.getBody().contains("secret"));
+        Assertions.assertFalse(visibleFieldResponse.getBody().contains("\"id\""));
+    }
+
+    @Test
     public void jsonPathQueryCanSelectCollectionArray() {
         Thingifier thingifier = todoThingifier();
         EntityInstance first = createTodo(thingifier, "First", "false", "One");


### PR DESCRIPTION
## Summary
- Evaluate JSONPath QUERY expressions against the route's response-view-projected JSON document.
- Carry the same response view onto the JSONPath-filtered ApiResponse.
- Map selected view-projected resource objects back to stored instances without requiring the projected document to expose the primary key.
- Add a regression test proving a hidden `secret` field cannot be queried while visible-field JSONPath filtering still works.

## Verification
- `mvn -pl thingifier '-Dtest=RestApiQueryHandlerTest' test` (25 tests, 0 failures)
- `mvn -pl thingifier test` (514 tests, 0 failures)
- `mvn -pl thingifier spotless:check`
- `git diff --check`

Follow-up to #105.