### PR TITLE
Reject nested JSONPath resource matches

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/JsonPathQueryFilter.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/JsonPathQueryFilter.java
@@ -7,12 +7,9 @@ import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.Option;
 import com.jayway.jsonpath.PathNotFoundException;
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import uk.co.compendiumdev.thingifier.api.ermodelconversion.JsonThing;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
@@ -166,28 +163,13 @@ final class JsonPathQueryFilter {
 
         private final IdentityHashMap<Map<?, ?>, EntityInstance> identityMatches =
                 new IdentityHashMap<>();
-        private final Map<Map<?, ?>, EntityInstance> equalMatches = new HashMap<>();
-        private final Set<Map<?, ?>> ambiguousEqualMatches = new HashSet<>();
 
         private void add(final Map<?, ?> resource, final EntityInstance instance) {
             identityMatches.put(resource, instance);
-            if (equalMatches.containsKey(resource)) {
-                ambiguousEqualMatches.add(resource);
-                return;
-            }
-            equalMatches.put(resource, instance);
         }
 
         private EntityInstance matchingInstanceFor(final Map<?, ?> selectedResource) {
-            if (identityMatches.containsKey(selectedResource)) {
-                return identityMatches.get(selectedResource);
-            }
-
-            if (ambiguousEqualMatches.contains(selectedResource)) {
-                return null;
-            }
-
-            return equalMatches.get(selectedResource);
+            return identityMatches.get(selectedResource);
         }
     }
 }

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandlerTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandlerTest.java
@@ -366,6 +366,30 @@ public class RestApiQueryHandlerTest {
     }
 
     @Test
+    public void jsonPathQueryRejectsNestedObjectEqualToAProjectedResource() {
+        Thingifier thingifier = new Thingifier();
+        EntityDefinition item = thingifier.defineThing("item", "items");
+        item.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT));
+        item.addField(Field.is("tag", FieldType.STRING));
+        item.addField(
+                Field.is("details", FieldType.OBJECT).withField(Field.is("tag", FieldType.STRING)));
+        item.defineView("PublicItem").hideResponseFields("id");
+        thingifier.apiSpec().route("QUERY", "/items").entityView("PublicItem");
+        storeFor(thingifier)
+                .entities()
+                .create(EntityInstanceDraft.forEntity(item).withField("tag", "same"));
+        storeFor(thingifier)
+                .entities()
+                .create(EntityInstanceDraft.forEntity(item).withField("details.tag", "same"));
+
+        HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .queryRequest(jsonPathQuery("items", "$.items[1].details"));
+
+        Assertions.assertEquals(422, response.getStatusCode());
+    }
+
+    @Test
     public void jsonPathQueryCanSelectCollectionArray() {
         Thingifier thingifier = todoThingifier();
         EntityInstance first = createTodo(thingifier, "First", "false", "One");


### PR DESCRIPTION
## Summary
- Restrict JSONPath resource matching to maps that originate from the top-level collection by identity.
- Remove the equals-based fallback so structurally equal nested objects cannot be treated as selected resources.
- Add regression coverage where a nested object has the same visible shape as an unrelated projected resource and must return 422.

## Root Cause
The previous lookup used identity first, then structural equality. With response views hiding identifiers, a nested object could compare equal to a projected top-level resource and be accepted as a resource selection.

## Validation
- `mvn -pl thingifier '-Dtest=RestApiQueryHandlerTest' test` (29 tests, 0 failures)
- `mvn -pl thingifier test` (521 tests, 0 failures)
- `mvn -pl thingifier spotless:check`
- `git diff --check`