### PR TITLE
Add structured JSON QUERY support

### DIFF
--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/query/ComparableFieldValue.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/query/ComparableFieldValue.java
@@ -50,9 +50,15 @@ public class ComparableFieldValue {
             return field1Value.compareTo(field2Value);
         }
 
+        if (fieldDefn.getType() == FieldType.AUTO_GUID || fieldDefn.getType() == FieldType.DATE) {
+            String field1Value = fieldValue.asString();
+            String field2Value = otherValue.getValue().asString();
+            return field1Value.compareTo(field2Value);
+        }
+
         // don't know how to handle that field type
         // so the instances are by default the same
-        // TODO: FieldType.OBJECT, FieldType.DATE
+        // TODO: FieldType.OBJECT
         return 0;
     }
 

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/query/EntityListFilterParamParser.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/query/EntityListFilterParamParser.java
@@ -49,44 +49,45 @@ public class EntityListFilterParamParser {
                                 defn.getField(fieldName).valueFor(filterByCondition.fieldValue));
 
                 switch (filterByCondition.filterOperation) {
-                    case "=":
+                    case EXACT_MATCH:
+                    case EQUALS:
                         if (!(actualValue.compareTo(filterConditionValue) == 0)) {
                             return false;
                         }
                         break;
-                    case "<":
+                    case LESS_THAN:
                         if (!(actualValue.compareTo(filterConditionValue) < 0)) {
                             return false;
                         }
                         break;
-                    case ">":
+                    case GREATER_THAN:
                         if (!(actualValue.compareTo(filterConditionValue) > 0)) {
                             return false;
                         }
                         break;
-                    case "<=":
+                    case LESS_THAN_OR_EQUAL:
                         if (!(actualValue.compareTo(filterConditionValue) <= 0)) {
                             return false;
                         }
                         break;
-                    case ">=":
+                    case GREATER_THAN_OR_EQUAL:
                         if (!(actualValue.compareTo(filterConditionValue) >= 0)) {
                             return false;
                         }
                         break;
-                    case "!=":
-                    case "!":
+                    case NOT_EQUALS:
+                    case NOT:
                         if (!(actualValue.compareTo(filterConditionValue) != 0)) {
                             return false;
                         }
                         break;
-                    case "~=":
+                    case REGEX_MATCH:
                         { // regex match
                             Pattern pattern = Pattern.compile(filterByCondition.fieldValue);
                             Matcher matcher = pattern.matcher(actualValue.getValue().asString());
                             return matcher.matches();
                         }
-                    case "*=":
+                    case WILDCARD_MATCH:
                         { // wildcard match so * matches any multiple and ? matches one
                             String actualFilter = filterByCondition.fieldValue.replace("*", ".*");
                             actualFilter = actualFilter.replace("?", ".");
@@ -94,11 +95,19 @@ public class EntityListFilterParamParser {
                             Matcher matcher = pattern.matcher(actualValue.getValue().asString());
                             return matcher.matches();
                         }
+                    case LITERAL_CONTAINS:
+                        if (!actualValue
+                                .getValue()
+                                .asString()
+                                .contains(filterByCondition.fieldValue)) {
+                            return false;
+                        }
+                        break;
                     default:
                         System.out.println(
                                 String.format(
                                         "Unhandled filterby condition %s%s%s",
-                                        fieldName, filterByCondition.filterOperation, value));
+                                        fieldName, filterByCondition.operationToken(), value));
                 }
             }
         }

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/query/FilterBy.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/query/FilterBy.java
@@ -1,39 +1,33 @@
 package uk.co.compendiumdev.thingifier.core.query;
 
 public class FilterBy {
-    public String fieldName;
-    public String fieldValue;
-    public String filterOperation;
-
-    public static final String[] operators = {
-        "<=", // <= e.g. ?id=<=2 id is less than or equal to 3
-        ">=", // >= e.g. ?id=>=3 id is greater than or equal to 3
-        "!=", // < e.g. ?id=!=3 id not equals 3
-        "~=", // regex comparison match
-        "*=", // wildcard comparison match
-        "<", // < e.g. ?id=<3 id is less than 3
-        ">", // < e.g. ?id=>3 id is > than 3
-        "=", // < e.g. ?id==3 id equals 3
-        "!", // < e.g. ?id=!3 id not equals 3
-    }; // by default comparison filter will be equals e.g. ?id=3
+    public final String fieldName;
+    public final String fieldValue;
+    public final FilterOperation filterOperation;
 
     public FilterBy(String key, String value) {
-        // key is the filename
         fieldName = key;
 
-        // value might contain an operator
-        String operatorToSet = "=";
-        String valueToSet = value;
+        FilterOperation.ParsedValue parsedValue = FilterOperation.parseLeadingToken(value);
+        fieldValue = parsedValue.value();
+        filterOperation = parsedValue.operation();
+    }
 
-        for (String operator : operators) {
-            if (value.startsWith(operator)) {
-                operatorToSet = operator;
-                valueToSet = value.substring(operator.length());
-                break;
-            }
-        }
+    public FilterBy(String key, FilterOperation operation, String value) {
+        fieldName = key;
+        filterOperation = operation == null ? FilterOperation.EQUALS : operation;
+        fieldValue = value == null ? "" : value;
+    }
 
-        fieldValue = valueToSet;
-        filterOperation = operatorToSet;
+    public FilterBy copy() {
+        return new FilterBy(fieldName, filterOperation, fieldValue);
+    }
+
+    public String operationToken() {
+        return filterOperation.token();
+    }
+
+    public String queryValue() {
+        return operationToken() + fieldValue;
     }
 }

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/query/FilterOperation.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/query/FilterOperation.java
@@ -1,0 +1,72 @@
+package uk.co.compendiumdev.thingifier.core.query;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+public enum FilterOperation {
+    LESS_THAN_OR_EQUAL("<="),
+    GREATER_THAN_OR_EQUAL(">="),
+    EXACT_MATCH("=="),
+    NOT_EQUALS("!="),
+    REGEX_MATCH("~="),
+    WILDCARD_MATCH("*="),
+    LITERAL_CONTAINS("%="),
+    LESS_THAN("<"),
+    GREATER_THAN(">"),
+    EQUALS("="),
+    NOT("!");
+
+    private static final List<FilterOperation> PREFIX_PARSE_ORDER =
+            List.of(
+                    LESS_THAN_OR_EQUAL,
+                    GREATER_THAN_OR_EQUAL,
+                    EXACT_MATCH,
+                    NOT_EQUALS,
+                    REGEX_MATCH,
+                    WILDCARD_MATCH,
+                    LITERAL_CONTAINS,
+                    LESS_THAN,
+                    GREATER_THAN,
+                    EQUALS,
+                    NOT);
+
+    private final String token;
+
+    FilterOperation(final String token) {
+        this.token = token;
+    }
+
+    public String token() {
+        return token;
+    }
+
+    public static ParsedValue parseLeadingToken(final String value) {
+        String parseValue = value == null ? "" : value;
+        for (FilterOperation operation : PREFIX_PARSE_ORDER) {
+            if (parseValue.startsWith(operation.token())) {
+                return new ParsedValue(operation, parseValue.substring(operation.token().length()));
+            }
+        }
+        return new ParsedValue(EQUALS, parseValue);
+    }
+
+    public static Optional<FilterOperation> firstIn(final String value) {
+        if (value == null || value.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return PREFIX_PARSE_ORDER.stream()
+                .map(operation -> new OperationIndex(operation, value.indexOf(operation.token())))
+                .filter(candidate -> candidate.index() >= 0)
+                .min(
+                        Comparator.comparingInt(OperationIndex::index)
+                                .thenComparing(
+                                        candidate -> -candidate.operation().token().length()))
+                .map(OperationIndex::operation);
+    }
+
+    public record ParsedValue(FilterOperation operation, String value) {}
+
+    private record OperationIndex(FilterOperation operation, int index) {}
+}

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/query/PaginationParams.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/query/PaginationParams.java
@@ -62,7 +62,7 @@ public final class PaginationParams {
             return null;
         }
 
-        if (!"=".equals(param.filterOperation)) {
+        if (param.filterOperation != FilterOperation.EQUALS) {
             validationError = String.format("%s must be a non-negative integer", parameterName);
             return null;
         }

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/query/QueryFilterParams.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/query/QueryFilterParams.java
@@ -15,6 +15,10 @@ public class QueryFilterParams {
         filterBys.add(new FilterBy(fieldName, fieldValue));
     }
 
+    public void put(String fieldName, FilterOperation operation, String fieldValue) {
+        filterBys.add(new FilterBy(fieldName, operation, fieldValue));
+    }
+
     public List<FilterBy> toList() {
         return filterBys;
     }
@@ -36,10 +40,7 @@ public class QueryFilterParams {
 
         for (FilterBy filterBy : filterBys) {
             if (!isReservedQueryControl(filterBy.fieldName)) {
-                fieldFilters.add(
-                        new FilterBy(
-                                filterBy.fieldName,
-                                filterBy.filterOperation + filterBy.fieldValue));
+                fieldFilters.add(filterBy.copy());
             }
         }
 
@@ -51,10 +52,7 @@ public class QueryFilterParams {
 
         for (FilterBy filterBy : filterBys) {
             if (!PaginationParams.isPaginationParam(filterBy.fieldName)) {
-                params.add(
-                        new FilterBy(
-                                filterBy.fieldName,
-                                filterBy.filterOperation + filterBy.fieldValue));
+                params.add(filterBy.copy());
             }
         }
 
@@ -75,7 +73,7 @@ public class QueryFilterParams {
         }
 
         for (FilterBy filterBy : params.toList()) {
-            add(new FilterBy(filterBy.fieldName, filterBy.filterOperation + filterBy.fieldValue));
+            add(filterBy.copy());
         }
     }
 

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/repository/sqlite/SqliteThingStore.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/repository/sqlite/SqliteThingStore.java
@@ -1021,27 +1021,32 @@ public class SqliteThingStore implements ThingStore {
 
             String column = identifier(filterBy.fieldName);
             switch (filterBy.filterOperation) {
-                case "=":
+                case EXACT_MATCH:
+                case EQUALS:
                     whereClauses.add(column + " = ?");
                     parameters.add(filterBy.fieldValue);
                     break;
-                case "!":
-                case "!=":
+                case NOT:
+                case NOT_EQUALS:
                     whereClauses.add(column + " <> ?");
                     parameters.add(filterBy.fieldValue);
                     break;
-                case "<":
-                case ">":
-                case "<=":
-                case ">=":
-                    whereClauses.add(column + " " + filterBy.filterOperation + " ?");
+                case LESS_THAN:
+                case GREATER_THAN:
+                case LESS_THAN_OR_EQUAL:
+                case GREATER_THAN_OR_EQUAL:
+                    whereClauses.add(column + " " + filterBy.operationToken() + " ?");
                     parameters.add(filterBy.fieldValue);
                     break;
-                case "*=":
+                case WILDCARD_MATCH:
                     whereClauses.add(column + " LIKE ? ESCAPE '\\'");
                     parameters.add(sqlLikeWildcard(filterBy.fieldValue));
                     break;
-                case "~=":
+                case LITERAL_CONTAINS:
+                    whereClauses.add(column + " LIKE ? ESCAPE '\\'");
+                    parameters.add(sqlContainsLiteral(filterBy.fieldValue));
+                    break;
+                case REGEX_MATCH:
                     whereClauses.add(regexSqlCondition(column, filterBy.fieldValue, parameters));
                     break;
                 default:
@@ -1108,31 +1113,36 @@ public class SqliteThingStore implements ThingStore {
 
             String column = "target." + identifier(filterBy.fieldName);
             switch (filterBy.filterOperation) {
-                case "=":
+                case EXACT_MATCH:
+                case EQUALS:
                     sql.append(" AND ").append(column).append(" = ?");
                     parameters.add(filterBy.fieldValue);
                     break;
-                case "!":
-                case "!=":
+                case NOT:
+                case NOT_EQUALS:
                     sql.append(" AND ").append(column).append(" <> ?");
                     parameters.add(filterBy.fieldValue);
                     break;
-                case "<":
-                case ">":
-                case "<=":
-                case ">=":
+                case LESS_THAN:
+                case GREATER_THAN:
+                case LESS_THAN_OR_EQUAL:
+                case GREATER_THAN_OR_EQUAL:
                     sql.append(" AND ")
                             .append(column)
                             .append(" ")
-                            .append(filterBy.filterOperation)
+                            .append(filterBy.operationToken())
                             .append(" ?");
                     parameters.add(filterBy.fieldValue);
                     break;
-                case "*=":
+                case WILDCARD_MATCH:
                     sql.append(" AND ").append(column).append(" LIKE ? ESCAPE '\\'");
                     parameters.add(sqlLikeWildcard(filterBy.fieldValue));
                     break;
-                case "~=":
+                case LITERAL_CONTAINS:
+                    sql.append(" AND ").append(column).append(" LIKE ? ESCAPE '\\'");
+                    parameters.add(sqlContainsLiteral(filterBy.fieldValue));
+                    break;
+                case REGEX_MATCH:
                     sql.append(" AND ")
                             .append(regexSqlCondition(column, filterBy.fieldValue, parameters));
                     break;
@@ -1298,6 +1308,10 @@ public class SqliteThingStore implements ThingStore {
                 .replace("_", "\\_")
                 .replace("*", "%")
                 .replace("?", "_");
+    }
+
+    private String sqlContainsLiteral(final String literal) {
+        return "%" + literal.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_") + "%";
     }
 
     private List<RelationshipVectorDefinition> relationshipVectorsFor(

--- a/ercoremodel/src/test/java/uk/co/compendiumdev/thingifier/core/query/TodoManagerQueryEngineTest.java
+++ b/ercoremodel/src/test/java/uk/co/compendiumdev/thingifier/core/query/TodoManagerQueryEngineTest.java
@@ -123,6 +123,20 @@ public class TodoManagerQueryEngineTest {
     }
 
     @Test
+    public void canFilterEntityCollectionByGuid() {
+        QueryFilterParams params = new QueryFilterParams();
+        params.put("guid", FilterOperation.EXACT_MATCH, paperwork.getPrimaryKeyValue());
+
+        RepositoryQuery queryResults =
+                new RepositoryQuery(store(), RepositoryQuerySpec.collection(todo))
+                        .performQuery(params);
+
+        List<EntityInstance> instances = queryResults.getListEntityInstances();
+        Assertions.assertEquals(1, instances.size());
+        Assertions.assertEquals(paperwork, instances.get(0));
+    }
+
+    @Test
     public void canQueryRelationships() {
         EntityInstance officeWork =
                 store().entities()

--- a/ercoremodel/src/test/java/uk/co/compendiumdev/thingifier/core/repository/ThingStoreContractTest.java
+++ b/ercoremodel/src/test/java/uk/co/compendiumdev/thingifier/core/repository/ThingStoreContractTest.java
@@ -16,6 +16,7 @@ import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.F
 import uk.co.compendiumdev.thingifier.core.domain.definitions.relationship.Optionality;
 import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
 import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstanceDraft;
+import uk.co.compendiumdev.thingifier.core.query.FilterOperation;
 import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
 import uk.co.compendiumdev.thingifier.core.query.RepositoryQuery;
 import uk.co.compendiumdev.thingifier.core.query.RepositoryQuerySpec;
@@ -737,6 +738,20 @@ public class ThingStoreContractTest {
         Assertions.assertEquals(1, regexProjects.size());
         Assertions.assertEquals(project, regexProjects.get(0));
 
+        QueryFilterParams literalContainsParams = new QueryFilterParams();
+        literalContainsParams.put("title", FilterOperation.LITERAL_CONTAINS, "Repository");
+        Assertions.assertEquals(
+                List.of(project),
+                repository.entityQueries().list(projectDefinition, literalContainsParams));
+
+        QueryFilterParams caseSensitiveContainsParams = new QueryFilterParams();
+        caseSensitiveContainsParams.put("title", FilterOperation.LITERAL_CONTAINS, "repository");
+        Assertions.assertTrue(
+                repository
+                        .entityQueries()
+                        .list(projectDefinition, caseSensitiveContainsParams)
+                        .isEmpty());
+
         Assertions.assertThrows(
                 RuntimeException.class,
                 () ->
@@ -787,6 +802,24 @@ public class ThingStoreContractTest {
                 repository.relationships().listRelated(project, "tasks", relationshipFilterParams);
         Assertions.assertEquals(1, filteredTasks.size());
         Assertions.assertEquals(task, filteredTasks.get(0));
+
+        QueryFilterParams relationshipLiteralContainsParams = new QueryFilterParams();
+        relationshipLiteralContainsParams.put(
+                "title", FilterOperation.LITERAL_CONTAINS, "repository");
+        Assertions.assertEquals(
+                List.of(task),
+                repository
+                        .relationships()
+                        .listRelated(project, "tasks", relationshipLiteralContainsParams));
+
+        QueryFilterParams relationshipCaseSensitiveContainsParams = new QueryFilterParams();
+        relationshipCaseSensitiveContainsParams.put(
+                "title", FilterOperation.LITERAL_CONTAINS, "Repository");
+        Assertions.assertTrue(
+                repository
+                        .relationships()
+                        .listRelated(project, "tasks", relationshipCaseSensitiveContainsParams)
+                        .isEmpty());
 
         QueryFilterParams relationshipSortParams = new QueryFilterParams();
         relationshipSortParams.put("_sortBy", "-id");

--- a/swaggerizer/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerTest.java
+++ b/swaggerizer/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerTest.java
@@ -35,6 +35,7 @@ public class SwaggerizerTest {
         Assertions.assertTrue(openApiVersion(swagger).startsWith("3.1."));
         Assertions.assertTrue(swagger.contains("\"x-query-operation\""));
         Assertions.assertTrue(swagger.contains("application/x-www-form-urlencoded"));
+        Assertions.assertTrue(swagger.contains("application/vnd.apichallenges.todo-query+json"));
     }
 
     @Test
@@ -50,6 +51,7 @@ public class SwaggerizerTest {
         Assertions.assertTrue(openApiVersion(swagger).startsWith("3.0."));
         Assertions.assertTrue(swagger.contains("\"x-query-operation\""));
         Assertions.assertTrue(swagger.contains("application/x-www-form-urlencoded"));
+        Assertions.assertTrue(swagger.contains("application/vnd.apichallenges.todo-query+json"));
     }
 
     @Test
@@ -80,6 +82,10 @@ public class SwaggerizerTest {
                 query.getAsJsonObject("requestBody")
                         .getAsJsonObject("content")
                         .has("application/x-www-form-urlencoded"));
+        Assertions.assertTrue(
+                query.getAsJsonObject("requestBody")
+                        .getAsJsonObject("content")
+                        .has("application/vnd.apichallenges.todo-query+json"));
     }
 
     private boolean hasParameterNamed(final JsonObject operation, final String name) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ApiRequestEnvelope.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ApiRequestEnvelope.java
@@ -11,7 +11,8 @@ public final class ApiRequestEnvelope {
 
     public enum QueryBodyFormat {
         URL_ENCODED,
-        JSONPATH
+        JSONPATH,
+        STRUCTURED_JSON
     }
 
     private final ThingifierHttpApi.HttpVerb verb;
@@ -70,6 +71,9 @@ public final class ApiRequestEnvelope {
                 new ContentTypeHeaderParser(request.getContentTypeHeader());
         if (contentType.isJsonPath()) {
             return QueryBodyFormat.JSONPATH;
+        }
+        if (contentType.isStructuredTodoQueryJson()) {
+            return QueryBodyFormat.STRUCTURED_JSON;
         }
         return QueryBodyFormat.URL_ENCODED;
     }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/HttpApiRequestValidator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/HttpApiRequestValidator.java
@@ -1,9 +1,11 @@
 package uk.co.compendiumdev.thingifier.api.http;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.jayway.jsonpath.InvalidPathException;
 import com.jayway.jsonpath.JsonPath;
 import java.util.ArrayList;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.BodyParser;
+import uk.co.compendiumdev.thingifier.api.http.bodyparser.JsonBodyValueConverter;
 import uk.co.compendiumdev.thingifier.api.http.headers.headerparser.ContentTypeHeaderParser;
 import uk.co.compendiumdev.thingifier.api.http.headers.headervalidator.AcceptHeaderValidator;
 import uk.co.compendiumdev.thingifier.api.http.headers.headervalidator.ContentTypeHeaderValidator;
@@ -101,7 +103,9 @@ public class HttpApiRequestValidator {
             return queryContentError(400, "Missing Content-Type for QUERY request");
         }
 
-        if (!contentType.isFormUrlEncoded() && !contentType.isJsonPath()) {
+        if (!contentType.isFormUrlEncoded()
+                && !contentType.isJsonPath()
+                && !contentType.isStructuredTodoQueryJson()) {
             ApiResponse response =
                     queryContentError(
                             this.apiConfig.statusCodes().contentTypeNotSupported(),
@@ -113,10 +117,12 @@ public class HttpApiRequestValidator {
         try {
             if (contentType.isJsonPath()) {
                 validateJsonPath(request.getBody());
+            } else if (contentType.isStructuredTodoQueryJson()) {
+                validateStructuredQueryJson(request.getBody());
             } else {
                 new UrlQueryParamParser().parseStrict(request.getBody());
             }
-        } catch (IllegalArgumentException | InvalidPathException e) {
+        } catch (IllegalArgumentException | InvalidPathException | JsonProcessingException e) {
             return queryContentError(400, e.getMessage());
         }
 
@@ -128,6 +134,10 @@ public class HttpApiRequestValidator {
             throw new IllegalArgumentException("Missing JSONPath expression for QUERY request");
         }
         JsonPath.compile(body.trim());
+    }
+
+    private void validateStructuredQueryJson(final String body) throws JsonProcessingException {
+        JsonBodyValueConverter.readStrictTree(body);
     }
 
     private ApiResponse queryContentError(final int statusCode, final String message) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
@@ -39,8 +39,13 @@ public final class ThingifierHttpApi {
     public static final String ACCEPT_QUERY_HEADER = "Accept-Query";
     public static final String QUERY_CONTENT_TYPE = "application/x-www-form-urlencoded";
     public static final String JSONPATH_QUERY_CONTENT_TYPE = "application/jsonpath";
+    public static final String STRUCTURED_TODO_QUERY_CONTENT_TYPE =
+            "application/vnd.apichallenges.todo-query+json";
     public static final List<String> SUPPORTED_QUERY_CONTENT_TYPES_LIST =
-            List.of(QUERY_CONTENT_TYPE, JSONPATH_QUERY_CONTENT_TYPE);
+            List.of(
+                    QUERY_CONTENT_TYPE,
+                    JSONPATH_QUERY_CONTENT_TYPE,
+                    STRUCTURED_TODO_QUERY_CONTENT_TYPE);
     public static final String SUPPORTED_QUERY_CONTENT_TYPES =
             String.join(", ", SUPPORTED_QUERY_CONTENT_TYPES_LIST);
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/UrlQueryParamParser.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/UrlQueryParamParser.java
@@ -3,6 +3,7 @@ package uk.co.compendiumdev.thingifier.api.http;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import uk.co.compendiumdev.thingifier.core.query.FilterBy;
+import uk.co.compendiumdev.thingifier.core.query.FilterOperation;
 import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
 
 public final class UrlQueryParamParser {
@@ -68,24 +69,24 @@ public final class UrlQueryParamParser {
 
     private FilterBy parseToFilterBy(final String rawParam) {
         String param = rawParam.trim();
-        String fieldName = getFieldNameFrom(param);
-
-        String opAndValue = param.substring(fieldName.length());
-
-        return new FilterBy(fieldName, opAndValue);
+        return FilterOperation.firstIn(param)
+                .map(operation -> filterByForOperation(param, operation))
+                .orElseGet(() -> new FilterBy(param, FilterOperation.EQUALS, ""));
     }
 
-    private String getFieldNameFrom(final String param) {
+    private FilterBy filterByForOperation(final String param, final FilterOperation operation) {
+        int operationIndex = param.indexOf(operation.token());
+        String fieldName = param.substring(0, operationIndex);
 
-        // for each FilterBy operator, try to find it in the string
-        // if present, split the string there and the fieldname is to the
-        // left of the operator
-        for (String anOperator : FilterBy.operators) {
-            if (param.contains(anOperator)) {
-                return param.substring(0, param.indexOf(anOperator));
-            }
+        if (operation != FilterOperation.EQUALS) {
+            return new FilterBy(
+                    fieldName,
+                    operation,
+                    param.substring(operationIndex + operation.token().length()));
         }
 
-        return param;
+        String value = param.substring(operationIndex + operation.token().length());
+        FilterOperation.ParsedValue parsedValue = FilterOperation.parseLeadingToken(value);
+        return new FilterBy(fieldName, parsedValue.operation(), parsedValue.value());
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/bodyparser/JsonBodyValueConverter.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/bodyparser/JsonBodyValueConverter.java
@@ -15,11 +15,16 @@ public final class JsonBodyValueConverter {
     private static final ObjectMapper JSON =
             new ObjectMapper(
                     JsonFactory.builder().enable(JsonReadFeature.ALLOW_SINGLE_QUOTES).build());
+    private static final ObjectMapper STRICT_JSON = new ObjectMapper();
 
     private JsonBodyValueConverter() {}
 
     public static JsonNode readTree(final String body) throws JsonProcessingException {
         return JSON.readTree(body);
+    }
+
+    public static JsonNode readStrictTree(final String body) throws JsonProcessingException {
+        return STRICT_JSON.readTree(body);
     }
 
     public static Map<String, Object> jsonObjectAsMap(final String body)

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/ContentTypeHeaderParser.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/ContentTypeHeaderParser.java
@@ -36,6 +36,10 @@ public class ContentTypeHeaderParser {
         return isMediaType("application/jsonpath");
     }
 
+    public boolean isStructuredTodoQueryJson() {
+        return isMediaType("application/vnd.apichallenges.todo-query+json");
+    }
+
     public boolean isMissing() {
         return (header.isEmpty());
     }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandler.java
@@ -19,6 +19,7 @@ import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityViewDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.relationship.RelationshipVectorDefinition;
 import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
 import uk.co.compendiumdev.thingifier.core.query.RepositoryQueryResult;
 
@@ -61,8 +62,18 @@ public final class RestApiQueryHandler {
                             404, String.format("Could not find an instance with %s", url)));
         }
 
+        QueryFilterParams requestedQueryParams = queryParams;
+        if (queryBodyFormat == ApiRequestEnvelope.QueryBodyFormat.STRUCTURED_JSON) {
+            StructuredJsonQueryCompiler.Result structuredQuery =
+                    StructuredJsonQueryCompiler.compile(queryBody, resultEntityFor(route));
+            if (structuredQuery.isError()) {
+                return advertiseQuery(apiMapper.map(structuredQuery.error()));
+            }
+            requestedQueryParams = combine(queryParams, structuredQuery.queryParams());
+        }
+
         EffectiveQueryParams effectiveQueryParams =
-                EffectiveQueryParams.forQuery(runtime.apiConfig(), route, queryParams);
+                EffectiveQueryParams.forQuery(runtime.apiConfig(), route, requestedQueryParams);
         if (effectiveQueryParams.isError()) {
             return apiMapper.map(effectiveQueryParams.error());
         }
@@ -110,6 +121,43 @@ public final class RestApiQueryHandler {
                 .filter(entity::hasViewNamed)
                 .map(entity::getViewNamed)
                 .orElse(null);
+    }
+
+    private QueryFilterParams combine(
+            final QueryFilterParams first, final QueryFilterParams second) {
+        QueryFilterParams combined = new QueryFilterParams();
+        combined.addAll(first);
+        combined.addAll(second);
+        return combined;
+    }
+
+    private EntityDefinition resultEntityFor(final ThingRoute route) {
+        if (route instanceof CollectionRoute) {
+            return runtime.schema()
+                    .definitionWithSingularOrPluralNamed(((CollectionRoute) route).entity().name());
+        }
+
+        if (route instanceof RelationshipCollectionRoute) {
+            RelationshipCollectionRoute relationship = (RelationshipCollectionRoute) route;
+            EntityDefinition parent =
+                    runtime.schema()
+                            .definitionWithSingularOrPluralNamed(
+                                    relationship.parentEntity().name());
+            if (parent == null) {
+                return null;
+            }
+            for (RelationshipVectorDefinition vector :
+                    parent.related().getRelationships(relationship.relationshipName())) {
+                if (vector.getFrom() == parent) {
+                    return vector.getTo();
+                }
+                if (vector.getTo() == parent) {
+                    return vector.getFrom();
+                }
+            }
+        }
+
+        return null;
     }
 
     private ApiResponse advertiseQuery(final ApiResponse response) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/StructuredJsonQueryCompiler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/StructuredJsonQueryCompiler.java
@@ -1,0 +1,371 @@
+package uk.co.compendiumdev.thingifier.api.restapihandlers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ApiMappingError;
+import uk.co.compendiumdev.thingifier.api.http.bodyparser.JsonBodyValueConverter;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.Field;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldType;
+import uk.co.compendiumdev.thingifier.core.query.FilterOperation;
+import uk.co.compendiumdev.thingifier.core.query.PaginationParams;
+import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
+import uk.co.compendiumdev.thingifier.core.query.SortByFieldName;
+
+final class StructuredJsonQueryCompiler {
+
+    private static final Set<String> TOP_LEVEL_KEYS = Set.of("filter", "sort", "limit", "offset");
+    private static final Set<String> SORT_KEYS = Set.of("field", "direction");
+
+    private final EntityDefinition entity;
+    private final QueryFilterParams queryParams;
+
+    private StructuredJsonQueryCompiler(final EntityDefinition entity) {
+        this.entity = entity;
+        this.queryParams = new QueryFilterParams();
+    }
+
+    static Result compile(final String body, final EntityDefinition entity) {
+        JsonNode document;
+        try {
+            document = JsonBodyValueConverter.readStrictTree(body);
+        } catch (JsonProcessingException | IllegalArgumentException e) {
+            return Result.error(400, "Malformed JSON query body");
+        }
+
+        return new StructuredJsonQueryCompiler(entity).compile(document);
+    }
+
+    private Result compile(final JsonNode document) {
+        if (entity == null) {
+            return Result.error(422, "Structured JSON query target entity could not be resolved");
+        }
+
+        if (document == null || !document.isObject()) {
+            return Result.error(422, "Structured JSON query body must be an object");
+        }
+
+        for (Map.Entry<String, JsonNode> property : document.properties()) {
+            if (!TOP_LEVEL_KEYS.contains(property.getKey())) {
+                return Result.error(
+                        422, String.format("Unknown structured query field %s", property.getKey()));
+            }
+        }
+
+        Result filterResult = compileFilter(document.get("filter"));
+        if (filterResult.isError()) {
+            return filterResult;
+        }
+
+        Result sortResult = compileSort(document.get("sort"));
+        if (sortResult.isError()) {
+            return sortResult;
+        }
+
+        Result limitResult =
+                compilePagination(
+                        document.get("limit"), PaginationParams.LIMIT_PARAMETER_NAME, "limit");
+        if (limitResult.isError()) {
+            return limitResult;
+        }
+
+        Result offsetResult =
+                compilePagination(
+                        document.get("offset"), PaginationParams.OFFSET_PARAMETER_NAME, "offset");
+        if (offsetResult.isError()) {
+            return offsetResult;
+        }
+
+        return Result.ok(queryParams);
+    }
+
+    private Result compileFilter(final JsonNode filter) {
+        if (filter == null) {
+            return Result.ok(queryParams);
+        }
+
+        if (!filter.isObject()) {
+            return Result.error(422, "filter must be an object");
+        }
+
+        for (Map.Entry<String, JsonNode> fieldFilter : filter.properties()) {
+            Result result = compileFieldFilter(fieldFilter.getKey(), fieldFilter.getValue());
+            if (result.isError()) {
+                return result;
+            }
+        }
+
+        return Result.ok(queryParams);
+    }
+
+    private Result compileFieldFilter(final String requestedFieldName, final JsonNode value) {
+        Field field = fieldNamed(requestedFieldName);
+        if (field == null) {
+            return Result.error(
+                    422, String.format("Unknown query filter field %s", requestedFieldName));
+        }
+
+        if (value != null && value.isObject()) {
+            return compileFieldOperators(field, value);
+        }
+
+        return compileExactFilter(field, value);
+    }
+
+    private Result compileExactFilter(final Field field, final JsonNode value) {
+        if (!isExactMatchValueCompatible(field, value)) {
+            return Result.error(
+                    422, String.format("Invalid exact match value for field %s", field.getName()));
+        }
+
+        queryParams.put(field.getName(), FilterOperation.EXACT_MATCH, queryValue(value));
+        return Result.ok(queryParams);
+    }
+
+    private Result compileFieldOperators(final Field field, final JsonNode operators) {
+        if (operators.isEmpty()) {
+            return Result.error(
+                    422,
+                    String.format("Filter operators for field %s are required", field.getName()));
+        }
+
+        for (Map.Entry<String, JsonNode> operator : operators.properties()) {
+            Result result = compileFieldOperator(field, operator.getKey(), operator.getValue());
+            if (result.isError()) {
+                return result;
+            }
+        }
+
+        return Result.ok(queryParams);
+    }
+
+    private Result compileFieldOperator(
+            final Field field, final String operator, final JsonNode value) {
+        switch (operator) {
+            case "contains":
+                return compileContainsFilter(field, value);
+            case "greaterThan":
+                return compileComparisonFilter(field, FilterOperation.GREATER_THAN, value);
+            case "lessThan":
+                return compileComparisonFilter(field, FilterOperation.LESS_THAN, value);
+            default:
+                return Result.error(
+                        422,
+                        String.format(
+                                "Unsupported query operator %s for field %s",
+                                operator, field.getName()));
+        }
+    }
+
+    private Result compileContainsFilter(final Field field, final JsonNode value) {
+        if (field.getType() != FieldType.STRING || value == null || !value.isTextual()) {
+            return Result.error(
+                    422,
+                    String.format("contains is only supported for text field %s", field.getName()));
+        }
+
+        queryParams.put(field.getName(), FilterOperation.LITERAL_CONTAINS, value.asText());
+        return Result.ok(queryParams);
+    }
+
+    private Result compileComparisonFilter(
+            final Field field, final FilterOperation operation, final JsonNode value) {
+        if (!isNumericValueCompatible(field, value)) {
+            return Result.error(
+                    422,
+                    String.format(
+                            "%s is only supported for numeric field %s",
+                            operationName(operation), field.getName()));
+        }
+
+        queryParams.put(field.getName(), operation, queryValue(value));
+        return Result.ok(queryParams);
+    }
+
+    private Result compileSort(final JsonNode sort) {
+        if (sort == null) {
+            return Result.ok(queryParams);
+        }
+
+        if (!sort.isArray()) {
+            return Result.error(422, "sort must be an array");
+        }
+
+        List<String> sortFields = new ArrayList<>();
+        for (JsonNode sortEntry : sort) {
+            Result result = compileSortEntry(sortEntry, sortFields);
+            if (result.isError()) {
+                return result;
+            }
+        }
+
+        if (!sortFields.isEmpty()) {
+            queryParams.put(SortByFieldName.PARAMETER_NAME, String.join(",", sortFields));
+        }
+
+        return Result.ok(queryParams);
+    }
+
+    private Result compileSortEntry(final JsonNode sortEntry, final List<String> sortFields) {
+        if (sortEntry == null || !sortEntry.isObject()) {
+            return Result.error(422, "sort entries must be objects");
+        }
+
+        for (Map.Entry<String, JsonNode> property : sortEntry.properties()) {
+            if (!SORT_KEYS.contains(property.getKey())) {
+                return Result.error(422, String.format("Unknown sort field %s", property.getKey()));
+            }
+        }
+
+        JsonNode fieldNode = sortEntry.get("field");
+        JsonNode directionNode = sortEntry.get("direction");
+        if (fieldNode == null || !fieldNode.isTextual()) {
+            return Result.error(422, "sort field must be a string");
+        }
+        if (directionNode == null || !directionNode.isTextual()) {
+            return Result.error(422, "sort direction must be asc or desc");
+        }
+
+        Field field = fieldNamed(fieldNode.asText());
+        if (field == null) {
+            return Result.error(422, String.format("Unknown sort field %s", fieldNode.asText()));
+        }
+        if (!isSortable(field)) {
+            return Result.error(422, String.format("Field %s can not be sorted", field.getName()));
+        }
+
+        switch (directionNode.asText()) {
+            case "asc":
+                sortFields.add("+" + field.getName());
+                return Result.ok(queryParams);
+            case "desc":
+                sortFields.add("-" + field.getName());
+                return Result.ok(queryParams);
+            default:
+                return Result.error(422, "sort direction must be asc or desc");
+        }
+    }
+
+    private Result compilePagination(
+            final JsonNode value, final String parameterName, final String jsonName) {
+        if (value == null) {
+            return Result.ok(queryParams);
+        }
+
+        if (!value.isIntegralNumber() || !value.canConvertToInt() || value.asInt() < 0) {
+            return Result.error(422, String.format("%s must be a non-negative integer", jsonName));
+        }
+
+        queryParams.put(parameterName, Integer.toString(value.asInt()));
+        return Result.ok(queryParams);
+    }
+
+    private Field fieldNamed(final String fieldName) {
+        if (fieldName == null || !entity.hasFieldNameDefined(fieldName)) {
+            return null;
+        }
+        return entity.getField(fieldName);
+    }
+
+    private boolean isExactMatchValueCompatible(final Field field, final JsonNode value) {
+        if (value == null || value.isNull() || value.isArray() || value.isObject()) {
+            return false;
+        }
+
+        switch (field.getType()) {
+            case AUTO_INCREMENT:
+            case INTEGER:
+                return value.isIntegralNumber();
+            case FLOAT:
+                return value.isNumber();
+            case BOOLEAN:
+                return value.isBoolean();
+            case AUTO_GUID:
+            case DATE:
+            case ENUM:
+            case STRING:
+                return value.isTextual();
+            default:
+                return false;
+        }
+    }
+
+    private boolean isNumericValueCompatible(final Field field, final JsonNode value) {
+        if (value == null || !value.isNumber()) {
+            return false;
+        }
+
+        switch (field.getType()) {
+            case AUTO_INCREMENT:
+            case INTEGER:
+                return value.isIntegralNumber();
+            case FLOAT:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private boolean isSortable(final Field field) {
+        switch (field.getType()) {
+            case AUTO_INCREMENT:
+            case INTEGER:
+            case FLOAT:
+            case BOOLEAN:
+            case ENUM:
+            case STRING:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private String queryValue(final JsonNode value) {
+        return value.asText();
+    }
+
+    private String operationName(final FilterOperation operation) {
+        switch (operation) {
+            case GREATER_THAN:
+                return "greaterThan";
+            case LESS_THAN:
+                return "lessThan";
+            default:
+                return operation.token();
+        }
+    }
+
+    static final class Result {
+        private final QueryFilterParams queryParams;
+        private final ApiMappingError error;
+
+        private Result(final QueryFilterParams queryParams, final ApiMappingError error) {
+            this.queryParams = queryParams;
+            this.error = error;
+        }
+
+        static Result ok(final QueryFilterParams queryParams) {
+            return new Result(queryParams, null);
+        }
+
+        static Result error(final int statusCode, final String message) {
+            return new Result(null, ApiMappingError.withMessage(statusCode, message));
+        }
+
+        boolean isError() {
+            return error != null;
+        }
+
+        QueryFilterParams queryParams() {
+            return queryParams;
+        }
+
+        ApiMappingError error() {
+            return error;
+        }
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/query/ThingReadQuery.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/query/ThingReadQuery.java
@@ -16,7 +16,7 @@ public interface ThingReadQuery {
         }
 
         for (FilterBy filterBy : queryParams.toList()) {
-            copy.put(filterBy.fieldName, filterBy.filterOperation + filterBy.fieldValue);
+            copy.add(filterBy.copy());
         }
         return copy;
     }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGenerator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGenerator.java
@@ -540,6 +540,12 @@ public class RestApiDocumentationGenerator {
                                                 + "</i> with an expression such as <i>"
                                                 + jsonPathQueryExampleFor(routingDefn)
                                                 + "</i>."));
+                        output.append(
+                                paragraph(
+                                        "QUERY structured JSON content uses <i>Content-Type: "
+                                                + ThingifierHttpApi
+                                                        .STRUCTURED_TODO_QUERY_CONTENT_TYPE
+                                                + "</i> with a JSON query object."));
                     }
                 }
             }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/OpenApi32Finalizer.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/OpenApi32Finalizer.java
@@ -38,12 +38,12 @@ public final class OpenApi32Finalizer {
             final JsonObject query = queryOperation.getAsJsonObject();
             query.remove("x-http-method");
             query.remove("x-query-content-types");
-            ensureFormEncodedRequestBody(query);
+            ensureQueryRequestBody(query);
             path.add("query", query);
         }
     }
 
-    private void ensureFormEncodedRequestBody(final JsonObject operation) {
+    private void ensureQueryRequestBody(final JsonObject operation) {
         JsonObject requestBody = objectAt(operation, "requestBody");
         if (requestBody == null) {
             requestBody = new JsonObject();
@@ -80,6 +80,18 @@ public final class OpenApi32Finalizer {
         if (!jsonPathMediaType.has("schema") || !jsonPathMediaType.get("schema").isJsonObject()) {
             jsonPathMediaType.add("schema", stringSchema());
         }
+
+        JsonObject structuredMediaType =
+                objectAt(content, ThingifierHttpApi.STRUCTURED_TODO_QUERY_CONTENT_TYPE);
+        if (structuredMediaType == null) {
+            structuredMediaType = new JsonObject();
+            content.add(ThingifierHttpApi.STRUCTURED_TODO_QUERY_CONTENT_TYPE, structuredMediaType);
+        }
+
+        if (!structuredMediaType.has("schema")
+                || !structuredMediaType.get("schema").isJsonObject()) {
+            structuredMediaType.add("schema", structuredQuerySchema());
+        }
     }
 
     private JsonObject permissiveFormSchema() {
@@ -94,6 +106,40 @@ public final class OpenApi32Finalizer {
     private JsonObject stringSchema() {
         final JsonObject schema = new JsonObject();
         schema.addProperty("type", "string");
+        return schema;
+    }
+
+    private JsonObject structuredQuerySchema() {
+        final JsonObject schema = new JsonObject();
+        schema.addProperty("type", "object");
+
+        final JsonObject properties = new JsonObject();
+        properties.add("filter", objectSchema());
+        properties.add("sort", sortArraySchema());
+        properties.add("limit", nonNegativeIntegerSchema());
+        properties.add("offset", nonNegativeIntegerSchema());
+        schema.add("properties", properties);
+
+        return schema;
+    }
+
+    private JsonObject objectSchema() {
+        final JsonObject schema = new JsonObject();
+        schema.addProperty("type", "object");
+        return schema;
+    }
+
+    private JsonObject sortArraySchema() {
+        final JsonObject schema = new JsonObject();
+        schema.addProperty("type", "array");
+        schema.add("items", objectSchema());
+        return schema;
+    }
+
+    private JsonObject nonNegativeIntegerSchema() {
+        final JsonObject schema = new JsonObject();
+        schema.addProperty("type", "integer");
+        schema.addProperty("minimum", 0);
         return schema;
     }
 

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/adapter/internalhttp/conversion/InternalHttpRequestToHttpApiRequestTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/adapter/internalhttp/conversion/InternalHttpRequestToHttpApiRequestTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import uk.co.compendiumdev.thingifier.adapter.internalhttp.InternalHttpMethod;
 import uk.co.compendiumdev.thingifier.adapter.internalhttp.InternalHttpRequest;
 import uk.co.compendiumdev.thingifier.api.http.HttpApiRequest;
+import uk.co.compendiumdev.thingifier.core.query.FilterOperation;
 
 class InternalHttpRequestToHttpApiRequestTest {
 
@@ -45,7 +46,9 @@ class InternalHttpRequestToHttpApiRequestTest {
         Assertions.assertEquals("1", apiRequest.rawQueryParamsValue("p"));
         Assertions.assertEquals(4, apiRequest.getFilterableQueryParams().size());
         Assertions.assertEquals("id", apiRequest.getFilterableQueryParams().get(0).fieldName);
-        Assertions.assertEquals(">=", apiRequest.getFilterableQueryParams().get(0).filterOperation);
+        Assertions.assertEquals(
+                FilterOperation.GREATER_THAN_OR_EQUAL,
+                apiRequest.getFilterableQueryParams().get(0).filterOperation);
         Assertions.assertEquals("1", apiRequest.getFilterableQueryParams().get(0).fieldValue);
     }
 }

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/docgen/ApiRoutingDefinitionDocGeneratorTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/docgen/ApiRoutingDefinitionDocGeneratorTest.java
@@ -32,6 +32,8 @@ public class ApiRoutingDefinitionDocGeneratorTest {
 
         Assertions.assertTrue(statuses(query).containsAll(Set.of(200, 400, 413, 415, 422)));
         Assertions.assertTrue(query.getDocumentation().contains("application/jsonpath"));
+        Assertions.assertTrue(
+                query.getDocumentation().contains("application/vnd.apichallenges.todo-query+json"));
         Assertions.assertEquals("OPTIONS, GET, HEAD, POST, QUERY", options.headerValue());
     }
 

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/UrlQueryParamParserTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/UrlQueryParamParserTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import uk.co.compendiumdev.thingifier.core.query.FilterOperation;
 import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
 
 public class UrlQueryParamParserTest {
@@ -32,7 +33,8 @@ public class UrlQueryParamParserTest {
         UrlQueryParamParser parser = new UrlQueryParamParser();
         QueryFilterParams values = parser.parse("id%3E%3D4");
         Assertions.assertEquals("id", values.get(0).fieldName);
-        Assertions.assertEquals(">=", values.get(0).filterOperation);
+        Assertions.assertEquals(
+                FilterOperation.GREATER_THAN_OR_EQUAL, values.get(0).filterOperation);
         Assertions.assertEquals("4", values.get(0).fieldValue);
     }
 
@@ -43,11 +45,12 @@ public class UrlQueryParamParserTest {
         Assertions.assertEquals(2, values.size());
 
         Assertions.assertEquals("id", values.get(0).fieldName);
-        Assertions.assertEquals(">=", values.get(0).filterOperation);
+        Assertions.assertEquals(
+                FilterOperation.GREATER_THAN_OR_EQUAL, values.get(0).filterOperation);
         Assertions.assertEquals("4", values.get(0).fieldValue);
 
         Assertions.assertEquals("id", values.get(1).fieldName);
-        Assertions.assertEquals("<=", values.get(1).filterOperation);
+        Assertions.assertEquals(FilterOperation.LESS_THAN_OR_EQUAL, values.get(1).filterOperation);
         Assertions.assertEquals("7", values.get(1).fieldValue);
     }
 
@@ -60,7 +63,8 @@ public class UrlQueryParamParserTest {
         Assertions.assertEquals(1, values.size());
 
         Assertions.assertEquals("id", values.get(0).fieldName);
-        Assertions.assertEquals(">=", values.get(0).filterOperation);
+        Assertions.assertEquals(
+                FilterOperation.GREATER_THAN_OR_EQUAL, values.get(0).filterOperation);
         Assertions.assertEquals("4", values.get(0).fieldValue);
     }
 
@@ -86,7 +90,8 @@ public class UrlQueryParamParserTest {
         Assertions.assertEquals(1, values.size());
 
         Assertions.assertEquals("fieldname4", values.get(0).fieldName);
-        Assertions.assertEquals("=", values.get(0).filterOperation, "expected = by default");
+        Assertions.assertEquals(
+                FilterOperation.EQUALS, values.get(0).filterOperation, "expected = by default");
         Assertions.assertEquals("", values.get(0).fieldValue);
     }
 
@@ -97,7 +102,53 @@ public class UrlQueryParamParserTest {
         Assertions.assertEquals(1, values.size());
 
         Assertions.assertEquals("fieldname", values.get(0).fieldName);
-        Assertions.assertEquals(">=", values.get(0).filterOperation);
+        Assertions.assertEquals(
+                FilterOperation.GREATER_THAN_OR_EQUAL, values.get(0).filterOperation);
         Assertions.assertEquals("", values.get(0).fieldValue);
+    }
+
+    @Test
+    public void explicitExactMatchCanKeepOperatorPrefixedValue() {
+        UrlQueryParamParser parser = new UrlQueryParamParser();
+        QueryFilterParams values = parser.parse("title==>blocked");
+        Assertions.assertEquals(1, values.size());
+
+        Assertions.assertEquals("title", values.get(0).fieldName);
+        Assertions.assertEquals(FilterOperation.EXACT_MATCH, values.get(0).filterOperation);
+        Assertions.assertEquals(">blocked", values.get(0).fieldValue);
+    }
+
+    @Test
+    public void keyValueQueryCanUseOperatorPrefixedValue() {
+        UrlQueryParamParser parser = new UrlQueryParamParser();
+        QueryFilterParams values = parser.parse("id=>=4");
+        Assertions.assertEquals(1, values.size());
+
+        Assertions.assertEquals("id", values.get(0).fieldName);
+        Assertions.assertEquals(
+                FilterOperation.GREATER_THAN_OR_EQUAL, values.get(0).filterOperation);
+        Assertions.assertEquals("4", values.get(0).fieldValue);
+    }
+
+    @Test
+    public void keyValueQueryCanUseNotEqualsOperatorPrefixedValue() {
+        UrlQueryParamParser parser = new UrlQueryParamParser();
+        QueryFilterParams values = parser.parse("id=!=4");
+        Assertions.assertEquals(1, values.size());
+
+        Assertions.assertEquals("id", values.get(0).fieldName);
+        Assertions.assertEquals(FilterOperation.NOT_EQUALS, values.get(0).filterOperation);
+        Assertions.assertEquals("4", values.get(0).fieldValue);
+    }
+
+    @Test
+    public void equalsValuesCanContainOtherOperatorTokens() {
+        UrlQueryParamParser parser = new UrlQueryParamParser();
+        QueryFilterParams values = parser.parse("title=one<two");
+        Assertions.assertEquals(1, values.size());
+
+        Assertions.assertEquals("title", values.get(0).fieldName);
+        Assertions.assertEquals(FilterOperation.EQUALS, values.get(0).filterOperation);
+        Assertions.assertEquals("one<two", values.get(0).fieldValue);
     }
 }

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/requests/ThingifierHttpApiAdditionalRepresentationsTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/requests/ThingifierHttpApiAdditionalRepresentationsTest.java
@@ -75,6 +75,28 @@ class ThingifierHttpApiAdditionalRepresentationsTest {
         }
     }
 
+    @Test
+    void structuredJsonQuerySelectsAdditionalResponseRepresentationsFromAcceptHeader() {
+        Thingifier thingifier = taskThingifier();
+        createTask(thingifier, "Task");
+        ThingifierHttpApi api = new ThingifierHttpApi(thingifier);
+
+        for (Map.Entry<String, String> expected : expectedBodies().entrySet()) {
+            HttpApiRequest request =
+                    new HttpApiRequest("tasks")
+                            .addHeader(
+                                    "Content-Type",
+                                    ThingifierHttpApi.STRUCTURED_TODO_QUERY_CONTENT_TYPE)
+                            .addHeader("Accept", expected.getKey())
+                            .setBody("{\"filter\":{\"title\":\"Task\"}}");
+            HttpApiResponse response = api.queryRequest(request);
+
+            Assertions.assertEquals(200, response.getStatusCode());
+            Assertions.assertEquals(expected.getKey(), response.getType());
+            Assertions.assertEquals(expected.getValue(), response.getBody());
+        }
+    }
+
     private Map<String, String> expectedBodies() {
         Map<String, String> expectedBodies = new LinkedHashMap<>();
         expectedBodies.put("text/csv", "id,title\n1,Task");

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandlerTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandlerTest.java
@@ -230,6 +230,289 @@ public class RestApiQueryHandlerTest {
     }
 
     @Test
+    public void structuredJsonQueryEntityCollectionFiltersByDoneStatus() {
+        Thingifier thingifier = todoThingifier();
+        EntityInstance matching = createTodo(thingifier, "Keep", "false", "Open item");
+        createTodo(thingifier, "Skip", "true", "Closed item");
+
+        HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .queryRequest(
+                                structuredJsonQuery(
+                                        "todos", "{\"filter\":{\"doneStatus\":false}}"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertTrue(response.apiResponse().isCollection());
+        Assertions.assertEquals(1, response.apiResponse().getReturnedInstanceCollection().size());
+        Assertions.assertEquals(
+                matching, response.apiResponse().getReturnedInstanceCollection().get(0));
+        Assertions.assertEquals(
+                ThingifierHttpApi.SUPPORTED_QUERY_CONTENT_TYPES,
+                response.getHeaders().get(ThingifierHttpApi.ACCEPT_QUERY_HEADER));
+    }
+
+    @Test
+    public void structuredJsonQueryContainsUsesLiteralText() {
+        Thingifier thingifier = todoThingifier();
+        EntityInstance matching = createTodo(thingifier, "Scan * literally", "false", "Open item");
+        createTodo(thingifier, "Scan documents", "false", "Open item");
+
+        HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .queryRequest(
+                                structuredJsonQuery(
+                                        "todos", "{\"filter\":{\"title\":{\"contains\":\"*\"}}}"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(1, response.apiResponse().getReturnedInstanceCollection().size());
+        Assertions.assertEquals(
+                matching, response.apiResponse().getReturnedInstanceCollection().get(0));
+    }
+
+    @Test
+    public void structuredJsonQueryExactStringKeepsOperatorPrefixedTextLiteral() {
+        Thingifier thingifier = todoThingifier();
+        EntityInstance matching = createTodo(thingifier, ">blocked", "false", "Open item");
+        createTodo(thingifier, "zebra", "false", "Open item");
+
+        HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .queryRequest(
+                                structuredJsonQuery(
+                                        "todos", "{\"filter\":{\"title\":\">blocked\"}}"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(1, response.apiResponse().getReturnedInstanceCollection().size());
+        Assertions.assertEquals(
+                matching, response.apiResponse().getReturnedInstanceCollection().get(0));
+    }
+
+    @Test
+    public void structuredJsonQueryFiltersByGuidExactly() {
+        Thingifier thingifier = taskProjectThingifier();
+        EntityInstance matching = createProject(thingifier, "Project");
+        createProject(thingifier, "Other");
+
+        HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .queryRequest(
+                                structuredJsonQuery(
+                                        "projects",
+                                        "{\"filter\":{\"guid\":\""
+                                                + matching.getPrimaryKeyValue()
+                                                + "\"}}"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(1, response.apiResponse().getReturnedInstanceCollection().size());
+        Assertions.assertEquals(
+                matching, response.apiResponse().getReturnedInstanceCollection().get(0));
+    }
+
+    @Test
+    public void structuredJsonQueryFiltersByNumericComparisons() {
+        Thingifier thingifier = todoThingifier();
+        createTodo(thingifier, "First", "false", "One");
+        EntityInstance expected = createTodo(thingifier, "Second", "false", "Two");
+        createTodo(thingifier, "Third", "false", "Three");
+
+        HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .queryRequest(
+                                structuredJsonQuery(
+                                        "todos",
+                                        "{\"filter\":{\"id\":{\"greaterThan\":1,"
+                                                + "\"lessThan\":3}}}"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(1, response.apiResponse().getReturnedInstanceCollection().size());
+        Assertions.assertEquals(
+                expected, response.apiResponse().getReturnedInstanceCollection().get(0));
+    }
+
+    @Test
+    public void structuredJsonQueryCanSortAndPaginateResults() {
+        Thingifier thingifier = todoThingifier();
+        createTodo(thingifier, "First", "false", "One");
+        EntityInstance expected = createTodo(thingifier, "Second", "false", "Two");
+        createTodo(thingifier, "Third", "false", "Three");
+
+        HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .queryRequest(
+                                structuredJsonQuery(
+                                        "todos",
+                                        "{\"sort\":[{\"field\":\"id\",\"direction\":\"desc\"}],"
+                                                + "\"limit\":1,\"offset\":1}"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(1, response.apiResponse().getReturnedInstanceCollection().size());
+        Assertions.assertEquals(
+                expected, response.apiResponse().getReturnedInstanceCollection().get(0));
+    }
+
+    @Test
+    public void structuredJsonQueryFiltersRelationshipCollections() {
+        Thingifier thingifier = taskProjectThingifier();
+        ThingStore store = storeFor(thingifier);
+        EntityInstance project = createProject(thingifier, "Project");
+        EntityInstance matching = createTask(thingifier, "Keep this", "Open");
+        EntityInstance relatedButFilteredOut = createTask(thingifier, "Skip this", "Open");
+        createTask(thingifier, "Keep unrelated", "Open");
+        store.relationships().connect(project, "tasks", matching);
+        store.relationships().connect(project, "tasks", relatedButFilteredOut);
+
+        HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .queryRequest(
+                                structuredJsonQuery(
+                                        "projects/" + project.getPrimaryKeyValue() + "/tasks",
+                                        "{\"filter\":{\"title\":{\"contains\":\"Keep\"}}}"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(1, response.apiResponse().getReturnedInstanceCollection().size());
+        Assertions.assertEquals(
+                matching, response.apiResponse().getReturnedInstanceCollection().get(0));
+    }
+
+    @Test
+    public void structuredJsonQueryWorksForNonTodoCollections() {
+        Thingifier thingifier = taskProjectThingifier();
+        EntityInstance matching = createProject(thingifier, "Migration");
+        createProject(thingifier, "Support");
+
+        HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .queryRequest(
+                                structuredJsonQuery(
+                                        "projects", "{\"filter\":{\"title\":\"Migration\"}}"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(1, response.apiResponse().getReturnedInstanceCollection().size());
+        Assertions.assertEquals(
+                matching, response.apiResponse().getReturnedInstanceCollection().get(0));
+    }
+
+    @Test
+    public void structuredJsonQueryAcceptsVendorJsonMediaTypeWithParameters() {
+        Thingifier thingifier = todoThingifier();
+        EntityInstance matching = createTodo(thingifier, "Keep", "false", "Open item");
+
+        HttpApiRequest request =
+                new HttpApiRequest("todos")
+                        .addHeader(
+                                "Content-Type",
+                                ThingifierHttpApi.STRUCTURED_TODO_QUERY_CONTENT_TYPE
+                                        + "; charset=utf-8")
+                        .setBody("{\"filter\":{\"title\":\"Keep\"}}");
+        HttpApiResponse response = new ThingifierHttpApi(thingifier).queryRequest(request);
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(1, response.apiResponse().getReturnedInstanceCollection().size());
+        Assertions.assertEquals(
+                matching, response.apiResponse().getReturnedInstanceCollection().get(0));
+    }
+
+    @Test
+    public void structuredJsonQueryRejectsMalformedJson() {
+        Thingifier thingifier = todoThingifier();
+
+        HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .queryRequest(structuredJsonQuery("todos", "{\"filter\":"));
+
+        Assertions.assertEquals(400, response.getStatusCode());
+    }
+
+    @Test
+    public void structuredJsonQueryRejectsSingleQuotedJson() {
+        Thingifier thingifier = todoThingifier();
+
+        HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .queryRequest(structuredJsonQuery("todos", "{'filter':{'title':'Task'}}"));
+
+        Assertions.assertEquals(400, response.getStatusCode());
+    }
+
+    @Test
+    public void structuredJsonQueryRejectsUnknownFields() {
+        Thingifier thingifier = todoThingifier();
+
+        HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .queryRequest(
+                                structuredJsonQuery(
+                                        "todos", "{\"filter\":{\"unknown\":\"value\"}}"));
+
+        Assertions.assertEquals(422, response.getStatusCode());
+    }
+
+    @Test
+    public void structuredJsonQueryRejectsUnsupportedOperators() {
+        Thingifier thingifier = todoThingifier();
+
+        HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .queryRequest(
+                                structuredJsonQuery(
+                                        "todos",
+                                        "{\"filter\":{\"title\":{\"startsWith\":\"Task\"}}}"));
+
+        Assertions.assertEquals(422, response.getStatusCode());
+    }
+
+    @Test
+    public void structuredJsonQueryRejectsInvalidPaginationValues() {
+        Thingifier thingifier = todoThingifier();
+
+        HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .queryRequest(structuredJsonQuery("todos", "{\"limit\":-1}"));
+
+        Assertions.assertEquals(422, response.getStatusCode());
+    }
+
+    @Test
+    public void structuredJsonQueryRejectsInvalidSortFields() {
+        Thingifier thingifier = todoThingifier();
+
+        HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .queryRequest(
+                                structuredJsonQuery(
+                                        "todos",
+                                        "{\"sort\":[{\"field\":\"missing\","
+                                                + "\"direction\":\"asc\"}]}"));
+
+        Assertions.assertEquals(422, response.getStatusCode());
+    }
+
+    @Test
+    public void structuredJsonQueryStillRejectsApplicationJsonContentType() {
+        Thingifier thingifier = todoThingifier();
+        HttpApiRequest request =
+                new HttpApiRequest("todos")
+                        .addHeader("Content-Type", "application/json")
+                        .setBody("{\"filter\":{\"title\":\"Task\"}}");
+
+        HttpApiResponse response = new ThingifierHttpApi(thingifier).queryRequest(request);
+
+        Assertions.assertEquals(415, response.getStatusCode());
+    }
+
+    @Test
+    public void structuredJsonQueryKeepsUnsupportedAcceptAsNotAcceptable() {
+        Thingifier thingifier = todoThingifier();
+        HttpApiRequest request =
+                structuredJsonQuery("todos", "{\"filter\":{\"doneStatus\":false}}")
+                        .addHeader("Accept", "text/*");
+
+        HttpApiResponse response = new ThingifierHttpApi(thingifier).queryRequest(request);
+
+        Assertions.assertEquals(406, response.getStatusCode());
+    }
+
+    @Test
     public void getCollectionAdvertisesQuerySupport() {
         Thingifier thingifier = taskProjectThingifier();
 
@@ -609,6 +892,12 @@ public class RestApiQueryHandlerTest {
     private HttpApiRequest jsonPathQuery(final String path, final String body) {
         return new HttpApiRequest(path)
                 .addHeader("Content-Type", ThingifierHttpApi.JSONPATH_QUERY_CONTENT_TYPE)
+                .setBody(body);
+    }
+
+    private HttpApiRequest structuredJsonQuery(final String path, final String body) {
+        return new HttpApiRequest(path)
+                .addHeader("Content-Type", ThingifierHttpApi.STRUCTURED_TODO_QUERY_CONTENT_TYPE)
                 .setBody(body);
     }
 }

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGeneratorTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGeneratorTest.java
@@ -241,6 +241,10 @@ class RestApiDocumentationGeneratorTest {
         Assertions.assertTrue(
                 docs.contains(
                         "QUERY JSONPath content uses <i>Content-Type: application/jsonpath</i>"));
+        Assertions.assertTrue(
+                docs.contains(
+                        "QUERY structured JSON content uses <i>Content-Type: "
+                                + "application/vnd.apichallenges.todo-query+json</i>"));
         Assertions.assertTrue(docs.contains("$['tasks'][?@['title'] == 'Task']"));
         Assertions.assertFalse(docs.contains("&amp;sortBy=-id"));
         Assertions.assertFalse(

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/OpenApi32FinalizerTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/OpenApi32FinalizerTest.java
@@ -27,7 +27,8 @@ class OpenApi32FinalizerTest {
                         "x-http-method": "QUERY",
                         "x-query-content-types": [
                           "application/x-www-form-urlencoded",
-                          "application/jsonpath"
+                          "application/jsonpath",
+                          "application/vnd.apichallenges.todo-query+json"
                         ],
                         "responses": {
                           "200": {
@@ -53,6 +54,10 @@ class OpenApi32FinalizerTest {
                 query.getAsJsonObject("requestBody")
                         .getAsJsonObject("content")
                         .getAsJsonObject("application/jsonpath");
+        final JsonObject structuredMediaType =
+                query.getAsJsonObject("requestBody")
+                        .getAsJsonObject("content")
+                        .getAsJsonObject("application/vnd.apichallenges.todo-query+json");
 
         Assertions.assertEquals("3.2.0", document.get("openapi").getAsString());
         Assertions.assertTrue(todos.has("get"));
@@ -73,6 +78,16 @@ class OpenApi32FinalizerTest {
                         .getAsString());
         Assertions.assertEquals(
                 "string", jsonPathMediaType.getAsJsonObject("schema").get("type").getAsString());
+        Assertions.assertEquals(
+                "object", structuredMediaType.getAsJsonObject("schema").get("type").getAsString());
+        Assertions.assertEquals(
+                "integer",
+                structuredMediaType
+                        .getAsJsonObject("schema")
+                        .getAsJsonObject("properties")
+                        .getAsJsonObject("limit")
+                        .get("type")
+                        .getAsString());
     }
 
     @Test
@@ -130,6 +145,14 @@ class OpenApi32FinalizerTest {
                 query.getAsJsonObject("requestBody")
                         .getAsJsonObject("content")
                         .getAsJsonObject("application/jsonpath")
+                        .getAsJsonObject("schema")
+                        .get("type")
+                        .getAsString());
+        Assertions.assertEquals(
+                "object",
+                query.getAsJsonObject("requestBody")
+                        .getAsJsonObject("content")
+                        .getAsJsonObject("application/vnd.apichallenges.todo-query+json")
                         .getAsJsonObject("schema")
                         .get("type")
                         .getAsString());

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerEntityDescriptionTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerEntityDescriptionTest.java
@@ -253,6 +253,10 @@ class SwaggerizerEntityDescriptionTest {
         Object contentTypes = operation.getExtensions().get("x-query-content-types");
         Assertions.assertTrue(contentTypes instanceof List<?>);
         Assertions.assertEquals(
-                List.of("application/x-www-form-urlencoded", "application/jsonpath"), contentTypes);
+                List.of(
+                        "application/x-www-form-urlencoded",
+                        "application/jsonpath",
+                        "application/vnd.apichallenges.todo-query+json"),
+                contentTypes);
     }
 }


### PR DESCRIPTION
## Summary

Adds structured JSON QUERY support for `application/vnd.apichallenges.todo-query+json` across collection and relationship-collection routes.

## Changes

- Adds structured query parsing for `filter`, `sort`, `limit`, and `offset`.
- Supports exact matches, literal `contains`, numeric comparisons, sorting, and pagination.
- Adds strict validation for malformed JSON, unknown fields, unsupported operators, invalid sort, invalid pagination, and unsupported media types.
- Adds `FilterOperation` so query operations are handled as typed domain values instead of scattered string literals.
- Updates docs and OpenAPI output to advertise the new query media type.

## Validation

- `mvn -q -pl ercoremodel,thingifier spotless:apply`
- Focused query/parser tests
- `mvn -q -pl thingifier,swaggerizer -am -DfailIfNoTests=false verify`
- `git diff --check`