### PR TITLE
Rename menu duplicate helper

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/DefaultGUIHTML.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/DefaultGUIHTML.java
@@ -24,13 +24,13 @@ public class DefaultGUIHTML {
     }
 
     public void appendMenuItem(final String title, final String url) {
-        if (hasMenuItem(title, url)) {
+        if (isDuplicateMenuItem(title, url)) {
             return;
         }
         menuItems.add(new GuiMenuItem(title, url));
     }
 
-    private boolean hasMenuItem(final String title, final String url) {
+    private boolean isDuplicateMenuItem(final String title, final String url) {
         for (GuiMenuItem item : menuItems) {
             if (item.menuTitle.equals(title) || item.url.equals(url)) {
                 // avoid adding duplicates
@@ -45,7 +45,7 @@ public class DefaultGUIHTML {
     }
 
     public void prefixMenuItem(final String title, final String url) {
-        if (hasMenuItem(title, url)) {
+        if (isDuplicateMenuItem(title, url)) {
             return;
         }
         menuItems.add(0, new GuiMenuItem(title, url));


### PR DESCRIPTION
## Summary

- Rename the private menu-item helper from `hasMenuItem` to `isDuplicateMenuItem`.
- Preserve the existing duplicate detection behavior where either a matching title or a matching URL prevents insertion.

## Validation

- `mvn -pl thingifier test` (516 tests, 0 failures)
- `mvn -pl thingifier spotless:check`
- `git diff --check`