### PR TITLE
Rename Swagger collection schema variable

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/Swaggerizer.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/Swaggerizer.java
@@ -349,8 +349,8 @@ public class Swaggerizer {
             components.addSchemas("create_" + objectSchemaDefinition.getName(), createObject);
 
             // add list response for entity plural
-            ObjectSchema arrayObject = asArrayObjectSchema(objectSchemaDefinition);
-            components.addSchemas(objectSchemaDefinition.getPlural(), arrayObject);
+            ObjectSchema collectionObject = asArrayObjectSchema(objectSchemaDefinition);
+            components.addSchemas(objectSchemaDefinition.getPlural(), collectionObject);
 
             for (EntityViewDefinition view : objectSchemaDefinition.getViews()) {
                 ObjectSchema viewObject = asResponseViewObjectSchema(view);


### PR DESCRIPTION
## Summary

- Rename the local Swaggerizer schema variable from `arrayObject` to `collectionObject` where the value is an `ObjectSchema` wrapper.
- Preserve the generated schema behavior unchanged.

## Validation

- `mvn -pl thingifier test` (516 tests, 0 failures)
- `mvn -pl thingifier spotless:check`
- `git diff --check`