### PR TITLE
Handle null JSON Patch bodies

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/EntityPatchDocumentMapper.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/EntityPatchDocumentMapper.java
@@ -95,7 +95,7 @@ public final class EntityPatchDocumentMapper {
         JsonNode patchDocument;
         try {
             patchDocument = JsonBodyValueConverter.readTree(rawBody);
-        } catch (JsonProcessingException e) {
+        } catch (JsonProcessingException | IllegalArgumentException e) {
             return malformedPatch("Malformed JSON Patch document");
         }
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
@@ -324,7 +324,7 @@ public final class ThingifierHttpApi {
         final JsonNode operations;
         try {
             operations = JsonBodyValueConverter.readTree(rawBody);
-        } catch (JsonProcessingException e) {
+        } catch (JsonProcessingException | IllegalArgumentException e) {
             return inputFields;
         }
 

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpecTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpecTest.java
@@ -225,12 +225,18 @@ class ThingifierApiSpecTest {
                                 path,
                                 "[{\"op\":\"copy\",\"from\":\"/forbidden\",\"path\":\"/name\"}]",
                                 JSON_PATCH_RFC6902.mediaType()));
+        final HttpApiResponse jsonPatchWithNullBodyResponse =
+                api.patch(patchRequestWithNullBody(path, JSON_PATCH_RFC6902.mediaType()));
 
         Assertions.assertEquals(422, partialJsonResponse.getStatusCode());
         Assertions.assertEquals(422, mergePatchResponse.getStatusCode());
         Assertions.assertEquals(422, jsonPatchPathResponse.getStatusCode());
         Assertions.assertEquals(422, jsonPatchFromResponse.getStatusCode());
+        Assertions.assertEquals(400, jsonPatchWithNullBodyResponse.getStatusCode());
         Assertions.assertTrue(partialJsonResponse.getBody().contains("forbidden"));
+        Assertions.assertTrue(
+                jsonPatchWithNullBodyResponse.getBody().contains("JSON Patch"),
+                jsonPatchWithNullBodyResponse.getBody());
         Assertions.assertEquals("original", currentItemField(thingifier, item, "forbidden"));
         Assertions.assertEquals("visible", currentItemField(thingifier, item, "name"));
 
@@ -319,6 +325,13 @@ class ThingifierApiSpecTest {
                 .addHeader("Content-Type", contentType)
                 .addHeader("Accept", "application/json")
                 .setBody(body);
+    }
+
+    private HttpApiRequest patchRequestWithNullBody(final String path, final String contentType) {
+        return new HttpApiRequest(path)
+                .addHeader("Content-Type", contentType)
+                .addHeader("Accept", "application/json")
+                .setBody(null);
     }
 
     private RoutingDefinition route(


### PR DESCRIPTION
## Summary
- Catch `IllegalArgumentException` while extracting JSON Patch view-input fields.
- Catch the same exception in the JSON Patch document mapper so null/raw invalid bodies return controlled 4xx responses.
- Add a regression for a PATCH route with a request entity view receiving a null JSON Patch body.

## Root Cause
`jsonPatchInputFields` only handled `JsonProcessingException` from `JsonBodyValueConverter.readTree(rawBody)`. If callers provided a null body, parsing could raise a runtime argument exception before normal PATCH handling could produce a client error response.

## Validation
- `mvn -pl thingifier '-Dtest=ThingifierApiSpecTest#patchRequestEntityViewsRejectDisallowedInputFieldsAtRuntime' test` (1 test, 0 failures)
- `mvn -pl thingifier '-Dtest=ThingifierApiSpecTest' test` (10 tests, 0 failures)
- `mvn -pl thingifier test` (525 tests, 0 failures)
- `mvn -pl thingifier spotless:check`
- `git diff --check`