### PR TITLE
Keep optional response fields optional

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/Swaggerizer.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/Swaggerizer.java
@@ -655,12 +655,26 @@ public class Swaggerizer {
     private static ObjectSchema asRequiredResponseObjectSchema(
             EntityDefinition objectSchemaDefinition) {
         ObjectSchema object = asObjectSchema(objectSchemaDefinition);
-        if (object.getProperties() != null) {
-            for (String propertyName : object.getProperties().keySet()) {
-                object.addRequiredItem(propertyName);
+        if (object.getProperties() == null) {
+            return object;
+        }
+        for (String propertyName : objectSchemaDefinition.getFieldNames()) {
+            if (!object.getProperties().containsKey(propertyName)) {
+                continue;
             }
+            Field field = objectSchemaDefinition.getField(propertyName);
+            if (!isAlwaysRenderedResponseField(field)) {
+                continue;
+            }
+            object.addRequiredItem(propertyName);
         }
         return object;
+    }
+
+    private static boolean isAlwaysRenderedResponseField(final Field field) {
+        return field.isMandatory()
+                || field.hasDefaultValue()
+                || field.getType().getDefault() != null;
     }
 
     private static ObjectSchema asObjectSchema(EntityDefinition objectSchemaDefinition) {

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerSchemaExampleTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerSchemaExampleTest.java
@@ -94,6 +94,44 @@ class SwaggerizerSchemaExampleTest {
     }
 
     @Test
+    void collectionResponseItemSchemasKeepOptionalNullableFieldsOptional() {
+        final Thingifier thingifier = new Thingifier();
+        final EntityDefinition item = thingifier.defineThing("item", "items");
+        item.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT).withExample("21"));
+        item.addField(Field.is("title", FieldType.STRING));
+        item.addField(Field.is("dueDate", FieldType.DATE));
+        item.addField(
+                Field.is("metadata", FieldType.OBJECT)
+                        .withField(Field.is("source", FieldType.STRING)));
+        item.addField(Field.is("scheduledDate", FieldType.DATE).makeMandatory());
+        item.addField(Field.is("createdDate", FieldType.DATE).withDefaultValue("2026-08-11"));
+
+        final ThingifierApiDocumentationDefn apiDefn =
+                new ThingifierApiDocumentationDefn().setThingifier(thingifier);
+
+        final JsonObject document =
+                JsonParser.parseString(new Swaggerizer(apiDefn).asJson()).getAsJsonObject();
+        final JsonObject schemas =
+                document.getAsJsonObject("components").getAsJsonObject("schemas");
+        final JsonObject itemsProperty =
+                schemas.getAsJsonObject("items")
+                        .getAsJsonObject("properties")
+                        .getAsJsonObject("items");
+        final JsonObject itemSchema = itemsProperty.getAsJsonObject("items");
+        final JsonObject properties = itemSchema.getAsJsonObject("properties");
+        final Set<String> required = stringsIn(itemSchema.getAsJsonArray("required"));
+
+        Assertions.assertTrue(properties.has("dueDate"));
+        Assertions.assertTrue(properties.has("metadata"));
+        Assertions.assertFalse(required.contains("dueDate"));
+        Assertions.assertFalse(required.contains("metadata"));
+        Assertions.assertTrue(required.contains("id"));
+        Assertions.assertTrue(required.contains("title"));
+        Assertions.assertTrue(required.contains("scheduledDate"));
+        Assertions.assertTrue(required.contains("createdDate"));
+    }
+
+    @Test
     void openApiSchemaExamplesUseJsonValuesMatchingTheFieldType() {
         final Thingifier thingifier = new Thingifier();
         final EntityDefinition item = thingifier.defineThing("item", "items");


### PR DESCRIPTION
## Summary

- Only mark collection item response fields as required when the field is guaranteed to render: mandatory fields, configured defaults, or non-null type defaults.
- Keep optional nullable fields such as DATE and OBJECT in schema properties without adding them to `required`.
- Add regression coverage for optional DATE/OBJECT fields alongside mandatory/default DATE fields.

## Validation

- `mvn -pl thingifier '-Dtest=SwaggerizerSchemaExampleTest' test` (3 tests, 0 failures)
- `mvn -pl thingifier test` (517 tests, 0 failures)
- `mvn -pl thingifier spotless:check`
- `git diff --check`