### PR TITLE
Assert merge patch updates entity

### DIFF
--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/requests/ThingifierHttpApiRequestHandlingTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/requests/ThingifierHttpApiRequestHandlingTest.java
@@ -292,6 +292,10 @@ public class ThingifierHttpApiRequestHandlingTest {
                                 path,
                                 "{\"title\":\"Merged\"}",
                                 EntityPatchUpdateStyle.JSON_MERGE_PATCH_RFC7396.mediaType()));
+
+        Assertions.assertEquals(200, mergePatchResponse.getStatusCode());
+        Assertions.assertEquals("Merged", currentThingTitle(thingifier, existing));
+
         HttpApiResponse jsonPatchResponse =
                 api.patch(
                         patchRequest(
@@ -299,7 +303,6 @@ public class ThingifierHttpApiRequestHandlingTest {
                                 "[{\"op\":\"replace\",\"path\":\"/title\",\"value\":\"Patched\"}]",
                                 EntityPatchUpdateStyle.JSON_PATCH_RFC6902.mediaType()));
 
-        Assertions.assertEquals(200, mergePatchResponse.getStatusCode());
         Assertions.assertEquals(200, jsonPatchResponse.getStatusCode());
         Assertions.assertEquals("Patched", currentThingTitle(thingifier, existing));
     }


### PR DESCRIPTION
## Summary
- Move the JSON Patch request until after the merge-patch assertions in `ThingifierHttpApiRequestHandlingTest`.
- Assert the JSON Merge Patch request both returns 200 and updates the stored title to `Merged` before JSON Patch changes it to `Patched`.

## Root Cause
The test only asserted the final title after a subsequent JSON Patch request. A no-op JSON Merge Patch implementation could still return 200 and leave the test passing because JSON Patch performed the visible mutation.

## Validation
- `mvn -pl thingifier '-Dtest=ThingifierHttpApiRequestHandlingTest' test` (11 tests, 0 failures)
- `mvn -pl thingifier test` (525 tests, 0 failures)
- `mvn -pl thingifier spotless:check`
- `git diff --check`