### PR TITLE
Keep relationship POST in Allow header

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/WriteMethodPolicy.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/WriteMethodPolicy.java
@@ -370,6 +370,10 @@ public final class WriteMethodPolicy {
             final ThingRoute route,
             final RoutingVerb blockedVerb,
             final RelationshipWriteOperation blockedOperation) {
+        if (verb == RoutingVerb.POST && route instanceof RelationshipCollectionRoute) {
+            return !relationshipOperationsFor(verb, route).isEmpty();
+        }
+
         RelationshipWriteOperation operation =
                 verb == blockedVerb
                         ? blockedOperation

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/WriteMethodPolicyTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/WriteMethodPolicyTest.java
@@ -567,26 +567,28 @@ public class WriteMethodPolicyTest {
                                 "projects/" + project.getPrimaryKeyValue() + "/tasks",
                                 "{\"title\":\"New\"}")
                         .getStatusCode());
-        Assertions.assertEquals(
-                405,
+        ApiResponse blockedConnectExisting =
                 post(
-                                createOnly,
-                                "projects/" + project.getPrimaryKeyValue() + "/tasks",
-                                "{\"id\":" + task.getPrimaryKeyValue() + "}")
-                        .getStatusCode());
+                        createOnly,
+                        "projects/" + project.getPrimaryKeyValue() + "/tasks",
+                        "{\"id\":" + task.getPrimaryKeyValue() + "}");
+        Assertions.assertEquals(405, blockedConnectExisting.getStatusCode());
+        Assertions.assertEquals(
+                "OPTIONS, GET, HEAD, POST, QUERY", blockedConnectExisting.getHeaderValue("Allow"));
 
         Thingifier connectOnly = relationshipModel();
         connectOnly.apiConfig().writeMethods().relationships().postCan(CONNECT_EXISTING);
         EntityInstance otherProject = createProject(connectOnly, "Project");
         EntityInstance otherTask = createTask(connectOnly, "Existing");
 
-        Assertions.assertEquals(
-                405,
+        ApiResponse blockedCreateAndConnect =
                 post(
-                                connectOnly,
-                                "projects/" + otherProject.getPrimaryKeyValue() + "/tasks",
-                                "{\"title\":\"New\"}")
-                        .getStatusCode());
+                        connectOnly,
+                        "projects/" + otherProject.getPrimaryKeyValue() + "/tasks",
+                        "{\"title\":\"New\"}");
+        Assertions.assertEquals(405, blockedCreateAndConnect.getStatusCode());
+        Assertions.assertEquals(
+                "OPTIONS, GET, HEAD, POST, QUERY", blockedCreateAndConnect.getHeaderValue("Allow"));
         Assertions.assertEquals(
                 201,
                 post(


### PR DESCRIPTION
## Summary
- Keep `POST` in relationship collection `Allow` headers whenever any relationship POST operation is enabled.
- Avoid basing method availability on the rejected request body's specific relationship operation.
- Add regression assertions for create-only and connect-only relationship POST policies.

## Root Cause
When a relationship POST request attempted a disabled operation, the 405 `Allow` calculation reused that rejected operation to decide whether `POST` was available. If the route still allowed the other POST operation, the response could omit `POST` even though OPTIONS and valid POST bodies advertised/support it.

## Validation
- `mvn -pl thingifier '-Dtest=WriteMethodPolicyTest' test` (31 tests, 0 failures)
- `mvn -pl thingifier test` (524 tests, 0 failures)
- `mvn -pl thingifier spotless:check`
- `git diff --check`