### PR TITLE
Preserve XML collection schema shape

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/Swaggerizer.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/Swaggerizer.java
@@ -194,12 +194,17 @@ public class Swaggerizer {
                                         if (routingDefinitions.hasObjectSchemaNamed(
                                                 subroute.getReturnPayloadFor(
                                                         possibleStatus.value()))) {
-                                            String ref =
-                                                    "#/components/schemas/"
-                                                            + subroute.getReturnPayloadFor(
-                                                                    possibleStatus.value());
+                                            String payloadName =
+                                                    subroute.getReturnPayloadFor(
+                                                            possibleStatus.value());
+                                            String ref = "#/components/schemas/" + payloadName;
 
-                                            response.setContent(responseContentWith(ref));
+                                            response.setContent(
+                                                    responseContentWith(
+                                                            ref,
+                                                            xmlResponseRefFor(
+                                                                    routingDefinitions,
+                                                                    payloadName)));
                                         }
                                     }
 
@@ -349,8 +354,11 @@ public class Swaggerizer {
             components.addSchemas("create_" + objectSchemaDefinition.getName(), createObject);
 
             // add list response for entity plural
-            ObjectSchema collectionObject = asArrayObjectSchema(objectSchemaDefinition);
+            ObjectSchema collectionObject = asJsonCollectionObjectSchema(objectSchemaDefinition);
             components.addSchemas(objectSchemaDefinition.getPlural(), collectionObject);
+            ArraySchema xmlCollectionObject = asXmlCollectionArraySchema(objectSchemaDefinition);
+            components.addSchemas(
+                    xmlCollectionSchemaNameFor(objectSchemaDefinition), xmlCollectionObject);
 
             for (EntityViewDefinition view : objectSchemaDefinition.getViews()) {
                 ObjectSchema viewObject = asResponseViewObjectSchema(view);
@@ -362,6 +370,16 @@ public class Swaggerizer {
             }
         }
         return components;
+    }
+
+    private String xmlResponseRefFor(
+            final ApiRoutingDefinition routingDefinitions, final String payloadName) {
+        for (EntityDefinition definition : routingDefinitions.getObjectSchemas()) {
+            if (definition.getPlural().equals(payloadName)) {
+                return "#/components/schemas/" + xmlCollectionSchemaNameFor(definition);
+            }
+        }
+        return "#/components/schemas/" + payloadName;
     }
 
     private void addParamSchemeValidationFromField(Schema<String> schema, Field aField) {
@@ -562,16 +580,16 @@ public class Swaggerizer {
         }
     }
 
