### PR TITLE
Enforce PATCH request entity views

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
@@ -1,5 +1,7 @@
 package uk.co.compendiumdev.thingifier.api.http;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,8 +19,11 @@ import uk.co.compendiumdev.thingifier.adapter.http.messagehooks.HttpApiResponseH
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.api.ermodelconversion.JsonThing;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyField;
+import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields;
+import uk.co.compendiumdev.thingifier.api.http.bodyparser.JsonBodyValueConverter;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
 import uk.co.compendiumdev.thingifier.api.spec.ThingifierApiRouteRule;
+import uk.co.compendiumdev.thingifier.apiconfig.EntityPatchUpdateStyle;
 import uk.co.compendiumdev.thingifier.application.schema.RelationshipSpec;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityViewDefinition;
@@ -227,7 +232,7 @@ public final class ThingifierHttpApi {
 
     private HttpApiResponse validateEntityViewInput(
             final HttpApiRequest request, final HttpVerb verb) {
-        if (verb != HttpVerb.POST && verb != HttpVerb.PUT) {
+        if (verb != HttpVerb.POST && verb != HttpVerb.PUT && verb != HttpVerb.PATCH) {
             return null;
         }
 
@@ -256,10 +261,7 @@ public final class ThingifierHttpApi {
 
         final EntityViewDefinition view = entity.getViewNamed(viewName);
         final List<String> disallowedFields = new ArrayList<>();
-        for (ApiBodyField field :
-                ApiRequestEnvelope.from(request, verb, thingifier.getThingNames())
-                        .bodyFields()
-                        .topLevelFields()) {
+        for (ApiBodyField field : entityViewInputFields(request, verb)) {
             if (entity.hasFieldNameDefined(field.name()) && !view.isInputAllowed(field.name())) {
                 disallowedFields.add(field.name());
             }
@@ -278,6 +280,110 @@ public final class ThingifierHttpApi {
                                 viewName, String.join(", ", disallowedFields))),
                 jsonThing,
                 thingifier.apiConfig());
+    }
+
+    private List<ApiBodyField> entityViewInputFields(
+            final HttpApiRequest request, final HttpVerb verb) {
+        if (verb == HttpVerb.PATCH) {
+            return patchInputFields(request);
+        }
+
+        return ApiRequestEnvelope.from(request, verb, thingifier.getThingNames())
+                .bodyFields()
+                .topLevelFields();
+    }
+
+    private List<ApiBodyField> patchInputFields(final HttpApiRequest request) {
+        final Optional<EntityPatchUpdateStyle> style =
+                EntityPatchUpdateStyle.fromContentType(request.getContentTypeHeader());
+        if (style.isEmpty()) {
+            return List.of();
+        }
+
+        if (style.get() == EntityPatchUpdateStyle.JSON_PATCH_RFC6902) {
+            return jsonPatchInputFields(request.getBody());
+        }
+
+        return objectPatchInputFields(request.getBody());
+    }
+
+    private List<ApiBodyField> objectPatchInputFields(final String rawBody) {
+        try {
+            final JsonNode document = JsonBodyValueConverter.readTree(rawBody);
+            if (document == null || !document.isObject()) {
+                return List.of();
+            }
+            return bodyFieldsForObject(document);
+        } catch (JsonProcessingException | IllegalArgumentException e) {
+            return List.of();
+        }
+    }
+
+    private List<ApiBodyField> jsonPatchInputFields(final String rawBody) {
+        final List<ApiBodyField> inputFields = new ArrayList<>();
+        final JsonNode operations;
+        try {
+            operations = JsonBodyValueConverter.readTree(rawBody);
+        } catch (JsonProcessingException e) {
+            return inputFields;
+        }
+
+        if (operations == null || !operations.isArray()) {
+            return inputFields;
+        }
+
+        for (JsonNode operation : operations) {
+            if (!operation.isObject()) {
+                continue;
+            }
+
+            addJsonPointerTopLevelField(inputFields, operation.get("path"));
+            addJsonPointerTopLevelField(inputFields, operation.get("from"));
+            addRootReplacementFields(inputFields, operation);
+        }
+
+        return inputFields;
+    }
+
+    private void addRootReplacementFields(
+            final List<ApiBodyField> inputFields, final JsonNode operation) {
+        final JsonNode path = operation.get("path");
+        final JsonNode value = operation.get("value");
+        if (path != null
+                && path.isTextual()
+                && path.asText().isEmpty()
+                && value != null
+                && value.isObject()) {
+            inputFields.addAll(bodyFieldsForObject(value));
+        }
+    }
+
+    private List<ApiBodyField> bodyFieldsForObject(final JsonNode document) {
+        return ApiBodyFields.fromMap(JsonBodyValueConverter.objectNodeAsMap(document))
+                .topLevelFields();
+    }
+
+    private void addJsonPointerTopLevelField(
+            final List<ApiBodyField> inputFields, final JsonNode pointerNode) {
+        if (pointerNode == null || !pointerNode.isTextual()) {
+            return;
+        }
+
+        final String fieldName = jsonPointerTopLevelFieldName(pointerNode.asText());
+        if (fieldName != null) {
+            inputFields.add(new ApiBodyField(fieldName, ""));
+        }
+    }
+
+    private String jsonPointerTopLevelFieldName(final String pointer) {
+        if (pointer == null || pointer.isEmpty() || !pointer.startsWith("/")) {
+            return null;
+        }
+
+        final int nextSeparator = pointer.indexOf("/", 1);
+        final String escapedToken =
+                nextSeparator == -1 ? pointer.substring(1) : pointer.substring(1, nextSeparator);
+        return escapedToken.replace("~1", "/").replace("~0", "~");
     }
 
     private void applyResponseEntityView(

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpecTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpecTest.java
@@ -1,5 +1,9 @@
 package uk.co.compendiumdev.thingifier.api.spec;
 
+import static uk.co.compendiumdev.thingifier.apiconfig.EntityPatchUpdateStyle.JSON_MERGE_PATCH_RFC7396;
+import static uk.co.compendiumdev.thingifier.apiconfig.EntityPatchUpdateStyle.JSON_PATCH_RFC6902;
+import static uk.co.compendiumdev.thingifier.apiconfig.EntityPatchUpdateStyle.PARTIAL_JSON_UPDATE;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import uk.co.compendiumdev.thingifier.Thingifier;
@@ -11,10 +15,13 @@ import uk.co.compendiumdev.thingifier.api.http.HttpApiRequest;
 import uk.co.compendiumdev.thingifier.api.http.HttpApiResponse;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierHttpApi;
 import uk.co.compendiumdev.thingifier.apiconfig.ThingifierApiConfig;
+import uk.co.compendiumdev.thingifier.core.EntityRelModel;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.Cardinality;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.Field;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldType;
+import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
+import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstanceDraft;
 
 class ThingifierApiSpecTest {
 
@@ -177,6 +184,68 @@ class ThingifierApiSpecTest {
         Assertions.assertTrue(disallowedResponse.getBody().contains("forbidden"));
     }
 
+    @Test
+    void patchRequestEntityViewsRejectDisallowedInputFieldsAtRuntime() {
+        final Thingifier thingifier = viewModel();
+        thingifier.apiConfig().setFrom(new ThingifierApiConfig("/api"));
+        thingifier
+                .apiConfig()
+                .writeMethods()
+                .entities()
+                .patchCan(PARTIAL_JSON_UPDATE, JSON_MERGE_PATCH_RFC7396, JSON_PATCH_RFC6902);
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.PATCH, "/api/items/{id}")
+                .requestEntityView("PublicItem");
+        final EntityInstance item = createItem(thingifier, "visible", "stored", "original");
+        final ThingifierHttpApi api = new ThingifierHttpApi(thingifier);
+        final String path = "/api/items/" + item.getPrimaryKeyValue();
+
+        final HttpApiResponse partialJsonResponse =
+                api.patch(
+                        patchRequest(
+                                path,
+                                "{\"forbidden\":\"partial\"}",
+                                PARTIAL_JSON_UPDATE.mediaType()));
+        final HttpApiResponse mergePatchResponse =
+                api.patch(
+                        patchRequest(
+                                path,
+                                "{\"forbidden\":\"merge\"}",
+                                JSON_MERGE_PATCH_RFC7396.mediaType()));
+        final HttpApiResponse jsonPatchPathResponse =
+                api.patch(
+                        patchRequest(
+                                path,
+                                "[{\"op\":\"replace\",\"path\":\"/forbidden\",\"value\":\"json patch\"}]",
+                                JSON_PATCH_RFC6902.mediaType()));
+        final HttpApiResponse jsonPatchFromResponse =
+                api.patch(
+                        patchRequest(
+                                path,
+                                "[{\"op\":\"copy\",\"from\":\"/forbidden\",\"path\":\"/name\"}]",
+                                JSON_PATCH_RFC6902.mediaType()));
+
+        Assertions.assertEquals(422, partialJsonResponse.getStatusCode());
+        Assertions.assertEquals(422, mergePatchResponse.getStatusCode());
+        Assertions.assertEquals(422, jsonPatchPathResponse.getStatusCode());
+        Assertions.assertEquals(422, jsonPatchFromResponse.getStatusCode());
+        Assertions.assertTrue(partialJsonResponse.getBody().contains("forbidden"));
+        Assertions.assertEquals("original", currentItemField(thingifier, item, "forbidden"));
+        Assertions.assertEquals("visible", currentItemField(thingifier, item, "name"));
+
+        final HttpApiResponse allowedMergePatchResponse =
+                api.patch(
+                        patchRequest(
+                                path,
+                                "{\"name\":\"updated\"}",
+                                JSON_MERGE_PATCH_RFC7396.mediaType()));
+
+        Assertions.assertEquals(200, allowedMergePatchResponse.getStatusCode());
+        Assertions.assertEquals("updated", currentItemField(thingifier, item, "name"));
+        Assertions.assertEquals("original", currentItemField(thingifier, item, "forbidden"));
+    }
+
     private Thingifier model() {
         Thingifier thingifier = new Thingifier();
 
@@ -209,10 +278,45 @@ class ThingifierApiSpecTest {
         return thingifier;
     }
 
+    private EntityInstance createItem(
+            final Thingifier thingifier,
+            final String name,
+            final String secret,
+            final String forbidden) {
+        final EntityDefinition item = thingifier.getDefinitionNamed("item");
+        return thingifier
+                .getStore(EntityRelModel.DEFAULT_DATABASE_NAME)
+                .entities()
+                .create(
+                        EntityInstanceDraft.forEntity(item)
+                                .withField("name", name)
+                                .withField("secret", secret)
+                                .withField("forbidden", forbidden));
+    }
+
+    private String currentItemField(
+            final Thingifier thingifier, final EntityInstance item, final String fieldName) {
+        return thingifier
+                .getStore(EntityRelModel.DEFAULT_DATABASE_NAME)
+                .entityQueries()
+                .findByQueryIdentifier(
+                        thingifier.getDefinitionNamed("item"), item.getPrimaryKeyValue())
+                .getFieldValue(fieldName)
+                .asString();
+    }
+
     private HttpApiRequest jsonRequest(final String path, final String body) {
         return new HttpApiRequest(path)
                 .setVerb("POST")
                 .addHeader("Content-Type", "application/json")
+                .addHeader("Accept", "application/json")
+                .setBody(body);
+    }
+
+    private HttpApiRequest patchRequest(
+            final String path, final String body, final String contentType) {
+        return new HttpApiRequest(path)
+                .addHeader("Content-Type", contentType)
                 .addHeader("Accept", "application/json")
                 .setBody(body);
     }


### PR DESCRIPTION
## Summary
- Include PATCH in HTTP request entity-view validation before dispatch.
- Validate partial JSON and JSON Merge Patch submitted top-level fields against the configured request view.
- Validate RFC 6902 JSON Patch `path` and `from` top-level fields, including root replacement values, before applying the patch.
- Add runtime coverage that PATCH rejects disallowed fields across all supported patch formats while still allowing permitted merge patches when stored disallowed fields already exist.

## Root Cause
PATCH was added to HTTP dispatch, but `validateEntityViewInput` returned immediately for every verb except POST and PUT. Routes configured with `requestEntityView(...)` or `entityView(...)` could therefore patch fields that the input view disallowed.

## Validation
- `mvn -pl thingifier '-Dtest=ThingifierApiSpecTest' test` (10 tests, 0 failures)
- `mvn -pl thingifier test` (522 tests, 0 failures)
- `mvn -pl thingifier spotless:check`
- `git diff --check`