### PR TITLE
Inline XML collection schemas

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/Swaggerizer.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/Swaggerizer.java
@@ -202,7 +202,7 @@ public class Swaggerizer {
                                             response.setContent(
                                                     responseContentWith(
                                                             ref,
-                                                            xmlResponseRefFor(
+                                                            xmlResponseSchemaFor(
                                                                     routingDefinitions,
                                                                     payloadName)));
                                         }
@@ -356,9 +356,6 @@ public class Swaggerizer {
             // add list response for entity plural
             ObjectSchema collectionObject = asJsonCollectionObjectSchema(objectSchemaDefinition);
             components.addSchemas(objectSchemaDefinition.getPlural(), collectionObject);
-            ArraySchema xmlCollectionObject = asXmlCollectionArraySchema(objectSchemaDefinition);
-            components.addSchemas(
-                    xmlCollectionSchemaNameFor(objectSchemaDefinition), xmlCollectionObject);
 
             for (EntityViewDefinition view : objectSchemaDefinition.getViews()) {
                 ObjectSchema viewObject = asResponseViewObjectSchema(view);
@@ -372,14 +369,14 @@ public class Swaggerizer {
         return components;
     }
 
-    private String xmlResponseRefFor(
+    private Schema<?> xmlResponseSchemaFor(
             final ApiRoutingDefinition routingDefinitions, final String payloadName) {
         for (EntityDefinition definition : routingDefinitions.getObjectSchemas()) {
             if (definition.getPlural().equals(payloadName)) {
-                return "#/components/schemas/" + xmlCollectionSchemaNameFor(definition);
+                return asXmlCollectionArraySchema(definition);
             }
         }
-        return "#/components/schemas/" + payloadName;
+        return refSchemaFor("#/components/schemas/" + payloadName);
     }
 
     private void addParamSchemeValidationFromField(Schema<String> schema, Field aField) {
@@ -580,16 +577,16 @@ public class Swaggerizer {
         }
     }
 
-    private Content responseContentWith(final String jsonRef, final String xmlRef) {
+    private Content responseContentWith(final String jsonRef, final Schema<?> xmlSchema) {
         Content content = new Content();
         for (AcceptHeaderParser.ACCEPT_TYPE responseType :
                 AcceptHeaderParser.ACCEPT_TYPE.responseMediaTypes()) {
             if (responseType.usesComponentSchemaInDocumentation()) {
-                Schema<String> object = new Schema<>();
                 MediaType schema = new MediaType();
-                schema.setSchema(object);
-                object.set$ref(
-                        responseType == AcceptHeaderParser.ACCEPT_TYPE.XML ? xmlRef : jsonRef);
+                schema.setSchema(
+                        responseType == AcceptHeaderParser.ACCEPT_TYPE.XML
+                                ? xmlSchema
+                                : refSchemaFor(jsonRef));
                 content.addMediaType(responseType.mediaType(), schema);
             } else {
                 MediaType textSchema = new MediaType();
@@ -598,6 +595,12 @@ public class Swaggerizer {
             }
         }
         return content;
+    }
+
+    private Schema<?> refSchemaFor(final String ref) {
+        Schema<String> object = new Schema<>();
+        object.set$ref(ref);
+        return object;
     }
 
     private void addHttpSecurityScheme(
@@ -646,10 +649,6 @@ public class Swaggerizer {
         collectionObject.setXml(xml);
 
         return collectionObject;
-    }
-
-    private static String xmlCollectionSchemaNameFor(EntityDefinition objectSchemaDefinition) {
-        return objectSchemaDefinition.getPlural() + "_xml_collection";
     }
 
     private static ObjectSchema asRequiredResponseObjectSchema(

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerEntityDescriptionTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerEntityDescriptionTest.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import java.util.List;
 import java.util.Set;
@@ -57,7 +58,7 @@ class SwaggerizerEntityDescriptionTest {
                         .getSchema()
                         .get$ref());
         Assertions.assertEquals(
-                "#/components/schemas/todos_xml_collection",
+                "array",
                 relationshipCollection
                         .getGet()
                         .getResponses()
@@ -65,7 +66,18 @@ class SwaggerizerEntityDescriptionTest {
                         .getContent()
                         .get("application/xml")
                         .getSchema()
-                        .get$ref());
+                        .getType());
+        Assertions.assertEquals(
+                "todos",
+                relationshipCollection
+                        .getGet()
+                        .getResponses()
+                        .get("200")
+                        .getContent()
+                        .get("application/xml")
+                        .getSchema()
+                        .getXml()
+                        .getName());
         Assertions.assertNotNull(relationshipCollection.getPost().getRequestBody());
         Assertions.assertEquals(
                 "#/components/schemas/todo",
@@ -110,9 +122,11 @@ class SwaggerizerEntityDescriptionTest {
         Assertions.assertEquals(
                 "#/components/schemas/projects",
                 content.get("application/json").getSchema().get$ref());
-        Assertions.assertEquals(
-                "#/components/schemas/projects_xml_collection",
-                content.get("application/xml").getSchema().get$ref());
+        final Schema<?> xmlCollectionSchema = content.get("application/xml").getSchema();
+        Assertions.assertNull(xmlCollectionSchema.get$ref());
+        Assertions.assertEquals("array", xmlCollectionSchema.getType());
+        Assertions.assertEquals("projects", xmlCollectionSchema.getXml().getName());
+        Assertions.assertTrue(xmlCollectionSchema.getXml().getWrapped());
         for (String mediaType :
                 List.of(
                         "text/csv",

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerSchemaExampleTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerSchemaExampleTest.java
@@ -37,9 +37,10 @@ class SwaggerizerSchemaExampleTest {
         final JsonObject itemsProperty =
                 itemsSchema.getAsJsonObject("properties").getAsJsonObject("items");
         final JsonObject itemSchema = itemsProperty.getAsJsonObject("items");
-        final JsonObject xmlItemsSchema = schemas.getAsJsonObject("items_xml_collection");
+        final JsonObject xmlItemsSchema = responseSchemaFor(document, "/items", "application/xml");
         final JsonObject xmlItemSchema = xmlItemsSchema.getAsJsonObject("items");
 
+        Assertions.assertFalse(schemas.has("items_xml_collection"));
         Assertions.assertEquals("object", itemsSchema.get("type").getAsString());
         Assertions.assertEquals("array", itemsProperty.get("type").getAsString());
         Assertions.assertEquals("object", itemSchema.get("type").getAsString());
@@ -60,18 +61,7 @@ class SwaggerizerSchemaExampleTest {
                         .getAsJsonObject("schema")
                         .get("$ref")
                         .getAsString());
-        Assertions.assertEquals(
-                "#/components/schemas/items_xml_collection",
-                document.getAsJsonObject("paths")
-                        .getAsJsonObject("/items")
-                        .getAsJsonObject("get")
-                        .getAsJsonObject("responses")
-                        .getAsJsonObject("200")
-                        .getAsJsonObject("content")
-                        .getAsJsonObject("application/xml")
-                        .getAsJsonObject("schema")
-                        .get("$ref")
-                        .getAsString());
+        Assertions.assertFalse(xmlItemsSchema.has("$ref"));
 
         Assertions.assertEquals("array", xmlItemsSchema.get("type").getAsString());
         Assertions.assertEquals(
@@ -83,6 +73,48 @@ class SwaggerizerSchemaExampleTest {
         Assertions.assertEquals(
                 Set.of("id", "type", "isbn13", "price", "numberinstock"),
                 requiredPropertiesIn(xmlItemSchema, "XML item"));
+    }
+
+    @Test
+    void generatedXmlCollectionSchemasDoNotCollideWithEntityNames() {
+        final Thingifier thingifier = new Thingifier();
+        final EntityDefinition item = thingifier.defineThing("item", "items");
+        item.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT));
+
+        final EntityDefinition collision =
+                thingifier.defineThing("items_xml_collection", "xml_items");
+        collision.addAsPrimaryKeyField(Field.is("collisionId", FieldType.AUTO_INCREMENT));
+
+        final ThingifierApiDocumentationDefn apiDefn =
+                new ThingifierApiDocumentationDefn().setThingifier(thingifier);
+
+        final JsonObject document =
+                JsonParser.parseString(new Swaggerizer(apiDefn).asJson()).getAsJsonObject();
+        final JsonObject schemas =
+                document.getAsJsonObject("components").getAsJsonObject("schemas");
+        final JsonObject collisionSchema = schemas.getAsJsonObject("items_xml_collection");
+        final JsonObject itemXmlSchema = responseSchemaFor(document, "/items", "application/xml");
+
+        Assertions.assertEquals("object", collisionSchema.get("type").getAsString());
+        Assertions.assertTrue(
+                collisionSchema.getAsJsonObject("properties").has("collisionId"),
+                "The model-defined component should not be overwritten");
+        Assertions.assertEquals("array", itemXmlSchema.get("type").getAsString());
+        Assertions.assertFalse(itemXmlSchema.has("$ref"));
+        Assertions.assertEquals(
+                "items", itemXmlSchema.getAsJsonObject("xml").get("name").getAsString());
+    }
+
+    private JsonObject responseSchemaFor(
+            final JsonObject document, final String path, final String mediaType) {
+        return document.getAsJsonObject("paths")
+                .getAsJsonObject(path)
+                .getAsJsonObject("get")
+                .getAsJsonObject("responses")
+                .getAsJsonObject("200")
+                .getAsJsonObject("content")
+                .getAsJsonObject(mediaType)
+                .getAsJsonObject("schema");
     }
 
     private Set<String> requiredPropertiesIn(final JsonObject schema, final String schemaName) {


### PR DESCRIPTION
## Summary
- Stop registering generated XML collection schemas as named OpenAPI components.
- Inline XML wrapped-array schemas in `application/xml` response content while keeping JSON responses on the normal collection component.
- Add a regression test showing a model-defined `items_xml_collection` component is preserved and not overwritten by generated XML collection documentation.

## Root Cause
XML collection response schemas were registered under `<plural>_xml_collection`, which is derived from caller-defined plural names. If an entity or view used that same name, schema registration order could overwrite either the generated XML schema or the model-defined component.

## Validation
- `mvn -pl thingifier '-Dtest=SwaggerizerSchemaExampleTest,SwaggerizerEntityDescriptionTest' test` (9 tests, 0 failures)
- `mvn -pl thingifier test` (525 tests, 0 failures)
- `mvn -pl thingifier spotless:check`
- `git diff --check`