-    private Content responseContentWith(final String ref) {
-        Schema<String> object = new Schema<>();
-        MediaType schema = new MediaType();
-        schema.setSchema(object);
-        object.set$ref(ref);
-
+    private Content responseContentWith(final String jsonRef, final String xmlRef) {
         Content content = new Content();
         for (AcceptHeaderParser.ACCEPT_TYPE responseType :
                 AcceptHeaderParser.ACCEPT_TYPE.responseMediaTypes()) {
             if (responseType.usesComponentSchemaInDocumentation()) {
+                Schema<String> object = new Schema<>();
+                MediaType schema = new MediaType();
+                schema.setSchema(object);
+                object.set$ref(
+                        responseType == AcceptHeaderParser.ACCEPT_TYPE.XML ? xmlRef : jsonRef);
                 content.addMediaType(responseType.mediaType(), schema);
             } else {
                 MediaType textSchema = new MediaType();
@@ -600,7 +618,7 @@ public class Swaggerizer {
         components.addSecuritySchemes(name, securityScheme);
     }
 
-    private ObjectSchema asArrayObjectSchema(EntityDefinition objectSchemaDefinition) {
+    private ObjectSchema asJsonCollectionObjectSchema(EntityDefinition objectSchemaDefinition) {
 
         ObjectSchema collectionObject = new ObjectSchema();
         collectionObject.setDescription(objectSchemaDefinition.getPlural());
@@ -609,13 +627,29 @@ public class Swaggerizer {
         ArraySchema arrayObject = new ArraySchema();
         arrayObject.setItems(asRequiredResponseObjectSchema(objectSchemaDefinition));
 
-        XML xml = new XML();
-        xml.setWrapped(true);
-        collectionObject.setXml(xml);
         collectionObject.addProperties(objectSchemaDefinition.getPlural(), arrayObject);
         collectionObject.addRequiredItem(objectSchemaDefinition.getPlural());
 
         return collectionObject;
+    }
+
+    private ArraySchema asXmlCollectionArraySchema(EntityDefinition objectSchemaDefinition) {
+
+        ArraySchema collectionObject = new ArraySchema();
+        collectionObject.setDescription(objectSchemaDefinition.getPlural());
+        collectionObject.setTitle(objectSchemaDefinition.getPlural());
+        collectionObject.setItems(asRequiredResponseObjectSchema(objectSchemaDefinition));
+
+        XML xml = new XML();
+        xml.setName(objectSchemaDefinition.getPlural());
+        xml.setWrapped(true);
+        collectionObject.setXml(xml);
+
+        return collectionObject;
+    }
+
+    private static String xmlCollectionSchemaNameFor(EntityDefinition objectSchemaDefinition) {
+        return objectSchemaDefinition.getPlural() + "_xml_collection";
     }
 
     private static ObjectSchema asRequiredResponseObjectSchema(

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerEntityDescriptionTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerEntityDescriptionTest.java
@@ -56,6 +56,16 @@ class SwaggerizerEntityDescriptionTest {
                         .get("application/json")
                         .getSchema()
                         .get$ref());
+        Assertions.assertEquals(
+                "#/components/schemas/todos_xml_collection",
+                relationshipCollection
+                        .getGet()
+                        .getResponses()
+                        .get("200")
+                        .getContent()
+                        .get("application/xml")
+                        .getSchema()
+                        .get$ref());
         Assertions.assertNotNull(relationshipCollection.getPost().getRequestBody());
         Assertions.assertEquals(
                 "#/components/schemas/todo",
@@ -101,7 +111,7 @@ class SwaggerizerEntityDescriptionTest {
                 "#/components/schemas/projects",
                 content.get("application/json").getSchema().get$ref());
         Assertions.assertEquals(
-                "#/components/schemas/projects",
+                "#/components/schemas/projects_xml_collection",
                 content.get("application/xml").getSchema().get$ref());
         for (String mediaType :
                 List.of(

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerSchemaExampleTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerSchemaExampleTest.java
@@ -17,7 +17,7 @@ import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.F
 class SwaggerizerSchemaExampleTest {
 
     @Test
-    void collectionResponseSchemasWrapTheArrayInThePluralNamedObject() {
+    void collectionResponseSchemasUseJsonWrapperAndXmlWrappedArray() {
         final Thingifier thingifier = new Thingifier();
         final EntityDefinition item = thingifier.defineThing("item", "items");
         item.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT).withExample("21"));
@@ -31,13 +31,14 @@ class SwaggerizerSchemaExampleTest {
 
         final JsonObject document =
                 JsonParser.parseString(new Swaggerizer(apiDefn).asJson()).getAsJsonObject();
-        final JsonObject itemsSchema =
-                document.getAsJsonObject("components")
-                        .getAsJsonObject("schemas")
-                        .getAsJsonObject("items");
+        final JsonObject schemas =
+                document.getAsJsonObject("components").getAsJsonObject("schemas");
+        final JsonObject itemsSchema = schemas.getAsJsonObject("items");
         final JsonObject itemsProperty =
                 itemsSchema.getAsJsonObject("properties").getAsJsonObject("items");
         final JsonObject itemSchema = itemsProperty.getAsJsonObject("items");
+        final JsonObject xmlItemsSchema = schemas.getAsJsonObject("items_xml_collection");
+        final JsonObject xmlItemSchema = xmlItemsSchema.getAsJsonObject("items");
 
         Assertions.assertEquals("object", itemsSchema.get("type").getAsString());
         Assertions.assertEquals("array", itemsProperty.get("type").getAsString());
@@ -59,6 +60,29 @@ class SwaggerizerSchemaExampleTest {
                         .getAsJsonObject("schema")
                         .get("$ref")
                         .getAsString());
+        Assertions.assertEquals(
+                "#/components/schemas/items_xml_collection",
+                document.getAsJsonObject("paths")
+                        .getAsJsonObject("/items")
+                        .getAsJsonObject("get")
+                        .getAsJsonObject("responses")
+                        .getAsJsonObject("200")
+                        .getAsJsonObject("content")
+                        .getAsJsonObject("application/xml")
+                        .getAsJsonObject("schema")
+                        .get("$ref")
+                        .getAsString());
+
+        Assertions.assertEquals("array", xmlItemsSchema.get("type").getAsString());
+        Assertions.assertEquals(
+                "items", xmlItemsSchema.getAsJsonObject("xml").get("name").getAsString());
+        Assertions.assertTrue(xmlItemsSchema.getAsJsonObject("xml").get("wrapped").getAsBoolean());
+        Assertions.assertEquals("object", xmlItemSchema.get("type").getAsString());
+        Assertions.assertEquals(
+                "item", xmlItemSchema.getAsJsonObject("xml").get("name").getAsString());
+        Assertions.assertEquals(
+                Set.of("id", "type", "isbn13", "price", "numberinstock"),
+                stringsIn(xmlItemSchema.getAsJsonArray("required")));
     }
 
     private Set<String> stringsIn(final JsonArray values) {


### PR DESCRIPTION
## Summary

- Keep JSON collection responses on the plural object wrapper schema.
- Add an XML-specific collection component shaped as a wrapped array with the plural root element.
- Point `application/xml` collection responses, including relationship collections, at the XML-specific schema.
- Add tests for JSON/XML collection refs and XML wrapped-array schema metadata.

## Validation

- `mvn -pl thingifier '-Dtest=SwaggerizerSchemaExampleTest,SwaggerizerEntityDescriptionTest' test` (7 tests, 0 failures)
- `mvn -pl thingifier test` (516 tests, 0 failures)
- `mvn -pl thingifier spotless:check`
- `git diff --check`