### PR TITLE
Quote JSONPath docs properties

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGenerator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGenerator.java
@@ -982,13 +982,24 @@ public class RestApiDocumentationGenerator {
 
         final String fieldName =
                 entity.getField("title") == null ? exampleFieldNameFor(entity) : "title";
-        return "$."
-                + escapeHtmlText(entity.getPlural())
-                + "[?@."
-                + escapeHtmlText(fieldName)
+        return "$"
+                + jsonPathPropertySelector(entity.getPlural())
+                + "[?@"
+                + jsonPathPropertySelector(fieldName)
                 + " == '"
-                + escapeHtmlText(exampleValueFor(fieldName))
+                + escapeHtmlText(jsonPathSingleQuotedContent(exampleValueFor(fieldName)))
                 + "']";
+    }
+
+    private String jsonPathPropertySelector(final String propertyName) {
+        return "['" + escapeHtmlText(jsonPathSingleQuotedContent(propertyName)) + "']";
+    }
+
+    private String jsonPathSingleQuotedContent(final String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replace("\\", "\\\\").replace("'", "\\'");
     }
 
     private String exampleFieldNameFor(final EntityDefinition entity) {

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGeneratorTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGeneratorTest.java
@@ -241,7 +241,7 @@ class RestApiDocumentationGeneratorTest {
         Assertions.assertTrue(
                 docs.contains(
                         "QUERY JSONPath content uses <i>Content-Type: application/jsonpath</i>"));
-        Assertions.assertTrue(docs.contains("$.tasks[?@.title == 'Task']"));
+        Assertions.assertTrue(docs.contains("$['tasks'][?@['title'] == 'Task']"));
         Assertions.assertFalse(docs.contains("&amp;sortBy=-id"));
         Assertions.assertFalse(
                 docs.contains(
@@ -273,8 +273,32 @@ class RestApiDocumentationGeneratorTest {
 
         Assertions.assertTrue(
                 paragraph.contains(
-                        "$.items&lt;script&gt;&amp;&#39;[?@.id&lt;bad&amp;&#39; == 'value']"));
-        Assertions.assertFalse(paragraph.contains("$.items<script>&'[?@.id<bad&' == 'value']"));
+                        "$['items&lt;script&gt;&amp;\\&#39;'][?@['id&lt;bad&amp;\\&#39;'] == 'value']"));
+        Assertions.assertFalse(paragraph.contains("<script>"));
+        Assertions.assertFalse(paragraph.contains("id<bad&"));
+    }
+
+    @Test
+    void apiDocumentationUsesJsonPathBracketNotationForModelNames() {
+        final Thingifier thingifier = new Thingifier();
+        final EntityDefinition item = thingifier.defineThing("item", "todo-items");
+        item.addAsPrimaryKeyField(Field.is("key-id", FieldType.AUTO_GUID));
+        item.addField(Field.is("name", FieldType.STRING));
+
+        final String docs =
+                new RestApiDocumentationGenerator(thingifier, new DefaultGUIHTML())
+                        .getApiDocumentation(
+                                new ApiRoutingDefinitionDocGenerator(thingifier).generate("/api"),
+                                List.of(),
+                                new ThingifierApiDocumentationDefn(),
+                                "/api",
+                                "https://example.com/api/docs");
+
+        final String paragraph = paragraphContaining(docs, "QUERY JSONPath content uses");
+
+        Assertions.assertTrue(paragraph.contains("$['todo-items'][?@['key-id'] == 'value']"));
+        Assertions.assertFalse(paragraph.contains("$.todo-items"));
+        Assertions.assertFalse(paragraph.contains("@.key-id"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Generate JSONPath QUERY documentation examples with bracket notation for model-defined plural and field names.
- Escape single quotes and backslashes inside those JSONPath property strings before HTML escaping.
- Update docs tests for the new bracket notation and add coverage for supported hyphenated names such as `todo-items` and `key-id`.

## Validation

- `mvn -pl thingifier '-Dtest=RestApiDocumentationGeneratorTest' test` (14 tests, 0 failures)
- `mvn -pl thingifier test` (519 tests, 0 failures)
- `mvn -pl thingifier spotless:check`
- `git diff --check`