### PR TITLE
Enforce PATCH validation and verification gates

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -16,5 +16,5 @@ run_maven() {
   fi
 }
 
-echo "Running Spotless formatting check..."
-run_maven -q spotless:check
+echo "Running full Maven verification..."
+run_maven -B clean verify

--- a/.github/workflows/run-juit-tests.yml
+++ b/.github/workflows/run-juit-tests.yml
@@ -4,6 +4,7 @@ name: Java CI
 
 on:
   push:
+  pull_request:
   workflow_dispatch:
 
 
@@ -39,5 +40,5 @@ jobs:
           distribution: temurin
           java-version: ${{ matrix.java }}
           cache: maven
-      - name: Build with Maven
-        run: mvn -B clean test
+      - name: Verify with Maven
+        run: mvn -B clean verify

--- a/.github/workflows/run-juit-tests.yml
+++ b/.github/workflows/run-juit-tests.yml
@@ -4,7 +4,11 @@ name: Java CI
 
 on:
   push:
+    branches:
+      - master
   pull_request:
+    branches:
+      - master
   workflow_dispatch:
 
 
@@ -41,4 +45,4 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: maven
       - name: Verify with Maven
-        run: mvn -B clean verify
+        run: mvn -B "-Dspotless.check.skip=true" clean verify

--- a/checkstyle-project-fqn.xml
+++ b/checkstyle-project-fqn.xml
@@ -105,6 +105,10 @@
         <property name="files" value=".*[/\\]thingifierapp[/\\]src[/\\]main[/\\]java[/\\]uk[/\\]co[/\\]compendiumdev[/\\]thingifier[/\\]application[/\\]Main\.java"/>
     </module>
     <module name="SuppressionSingleFilter">
+        <property name="id" value="applicationNoHttpVerbVocabulary"/>
+        <property name="files" value=".*[/\\]examplemodels[/\\]src[/\\]main[/\\]java[/\\]uk[/\\]co[/\\]compendiumdev[/\\]thingifier[/\\]application[/\\]examples[/\\].*"/>
+    </module>
+    <module name="SuppressionSingleFilter">
         <property name="id" value="applicationNoHttpStatusOrTypes"/>
         <property name="files" value=".*[/\\]src[/\\]test[/\\]java[/\\].*"/>
     </module>
@@ -135,6 +139,10 @@
     <module name="SuppressionSingleFilter">
         <property name="id" value="schemaDefinitionSpecsNoMutableRuntimeSchema"/>
         <property name="files" value=".*[/\\]thingifier[/\\]src[/\\]main[/\\]java[/\\]uk[/\\]co[/\\]compendiumdev[/\\]thingifier[/\\]application[/\\]schema[/\\]definition[/\\]ThingifierModel(Assembler|Exporter)\.java"/>
+    </module>
+    <module name="SuppressionSingleFilter">
+        <property name="id" value="productionDeprecatedApi"/>
+        <property name="files" value=".*[/\\]thingifier[/\\]src[/\\]main[/\\]java[/\\]uk[/\\]co[/\\]compendiumdev[/\\]thingifier[/\\]Thingifier\.java"/>
     </module>
     <module name="RegexpMultiline">
         <property name="id" value="commandDtosNoMutableDomain"/>

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,8 @@ mvn spotless:check
 ```
 
 The repository includes a pre-commit hook that runs the Spotless check before
-each commit. Enable the versioned hooks in a clone with:
+each commit as part of the full Maven verification. Enable the versioned hooks
+in a clone with:
 
 ```shell
 git config core.hooksPath .githooks
