### PR TITLE
Preserve PATCH content type policy

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/HttpApiRequestValidator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/HttpApiRequestValidator.java
@@ -52,14 +52,16 @@ public class HttpApiRequestValidator {
 
         if (apiResponse == null) {
             // only validate content if it contains content
-            if (verb == ThingifierHttpApi.HttpVerb.POST || verb == ThingifierHttpApi.HttpVerb.PUT) {
+            if (verb == ThingifierHttpApi.HttpVerb.POST
+                    || verb == ThingifierHttpApi.HttpVerb.PUT
+                    || verb == ThingifierHttpApi.HttpVerb.PATCH) {
 
-                apiResponse =
-                        new ContentTypeHeaderValidator(this.apiConfig)
-                                .validate(request.getContentTypeHeader());
+                apiResponse = validateWriteContentType(request, verb);
 
                 // validate the content syntax format against content type
-                if (apiResponse == null) {
+                if (apiResponse == null
+                        && (verb == ThingifierHttpApi.HttpVerb.POST
+                                || verb == ThingifierHttpApi.HttpVerb.PUT)) {
                     BodyParser parser = new BodyParser(request, new ArrayList<>());
                     String parsingError = "";
                     if (!apiConfig.willAllowJsonAsDefaultContentType()) {
@@ -76,6 +78,19 @@ public class HttpApiRequestValidator {
 
         this.isValid = (apiResponse == null);
         return this.isValid;
+    }
+
+    private ApiResponse validateWriteContentType(
+            final HttpApiRequest request, final ThingifierHttpApi.HttpVerb verb) {
+        final ContentTypeHeaderParser contentType =
+                new ContentTypeHeaderParser(request.getContentTypeHeader());
+        if (verb == ThingifierHttpApi.HttpVerb.PATCH
+                && (contentType.isJsonMergePatch() || contentType.isJsonPatch())) {
+            return null;
+        }
+
+        return new ContentTypeHeaderValidator(this.apiConfig)
+                .validate(request.getContentTypeHeader());
     }
 
     private ApiResponse validateQueryContent(final HttpApiRequest request) {

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/requests/ThingifierHttpApiRequestHandlingTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/requests/ThingifierHttpApiRequestHandlingTest.java
@@ -247,6 +247,64 @@ public class ThingifierHttpApiRequestHandlingTest {
     }
 
     @Test
+    public void patchHonoursJsonContentTypePolicyForPartialJsonUpdate() {
+        Thingifier thingifier = strictTypedThingifier();
+        thingifier.apiConfig().setApiToAllowJsonForContentType(false);
+        thingifier
+                .apiConfig()
+                .writeMethods()
+                .entities()
+                .patchCan(EntityPatchUpdateStyle.PARTIAL_JSON_UPDATE);
+        ThingifierHttpApi api = new ThingifierHttpApi(thingifier, null, null);
+        EntityInstance existing = createThing(thingifier, "Original");
+
+        HttpApiResponse response =
+                api.patch(
+                        jsonRequest(
+                                "/things/" + existing.getPrimaryKeyValue(),
+                                "{\"title\":\"Patched\"}"));
+
+        Assertions.assertEquals(
+                thingifier.apiConfig().statusCodes().contentTypeNotSupported(),
+                response.getStatusCode());
+        Assertions.assertTrue(response.getBody().contains("JSON Not Supported"));
+        Assertions.assertEquals("Original", currentThingTitle(thingifier, existing));
+    }
+
+    @Test
+    public void patchContentTypePolicyAllowsConfiguredPatchMediaTypes() {
+        Thingifier thingifier = strictTypedThingifier();
+        thingifier.apiConfig().setApiToAllowJsonForContentType(false);
+        thingifier
+                .apiConfig()
+                .writeMethods()
+                .entities()
+                .patchCan(
+                        EntityPatchUpdateStyle.JSON_MERGE_PATCH_RFC7396,
+                        EntityPatchUpdateStyle.JSON_PATCH_RFC6902);
+        ThingifierHttpApi api = new ThingifierHttpApi(thingifier, null, null);
+        EntityInstance existing = createThing(thingifier, "Original");
+        String path = "/things/" + existing.getPrimaryKeyValue();
+
+        HttpApiResponse mergePatchResponse =
+                api.patch(
+                        patchRequest(
+                                path,
+                                "{\"title\":\"Merged\"}",
+                                EntityPatchUpdateStyle.JSON_MERGE_PATCH_RFC7396.mediaType()));
+        HttpApiResponse jsonPatchResponse =
+                api.patch(
+                        patchRequest(
+                                path,
+                                "[{\"op\":\"replace\",\"path\":\"/title\",\"value\":\"Patched\"}]",
+                                EntityPatchUpdateStyle.JSON_PATCH_RFC6902.mediaType()));
+
+        Assertions.assertEquals(200, mergePatchResponse.getStatusCode());
+        Assertions.assertEquals(200, jsonPatchResponse.getStatusCode());
+        Assertions.assertEquals("Patched", currentThingTitle(thingifier, existing));
+    }
+
+    @Test
     public void aDeleteRequestWillCreateNewSessionWithDatabase() {
 
         Thingifier thingifier = getTestThingifier();
@@ -317,9 +375,26 @@ public class ThingifierHttpApiRequestHandlingTest {
                 .create(EntityInstanceDraft.forEntity(thing).withField("title", title));
     }
 
+    private String currentThingTitle(final Thingifier thingifier, final EntityInstance instance) {
+        return thingifier
+                .getStore(EntityRelModel.DEFAULT_DATABASE_NAME)
+                .entityQueries()
+                .findByQueryIdentifier(
+                        thingifier.getDefinitionNamed("thing"), instance.getPrimaryKeyValue())
+                .getFieldValue("title")
+                .asString();
+    }
+
     private HttpApiRequest jsonRequest(final String path, final String body) {
         return new HttpApiRequest(path)
                 .setHeaders(Map.of("content-type", "application/json"))
+                .setBody(body);
+    }
+
+    private HttpApiRequest patchRequest(
+            final String path, final String body, final String contentType) {
+        return new HttpApiRequest(path)
+                .setHeaders(Map.of("content-type", contentType))
                 .setBody(body);
     }
 }


### PR DESCRIPTION
## Summary
- Run write content-type validation for PATCH as well as POST and PUT.
- Keep plain `application/json` PATCH subject to the global JSON content policy.
- Allow PATCH-specific `application/merge-patch+json` and `application/json-patch+json` media types through to the PATCH handler/configuration checks.
- Add regression coverage for JSON-disabled partial PATCH rejection and configured patch media type acceptance.

## Root Cause
PATCH was removed from the shared request content-type validation path. That let enabled `application/json` PATCH requests bypass `setApiToAllowJsonForContentType(false)`, while POST and PUT still honored it.

## Validation
- `mvn -pl thingifier '-Dtest=ThingifierHttpApiRequestHandlingTest' test` (11 tests, 0 failures)
- `mvn -pl thingifier test` (524 tests, 0 failures)
- `mvn -pl thingifier spotless:check`
- `git diff --check`