### PR TITLE
Terminate NDJSON records with newlines

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseAsJsonLines.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseAsJsonLines.java
@@ -19,7 +19,11 @@ public final class ApiResponseAsJsonLines {
     }
 
     public String getJsonLines() {
-        return String.join("\n", jsonObjects());
+        List<String> jsonObjects = jsonObjects();
+        if (jsonObjects.isEmpty()) {
+            return "";
+        }
+        return String.join("\n", jsonObjects) + "\n";
     }
 
     public String getJsonSequence() {

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/requests/ThingifierHttpApiAdditionalRepresentationsTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/requests/ThingifierHttpApiAdditionalRepresentationsTest.java
@@ -83,8 +83,8 @@ class ThingifierHttpApiAdditionalRepresentationsTest {
                 "text/html",
                 "<table><thead><tr><th>id</th><th>title</th></tr></thead>"
                         + "<tbody><tr><td>1</td><td>Task</td></tr></tbody></table>");
-        expectedBodies.put("application/x-ndjson", "{\"id\":1,\"title\":\"Task\"}");
-        expectedBodies.put("application/jsonl", "{\"id\":1,\"title\":\"Task\"}");
+        expectedBodies.put("application/x-ndjson", "{\"id\":1,\"title\":\"Task\"}\n");
+        expectedBodies.put("application/jsonl", "{\"id\":1,\"title\":\"Task\"}\n");
         expectedBodies.put("application/json-seq", "\u001E{\"id\":1,\"title\":\"Task\"}\n");
         expectedBodies.put("text/tab-separated-values", "id\ttitle\n1\tTask");
         return expectedBodies;

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseAdditionalRepresentationsTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseAdditionalRepresentationsTest.java
@@ -105,7 +105,7 @@ class ApiResponseAdditionalRepresentationsTest {
                 "{\"id\":1,\"title\":\"One\",\"notes\":\"Simple\","
                         + "\"metadata\":{\"tag\":\"ignored\"}}\n"
                         + "{\"id\":2,\"title\":\"Two\",\"notes\":\"More\","
-                        + "\"metadata\":{\"tag\":\"ignored\"}}",
+                        + "\"metadata\":{\"tag\":\"ignored\"}}\n",
                 new ApiResponseAsJsonLines(response, jsonThing).getJsonLines());
     }
 
@@ -149,7 +149,7 @@ class ApiResponseAdditionalRepresentationsTest {
         Assertions.assertEquals(
                 "<ul><li>&lt;bad&gt;</li></ul>", new ApiResponseAsHtml(response).getHtml());
         Assertions.assertEquals(
-                "{\"errorMessage\":\"<bad>\"}",
+                "{\"errorMessage\":\"<bad>\"}\n",
                 new ApiResponseAsJsonLines(response, jsonThing).getJsonLines());
         Assertions.assertEquals(
                 "errorMessage\n<bad>", new ApiResponseAsDelimitedText(response, ',').getText());


### PR DESCRIPTION
## Summary
- Append a final newline to nonempty JSON Lines/NDJSON responses.
- Keep empty JSON Lines responses empty.
- Update direct renderer and HTTP additional-representation tests for `application/x-ndjson` and `application/jsonl`.

## Root Cause
`ApiResponseAsJsonLines#getJsonLines` joined records with newlines only between records, so the last JSON text was not newline-terminated. Incremental NDJSON consumers can miss or merge an unterminated final record.

## Validation
- `mvn -pl thingifier '-Dtest=ApiResponseAdditionalRepresentationsTest,ThingifierHttpApiAdditionalRepresentationsTest' test` (11 tests, 0 failures)
- `mvn -pl thingifier test` (521 tests, 0 failures)
- `mvn -pl thingifier spotless:check`
- `git diff --check`