@@ -68,8 +69,19 @@ On Unix-like systems, if Git reports that the hook is not executable, run:
 chmod +x .githooks/pre-commit
 ```
 
-GitHub Actions also runs `mvn -B spotless:check` in both Java 17 and Java 21
-matrix builds before running the Maven tests.
+## Local Verification
+
+Run the same verification used by the pre-commit hook and CI with:
+
+```shell
+mvn -B clean verify
+```
+
+This runs unit tests, integration tests, Spotless, Checkstyle, and PMD.
+
+GitHub Actions runs on push, pull request, and manual dispatch. It runs a fast
+`mvn -B spotless:check` formatting job and full `mvn -B clean verify` jobs on
+Java 17 and Java 21.
     
 ## Details
 

--- a/readme.md
+++ b/readme.md
@@ -79,9 +79,10 @@ mvn -B clean verify
 
 This runs unit tests, integration tests, Spotless, Checkstyle, and PMD.
 
-GitHub Actions runs on push, pull request, and manual dispatch. It runs a fast
-`mvn -B spotless:check` formatting job and full `mvn -B clean verify` jobs on
-Java 17 and Java 21.
+GitHub Actions runs on pushes to `master`, pull requests targeting `master`,
+and manual dispatch. It runs a fast `mvn -B spotless:check` formatting job and
+Java 17/21 `mvn -B "-Dspotless.check.skip=true" clean verify` jobs for compile,
+unit tests, integration tests, Checkstyle, and PMD.
     
 ## Details
 

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/CrudUiApiIT.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/CrudUiApiIT.java
@@ -138,7 +138,7 @@ public class CrudUiApiIT {
 
         CrudUiApiClient.ApiResult disconnected =
                 api.delete("/api/projects/" + projectId + "/tasks/" + todoId);
-        Assertions.assertEquals(200, disconnected.statusCode(), disconnected.body());
+        Assertions.assertEquals(204, disconnected.statusCode(), disconnected.body());
         Assertions.assertTrue(api.get("/api/todos/" + todoId).body().contains("Do this"));
     }
 

--- a/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/WorkspaceUiIT.java
+++ b/thingifier-crud-ui/src/test/java/uk/co/compendiumdev/thingifier/crudui/e2e/WorkspaceUiIT.java
@@ -73,7 +73,7 @@ public class WorkspaceUiIT extends BrowserTestBase {
         page.navigate(server().baseUrl() + "/");
         workspace.topBar().openSwagger();
         page.waitForURL("**/swagger");
-        assertThat(page.locator("body")).containsText("Explore");
+        assertThat(page.locator("body")).containsText("Select a definition");
         page.navigate(server().baseUrl() + "/");
         Assertions.assertTrue(
                 workspace.topBar().downloadOpenApi().suggestedFilename().endsWith(".json"));

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/DefaultThingifierApiRuntime.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/DefaultThingifierApiRuntime.java
@@ -51,7 +51,8 @@ public final class DefaultThingifierApiRuntime implements ThingifierApiRuntime {
         return new ThingCommandService(
                 context.store(),
                 schema,
-                thingifier.apiConfig().willApiEnforceDeclaredTypesInInput());
+                thingifier.apiConfig().willApiEnforceDeclaredTypesInInput(),
+                thingifier.apiConfig().jsonOutput());
     }
 
     @Override

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/EntityPatchDocumentMapper.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/EntityPatchDocumentMapper.java
@@ -2,35 +2,23 @@ package uk.co.compendiumdev.thingifier.adapter.http.apihandlers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.flipkart.zjsonpatch.JsonPatch;
-import java.util.Map;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.InstanceRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
-import uk.co.compendiumdev.thingifier.api.ermodelconversion.JsonThing;
-import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.JsonBodyValueConverter;
 import uk.co.compendiumdev.thingifier.apiconfig.EntityPatchUpdateStyle;
-import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
-import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
+import uk.co.compendiumdev.thingifier.application.command.PatchThingDocumentCommand;
 
 public final class EntityPatchDocumentMapper {
 
-    private final ThingifierApiRuntime runtime;
     private final ThingWriteRequestMapper writeMapper;
 
-    public EntityPatchDocumentMapper(final ThingifierApiRuntime runtime) {
-        this.runtime = runtime;
-        this.writeMapper = new ThingWriteRequestMapper(runtime.schema());
+    public EntityPatchDocumentMapper(final SchemaCatalog schema) {
+        this.writeMapper = new ThingWriteRequestMapper(schema);
     }
 
     public ThingWriteRequestMapping map(
-            final EntityPatchUpdateStyle style,
-            final ThingRoute route,
-            final String rawBody,
-            final ThingifierRequestContext context) {
+            final EntityPatchUpdateStyle style, final ThingRoute route, final String rawBody) {
         if (!(route instanceof InstanceRoute)) {
             return writeMapper.mapPatch(route, ApiBodyFields.empty());
         }
@@ -40,10 +28,16 @@ public final class EntityPatchDocumentMapper {
             return mapPartialJsonUpdate(instanceRoute, rawBody);
         }
         if (style == EntityPatchUpdateStyle.JSON_MERGE_PATCH_RFC7396) {
-            return mapJsonMergePatch(instanceRoute, rawBody, context);
+            return mapJsonDocumentPatch(
+                    instanceRoute,
+                    rawBody,
+                    PatchThingDocumentCommand.DocumentStyle.JSON_MERGE_PATCH_RFC7396);
         }
         if (style == EntityPatchUpdateStyle.JSON_PATCH_RFC6902) {
-            return mapJsonPatch(instanceRoute, rawBody, context);
+            return mapJsonDocumentPatch(
+                    instanceRoute,
+                    rawBody,
+                    PatchThingDocumentCommand.DocumentStyle.JSON_PATCH_RFC6902);
         }
 
         return ThingWriteRequestMapping.error(
@@ -59,117 +53,14 @@ public final class EntityPatchDocumentMapper {
         return writeMapper.mapPatch(route, parsed.bodyFields());
     }
 
-    private ThingWriteRequestMapping mapJsonMergePatch(
+    private ThingWriteRequestMapping mapJsonDocumentPatch(
             final InstanceRoute route,
             final String rawBody,
-            final ThingifierRequestContext context) {
-        EntityInstance instance = findInstance(route, context);
-        if (instance == null) {
-            return missingInstance(route);
-        }
-
-        JsonNode patchDocument;
-        try {
-            patchDocument = JsonBodyValueConverter.readTree(rawBody);
-        } catch (JsonProcessingException e) {
-            return malformedPatch("Malformed JSON Merge Patch document");
-        }
-
-        if (patchDocument == null || !patchDocument.isObject()) {
-            return unprocessablePatch("JSON Merge Patch for entity resources must be an object");
-        }
-
-        JsonNode patchedDocument = applyMergePatch(jsonFor(instance), patchDocument);
-        return mapReplacement(route, patchedDocument);
-    }
-
-    private ThingWriteRequestMapping mapJsonPatch(
-            final InstanceRoute route,
-            final String rawBody,
-            final ThingifierRequestContext context) {
-        EntityInstance instance = findInstance(route, context);
-        if (instance == null) {
-            return missingInstance(route);
-        }
-
-        JsonNode patchDocument;
-        try {
-            patchDocument = JsonBodyValueConverter.readTree(rawBody);
-        } catch (JsonProcessingException | IllegalArgumentException e) {
-            return malformedPatch("Malformed JSON Patch document");
-        }
-
-        if (patchDocument == null || !patchDocument.isArray()) {
-            return malformedPatch("JSON Patch document must be an array of operations");
-        }
-
-        JsonNode patchedDocument;
-        try {
-            patchedDocument = JsonPatch.apply(patchDocument, jsonFor(instance));
-        } catch (RuntimeException e) {
-            return conflictingPatch("JSON Patch could not be applied");
-        }
-
-        return mapReplacement(route, patchedDocument);
-    }
-
-    private JsonNode applyMergePatch(final JsonNode target, final JsonNode patch) {
-        if (!patch.isObject()) {
-            return patch;
-        }
-
-        ObjectNode result =
-                target != null && target.isObject()
-                        ? ((ObjectNode) target).deepCopy()
-                        : JsonNodeFactory.instance.objectNode();
-        for (Map.Entry<String, JsonNode> entry : patch.properties()) {
-            if (entry.getValue().isNull()) {
-                result.remove(entry.getKey());
-            } else {
-                result.set(
-                        entry.getKey(),
-                        applyMergePatch(result.get(entry.getKey()), entry.getValue()));
-            }
-        }
-        return result;
-    }
-
-    private ThingWriteRequestMapping mapReplacement(
-            final InstanceRoute route, final JsonNode patchedDocument) {
-        if (patchedDocument == null || !patchedDocument.isObject()) {
-            return unprocessablePatch("PATCH result for entity resources must be an object");
-        }
-
-        return writeMapper.mapPatchReplacingFields(
-                route,
-                ApiBodyFields.fromMap(JsonBodyValueConverter.objectNodeAsMap(patchedDocument)));
-    }
-
-    private JsonNode jsonFor(final EntityInstance instance) {
-        try {
-            return JsonBodyValueConverter.readTree(
-                    new JsonThing(runtime.apiConfig().jsonOutput())
-                            .asJsonObject(instance)
-                            .toString());
-        } catch (JsonProcessingException e) {
-            throw new IllegalStateException("Could not render entity instance as JSON", e);
-        }
-    }
-
-    private EntityInstance findInstance(
-            final InstanceRoute route, final ThingifierRequestContext context) {
-        EntityDefinition entity =
-                runtime.schema().definitionWithSingularOrPluralNamed(route.entity().name());
-        if (entity == null) {
-            return null;
-        }
-        return context.store().entityQueries().findByQueryIdentifier(entity, route.identifier());
-    }
-
-    private ThingWriteRequestMapping missingInstance(final InstanceRoute route) {
-        return ThingWriteRequestMapping.error(
-                ApiMappingError.withMessage(
-                        404,
+            final PatchThingDocumentCommand.DocumentStyle style) {
+        return ThingWriteRequestMapping.command(
+                new PatchThingDocumentCommand(
+                        route.entity().name(), route.identifier(), rawBody, style),
+                ApiRouteDisplay.missingInstanceMessage(
                         String.format(
                                 "No such %s entity instance with %s == %s found",
                                 route.entity().name(),
@@ -203,14 +94,6 @@ public final class EntityPatchDocumentMapper {
 
     private ThingWriteRequestMapping malformedPatch(final String message) {
         return ThingWriteRequestMapping.error(ApiMappingError.withMessage(400, message));
-    }
-
-    private ThingWriteRequestMapping unprocessablePatch(final String message) {
-        return ThingWriteRequestMapping.error(ApiMappingError.withMessage(422, message));
-    }
-
-    private ThingWriteRequestMapping conflictingPatch(final String message) {
-        return ThingWriteRequestMapping.error(ApiMappingError.withMessage(409, message));
     }
 
     private static final class ParseResult {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/ThingCommandResultApiMapper.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/ThingCommandResultApiMapper.java
@@ -11,6 +11,7 @@ import uk.co.compendiumdev.thingifier.application.command.CreateAndConnectRelati
 import uk.co.compendiumdev.thingifier.application.command.CreateThingCommand;
 import uk.co.compendiumdev.thingifier.application.command.DeleteThingCommand;
 import uk.co.compendiumdev.thingifier.application.command.DisconnectRelationshipCommand;
+import uk.co.compendiumdev.thingifier.application.command.PatchThingDocumentCommand;
 import uk.co.compendiumdev.thingifier.application.command.RelateThingCommand;
 import uk.co.compendiumdev.thingifier.application.command.ReplaceThingCommand;
 import uk.co.compendiumdev.thingifier.application.command.ThingWriteCommand;
@@ -69,7 +70,7 @@ public final class ThingCommandResultApiMapper {
             return ApiResponse.success().returnSingleInstance(result.getInstance());
         }
 
-        if (command instanceof AmendThingCommand) {
+        if (command instanceof AmendThingCommand || command instanceof PatchThingDocumentCommand) {
             return ApiResponse.success().returnSingleInstance(result.getInstance());
         }
 
@@ -106,6 +107,9 @@ public final class ThingCommandResultApiMapper {
         if (error == null) {
             return 400;
         }
+        if (error.category() == ApplicationError.Category.BAD_REQUEST) {
+            return 400;
+        }
         if (error.category() == ApplicationError.Category.NOT_FOUND) {
             return 404;
         }
@@ -139,6 +143,10 @@ public final class ThingCommandResultApiMapper {
                             error.detail("entityName"),
                             error.detail("routeIdentifier"),
                             error.detail("bodyIdentifier")));
+        }
+
+        if (error.code() == ApplicationError.Code.PATCH_RESULT_NOT_OBJECT) {
+            return List.of("PATCH result for entity resources must be an object");
         }
 
         if (error.code() == ApplicationError.Code.INSTANCE_NOT_FOUND) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
@@ -3,6 +3,7 @@ package uk.co.compendiumdev.thingifier.api.http;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.flipkart.zjsonpatch.JsonPatch;
+import com.flipkart.zjsonpatch.JsonPatchApplicationException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -389,7 +390,9 @@ public final class ThingifierHttpApi {
             if (patchedDocument != null && patchedDocument.isObject()) {
                 return Optional.of(bodyFieldsForObject(patchedDocument));
             }
-        } catch (JsonProcessingException | RuntimeException e) {
+        } catch (JsonProcessingException
+                | JsonPatchApplicationException
+                | IllegalArgumentException e) {
             return Optional.empty();
         }
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPatchHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPatchHandler.java
@@ -14,7 +14,6 @@ import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRouteMapper;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
-import uk.co.compendiumdev.thingifier.api.http.bodyparser.BodyParser;
 import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
 import uk.co.compendiumdev.thingifier.apiconfig.EntityPatchUpdateStyle;
@@ -29,16 +28,6 @@ public class RestApiPatchHandler {
 
     public RestApiPatchHandler(final ThingifierApiRuntime runtime) {
         this.runtime = runtime;
-    }
-
-    public ApiResponse handle(
-            final String url, final BodyParser args, final HttpHeadersBlock requestHeaders) {
-        return handle(url, args.rawBody(), requestHeaders, runtime.contextFrom(requestHeaders));
-    }
-
-    public ApiResponse handle(
-            final String url, final BodyParser args, final ThingifierRequestContext context) {
-        return handle(url, args.rawBody(), new HttpHeadersBlock(), context);
     }
 
     public ApiResponse handle(
@@ -68,12 +57,11 @@ public class RestApiPatchHandler {
         }
 
         ThingWriteRequestMapping mapping =
-                new EntityPatchDocumentMapper(runtime)
+                new EntityPatchDocumentMapper(runtime.schema())
                         .map(
                                 style.orElse(EntityPatchUpdateStyle.PARTIAL_JSON_UPDATE),
                                 route,
-                                rawBody,
-                                context);
+                                rawBody);
         ThingCommandResultApiMapper apiMapper =
                 new ThingCommandResultApiMapper(runtime.apiConfig());
         if (mapping.isError()) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/ApplicationError.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/ApplicationError.java
@@ -10,6 +10,7 @@ import java.util.Map;
 public final class ApplicationError {
 
     public enum Category {
+        BAD_REQUEST,
         VALIDATION,
         NOT_FOUND,
         CONFLICT,
@@ -27,6 +28,8 @@ public final class ApplicationError {
         UNSUPPORTED_COMMAND,
         REPLACE_CREATE_AUTO_FIELDS_NOT_ALLOWED,
         REPLACE_CREATE_KEY_MISMATCH,
+        BAD_REQUEST,
+        PATCH_RESULT_NOT_OBJECT,
         MAX_INSTANCE_LIMIT_REACHED,
         MAX_INSTANCE_LIMIT_WOULD_BE_EXCEEDED,
         DUPLICATE_PRIMARY_KEY,
@@ -57,6 +60,11 @@ public final class ApplicationError {
     public static ApplicationError validation(final Collection<String> messages) {
         return new ApplicationError(
                 Category.VALIDATION, Code.VALIDATION_FAILED, messages, Map.of());
+    }
+
+    public static ApplicationError badRequest(final String message) {
+        return new ApplicationError(
+                Category.BAD_REQUEST, Code.BAD_REQUEST, List.of(message), Map.of());
     }
 
     public static ApplicationError notFound(final String message) {
@@ -186,6 +194,14 @@ public final class ApplicationError {
                         routeIdentifier,
                         "bodyIdentifier",
                         bodyIdentifier));
+    }
+
+    public static ApplicationError patchResultNotObject() {
+        return new ApplicationError(
+                Category.VALIDATION,
+                Code.PATCH_RESULT_NOT_OBJECT,
+                List.of("Patch result for entity resources must be an object"),
+                Map.of());
     }
 
     public Category category() {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/PatchThingDocumentHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/PatchThingDocumentHandler.java
@@ -1,0 +1,211 @@
+package uk.co.compendiumdev.thingifier.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.flipkart.zjsonpatch.JsonPatch;
+import com.flipkart.zjsonpatch.JsonPatchApplicationException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import uk.co.compendiumdev.thingifier.api.ermodelconversion.JsonThing;
+import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyField;
+import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields;
+import uk.co.compendiumdev.thingifier.api.http.bodyparser.JsonBodyValueConverter;
+import uk.co.compendiumdev.thingifier.apiconfig.JsonOutputConfig;
+import uk.co.compendiumdev.thingifier.application.command.AmendThingCommand;
+import uk.co.compendiumdev.thingifier.application.command.BodyFieldValue;
+import uk.co.compendiumdev.thingifier.application.command.PatchThingDocumentCommand;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.instance.NamedValue;
+import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
+
+final class PatchThingDocumentHandler {
+
+    private final ThingDefinitionResolver definitions;
+    private final AmendThingHandler amendHandler;
+    private final JsonOutputConfig jsonOutput;
+
+    PatchThingDocumentHandler(
+            final ThingDefinitionResolver definitions,
+            final AmendThingHandler amendHandler,
+            final JsonOutputConfig jsonOutput) {
+        this.definitions = definitions;
+        this.amendHandler = amendHandler;
+        this.jsonOutput = jsonOutput == null ? new JsonOutputConfig() : jsonOutput;
+    }
+
+    ThingCommandResult handle(final PatchThingDocumentCommand command) {
+        EntityDefinition entity = definitions.entityNamed(command.getEntityName());
+        EntityInstance instance = definitions.resolveInstance(entity, command.getIdentifier());
+        if (instance == null) {
+            return ThingCommandResult.error(
+                    ApplicationError.instanceNotFound(
+                            command.getEntityName(), command.getIdentifier()));
+        }
+
+        JsonNode patchDocument = parsePatchDocument(command);
+        if (patchDocument == null) {
+            return malformedPatch(command);
+        }
+
+        ThingCommandResult shapeValidation = validateDocumentShape(command, patchDocument);
+        if (shapeValidation != null) {
+            return shapeValidation;
+        }
+
+        JsonNode patchedDocument = patchedDocument(command, instance, patchDocument);
+        if (patchedDocument == null) {
+            return ThingCommandResult.error(
+                    ApplicationError.conflict("JSON Patch could not be applied"));
+        }
+        if (!patchedDocument.isObject()) {
+            return ThingCommandResult.error(ApplicationError.patchResultNotObject());
+        }
+
+        return amendHandler.handle(replacementCommand(command, patchedDocument));
+    }
+
+    private JsonNode parsePatchDocument(final PatchThingDocumentCommand command) {
+        try {
+            return JsonBodyValueConverter.readTree(command.getRawDocument());
+        } catch (JsonProcessingException | IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private ThingCommandResult malformedPatch(final PatchThingDocumentCommand command) {
+        if (command.getStyle()
+                == PatchThingDocumentCommand.DocumentStyle.JSON_MERGE_PATCH_RFC7396) {
+            return ThingCommandResult.error(
+                    ApplicationError.badRequest("Malformed JSON Merge Patch document"));
+        }
+        return ThingCommandResult.error(
+                ApplicationError.badRequest("Malformed JSON Patch document"));
+    }
+
+    private ThingCommandResult validateDocumentShape(
+            final PatchThingDocumentCommand command, final JsonNode patchDocument) {
+        if (command.getStyle()
+                == PatchThingDocumentCommand.DocumentStyle.JSON_MERGE_PATCH_RFC7396) {
+            if (!patchDocument.isObject()) {
+                return ThingCommandResult.error(
+                        ApplicationError.validation(
+                                "JSON Merge Patch for entity resources must be an object"));
+            }
+            return null;
+        }
+
+        if (!patchDocument.isArray()) {
+            return ThingCommandResult.error(
+                    ApplicationError.badRequest(
+                            "JSON Patch document must be an array of operations"));
+        }
+        return null;
+    }
+
+    private JsonNode patchedDocument(
+            final PatchThingDocumentCommand command,
+            final EntityInstance instance,
+            final JsonNode patchDocument) {
+        JsonNode currentDocument = jsonFor(instance);
+        if (command.getStyle()
+                == PatchThingDocumentCommand.DocumentStyle.JSON_MERGE_PATCH_RFC7396) {
+            return applyMergePatch(currentDocument, patchDocument);
+        }
+
+        try {
+            return JsonPatch.apply(patchDocument, currentDocument);
+        } catch (JsonPatchApplicationException | IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private JsonNode applyMergePatch(final JsonNode target, final JsonNode patch) {
+        if (!patch.isObject()) {
+            return patch;
+        }
+
+        ObjectNode result =
+                target != null && target.isObject()
+                        ? ((ObjectNode) target).deepCopy()
+                        : JsonNodeFactory.instance.objectNode();
+        for (Map.Entry<String, JsonNode> entry : patch.properties()) {
+            if (entry.getValue().isNull()) {
+                result.remove(entry.getKey());
+            } else {
+                result.set(
+                        entry.getKey(),
+                        applyMergePatch(result.get(entry.getKey()), entry.getValue()));
+            }
+        }
+        return result;
+    }
+
+    private JsonNode jsonFor(final EntityInstance instance) {
+        try {
+            return JsonBodyValueConverter.readTree(
+                    new JsonThing(jsonOutput).asJsonObject(instance).toString());
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Could not render entity instance as JSON", e);
+        }
+    }
+
+    private AmendThingCommand replacementCommand(
+            final PatchThingDocumentCommand command, final JsonNode patchedDocument) {
+        ApiBodyFields bodyFields =
+                ApiBodyFields.fromMap(JsonBodyValueConverter.objectNodeAsMap(patchedDocument));
+        return new AmendThingCommand(
+                command.getEntityName(),
+                command.getIdentifier(),
+                fieldValues(bodyFields),
+                bodyFieldValues(bodyFields),
+                true,
+                false,
+                List.of());
+    }
+
+    private List<NamedValue> fieldValues(final ApiBodyFields bodyFields) {
+        List<NamedValue> values = new ArrayList<>();
+        for (Map.Entry<String, String> entry : bodyFields.asFlattenedStringMap()) {
+            values.add(new NamedValue(entry.getKey(), entry.getValue()));
+        }
+        return values;
+    }
+
+    private List<BodyFieldValue> bodyFieldValues(final ApiBodyFields bodyFields) {
+        List<BodyFieldValue> values = new ArrayList<>();
+        for (ApiBodyField field : bodyFields.topLevelFields()) {
+            values.add(
+                    new BodyFieldValue(
+                            field.name(), field.value(), sourceTypeFor(field.sourceType())));
+        }
+        return values;
+    }
+
+    private BodyFieldValue.SourceType sourceTypeFor(final String sourceType) {
+        if ("STRING".equals(sourceType)) {
+            return BodyFieldValue.SourceType.STRING;
+        }
+        if ("BOOLEAN".equals(sourceType)) {
+            return BodyFieldValue.SourceType.BOOLEAN;
+        }
+        if ("INTEGER".equals(sourceType)) {
+            return BodyFieldValue.SourceType.INTEGER;
+        }
+        if ("NUMERIC".equals(sourceType)) {
+            return BodyFieldValue.SourceType.NUMERIC;
+        }
+        if ("OBJECT".equals(sourceType)) {
+            return BodyFieldValue.SourceType.OBJECT;
+        }
+        if ("ARRAY".equals(sourceType)) {
+            return BodyFieldValue.SourceType.ARRAY;
+        }
+        if ("NULL".equals(sourceType)) {
+            return BodyFieldValue.SourceType.NULL;
+        }
+        return BodyFieldValue.SourceType.SOMETHING_ELSE;
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/ThingCommandService.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/ThingCommandService.java
@@ -1,11 +1,13 @@
 package uk.co.compendiumdev.thingifier.application;
 
+import uk.co.compendiumdev.thingifier.apiconfig.JsonOutputConfig;
 import uk.co.compendiumdev.thingifier.application.command.AmendThingCommand;
 import uk.co.compendiumdev.thingifier.application.command.ConnectExistingRelationshipCommand;
 import uk.co.compendiumdev.thingifier.application.command.CreateAndConnectRelationshipCommand;
 import uk.co.compendiumdev.thingifier.application.command.CreateThingCommand;
 import uk.co.compendiumdev.thingifier.application.command.DeleteThingCommand;
 import uk.co.compendiumdev.thingifier.application.command.DisconnectRelationshipCommand;
+import uk.co.compendiumdev.thingifier.application.command.PatchThingDocumentCommand;
 import uk.co.compendiumdev.thingifier.application.command.RelateThingCommand;
 import uk.co.compendiumdev.thingifier.application.command.ReplaceThingCommand;
 import uk.co.compendiumdev.thingifier.application.command.ThingWriteCommand;
@@ -17,6 +19,7 @@ public final class ThingCommandService {
     private final WriteTransactionRunner transactionRunner;
     private final CreateThingHandler createHandler;
     private final AmendThingHandler amendHandler;
+    private final PatchThingDocumentHandler patchDocumentHandler;
     private final DeleteThingHandler deleteHandler;
     private final RelationshipCommandHandler relationshipHandler;
 
@@ -28,6 +31,14 @@ public final class ThingCommandService {
             final ThingStore store,
             final SchemaDefinitionResolver schema,
             final boolean enforceDeclaredTypes) {
+        this(store, schema, enforceDeclaredTypes, new JsonOutputConfig());
+    }
+
+    public ThingCommandService(
+            final ThingStore store,
+            final SchemaDefinitionResolver schema,
+            final boolean enforceDeclaredTypes,
+            final JsonOutputConfig jsonOutput) {
         ThingDefinitionResolver definitions = new ThingDefinitionResolver(store, schema);
         WriteValidationPolicy validation = new WriteValidationPolicy(store, enforceDeclaredTypes);
         RelationshipReferenceResolver relationshipResolver =
@@ -48,6 +59,8 @@ public final class ThingCommandService {
                         drafts,
                         createHandler,
                         relationshipConnections);
+        this.patchDocumentHandler =
+                new PatchThingDocumentHandler(definitions, amendHandler, jsonOutput);
         this.deleteHandler = new DeleteThingHandler(store, definitions);
         this.relationshipHandler =
                 new RelationshipCommandHandler(
@@ -75,6 +88,10 @@ public final class ThingCommandService {
 
         if (command instanceof DeleteThingCommand) {
             return deleteHandler.handle((DeleteThingCommand) command);
+        }
+
+        if (command instanceof PatchThingDocumentCommand) {
+            return patchDocumentHandler.handle((PatchThingDocumentCommand) command);
         }
 
         if (command instanceof ReplaceThingCommand) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/command/PatchThingDocumentCommand.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/command/PatchThingDocumentCommand.java
@@ -1,0 +1,41 @@
+package uk.co.compendiumdev.thingifier.application.command;
+
+public final class PatchThingDocumentCommand implements ThingWriteCommand {
+
+    public enum DocumentStyle {
+        JSON_MERGE_PATCH_RFC7396,
+        JSON_PATCH_RFC6902
+    }
+
+    private final String entityName;
+    private final String identifier;
+    private final String rawDocument;
+    private final DocumentStyle style;
+
+    public PatchThingDocumentCommand(
+            final String entityName,
+            final String identifier,
+            final String rawDocument,
+            final DocumentStyle style) {
+        this.entityName = entityName;
+        this.identifier = identifier;
+        this.rawDocument = rawDocument;
+        this.style = style;
+    }
+
+    public String getEntityName() {
+        return entityName;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public String getRawDocument() {
+        return rawDocument;
+    }
+
+    public DocumentStyle getStyle() {
+        return style;
+    }
+}


### PR DESCRIPTION
## Summary

- move RFC PATCH document application into the application command layer so entity-view validation remains enforced
- update CRUD UI integration tests to match current API/UI responses
- strengthen local and CI verification so Checkstyle, PMD, unit tests, and integration tests run via Maven verify

## Validation

- mvn -B clean verify
- pre-commit hook ran mvn -B clean verify successfully during commit