### PR TITLE
Rename structured query media type

### DIFF
--- a/swaggerizer/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerTest.java
+++ b/swaggerizer/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerTest.java
@@ -35,7 +35,7 @@ public class SwaggerizerTest {
         Assertions.assertTrue(openApiVersion(swagger).startsWith("3.1."));
         Assertions.assertTrue(swagger.contains("\"x-query-operation\""));
         Assertions.assertTrue(swagger.contains("application/x-www-form-urlencoded"));
-        Assertions.assertTrue(swagger.contains("application/vnd.apichallenges.todo-query+json"));
+        Assertions.assertTrue(swagger.contains("application/vnd.thingifier.query+json"));
     }
 
     @Test
@@ -51,7 +51,7 @@ public class SwaggerizerTest {
         Assertions.assertTrue(openApiVersion(swagger).startsWith("3.0."));
         Assertions.assertTrue(swagger.contains("\"x-query-operation\""));
         Assertions.assertTrue(swagger.contains("application/x-www-form-urlencoded"));
-        Assertions.assertTrue(swagger.contains("application/vnd.apichallenges.todo-query+json"));
+        Assertions.assertTrue(swagger.contains("application/vnd.thingifier.query+json"));
     }
 
     @Test
@@ -85,7 +85,7 @@ public class SwaggerizerTest {
         Assertions.assertTrue(
                 query.getAsJsonObject("requestBody")
                         .getAsJsonObject("content")
-                        .has("application/vnd.apichallenges.todo-query+json"));
+                        .has("application/vnd.thingifier.query+json"));
     }
 
     private boolean hasParameterNamed(final JsonObject operation, final String name) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ApiRequestEnvelope.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ApiRequestEnvelope.java
@@ -72,7 +72,7 @@ public final class ApiRequestEnvelope {
         if (contentType.isJsonPath()) {
             return QueryBodyFormat.JSONPATH;
         }
-        if (contentType.isStructuredTodoQueryJson()) {
+        if (contentType.isStructuredQueryJson()) {
             return QueryBodyFormat.STRUCTURED_JSON;
         }
         return QueryBodyFormat.URL_ENCODED;

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/HttpApiRequestValidator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/HttpApiRequestValidator.java
@@ -105,7 +105,7 @@ public class HttpApiRequestValidator {
 
         if (!contentType.isFormUrlEncoded()
                 && !contentType.isJsonPath()
-                && !contentType.isStructuredTodoQueryJson()) {
+                && !contentType.isStructuredQueryJson()) {
             ApiResponse response =
                     queryContentError(
                             this.apiConfig.statusCodes().contentTypeNotSupported(),
@@ -117,7 +117,7 @@ public class HttpApiRequestValidator {
         try {
             if (contentType.isJsonPath()) {
                 validateJsonPath(request.getBody());
-            } else if (contentType.isStructuredTodoQueryJson()) {
+            } else if (contentType.isStructuredQueryJson()) {
                 validateStructuredQueryJson(request.getBody());
             } else {
                 new UrlQueryParamParser().parseStrict(request.getBody());

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
@@ -39,13 +39,10 @@ public final class ThingifierHttpApi {
     public static final String ACCEPT_QUERY_HEADER = "Accept-Query";
     public static final String QUERY_CONTENT_TYPE = "application/x-www-form-urlencoded";
     public static final String JSONPATH_QUERY_CONTENT_TYPE = "application/jsonpath";
-    public static final String STRUCTURED_TODO_QUERY_CONTENT_TYPE =
-            "application/vnd.apichallenges.todo-query+json";
+    public static final String STRUCTURED_QUERY_CONTENT_TYPE =
+            "application/vnd.thingifier.query+json";
     public static final List<String> SUPPORTED_QUERY_CONTENT_TYPES_LIST =
-            List.of(
-                    QUERY_CONTENT_TYPE,
-                    JSONPATH_QUERY_CONTENT_TYPE,
-                    STRUCTURED_TODO_QUERY_CONTENT_TYPE);
+            List.of(QUERY_CONTENT_TYPE, JSONPATH_QUERY_CONTENT_TYPE, STRUCTURED_QUERY_CONTENT_TYPE);
     public static final String SUPPORTED_QUERY_CONTENT_TYPES =
             String.join(", ", SUPPORTED_QUERY_CONTENT_TYPES_LIST);
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/ContentTypeHeaderParser.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/ContentTypeHeaderParser.java
@@ -36,8 +36,8 @@ public class ContentTypeHeaderParser {
         return isMediaType("application/jsonpath");
     }
 
-    public boolean isStructuredTodoQueryJson() {
-        return isMediaType("application/vnd.apichallenges.todo-query+json");
+    public boolean isStructuredQueryJson() {
+        return isMediaType("application/vnd.thingifier.query+json");
     }
 
     public boolean isMissing() {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGenerator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGenerator.java
@@ -543,8 +543,7 @@ public class RestApiDocumentationGenerator {
                         output.append(
                                 paragraph(
                                         "QUERY structured JSON content uses <i>Content-Type: "
-                                                + ThingifierHttpApi
-                                                        .STRUCTURED_TODO_QUERY_CONTENT_TYPE
+                                                + ThingifierHttpApi.STRUCTURED_QUERY_CONTENT_TYPE
                                                 + "</i> with a JSON query object."));
                     }
                 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/OpenApi32Finalizer.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/OpenApi32Finalizer.java
@@ -82,10 +82,10 @@ public final class OpenApi32Finalizer {
         }
 
         JsonObject structuredMediaType =
-                objectAt(content, ThingifierHttpApi.STRUCTURED_TODO_QUERY_CONTENT_TYPE);
+                objectAt(content, ThingifierHttpApi.STRUCTURED_QUERY_CONTENT_TYPE);
         if (structuredMediaType == null) {
             structuredMediaType = new JsonObject();
-            content.add(ThingifierHttpApi.STRUCTURED_TODO_QUERY_CONTENT_TYPE, structuredMediaType);
+            content.add(ThingifierHttpApi.STRUCTURED_QUERY_CONTENT_TYPE, structuredMediaType);
         }
 
         if (!structuredMediaType.has("schema")

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/docgen/ApiRoutingDefinitionDocGeneratorTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/docgen/ApiRoutingDefinitionDocGeneratorTest.java
@@ -33,7 +33,7 @@ public class ApiRoutingDefinitionDocGeneratorTest {
         Assertions.assertTrue(statuses(query).containsAll(Set.of(200, 400, 413, 415, 422)));
         Assertions.assertTrue(query.getDocumentation().contains("application/jsonpath"));
         Assertions.assertTrue(
-                query.getDocumentation().contains("application/vnd.apichallenges.todo-query+json"));
+                query.getDocumentation().contains("application/vnd.thingifier.query+json"));
         Assertions.assertEquals("OPTIONS, GET, HEAD, POST, QUERY", options.headerValue());
     }
 

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/ContentTypeHeaderParserTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/ContentTypeHeaderParserTest.java
@@ -1,0 +1,26 @@
+package uk.co.compendiumdev.thingifier.api.http.headers.headerparser;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import uk.co.compendiumdev.thingifier.api.http.ThingifierHttpApi;
+
+class ContentTypeHeaderParserTest {
+
+    @Test
+    void recognizesThingifierStructuredQueryJsonMediaType() {
+        ContentTypeHeaderParser parser =
+                new ContentTypeHeaderParser(
+                        ThingifierHttpApi.STRUCTURED_QUERY_CONTENT_TYPE + "; charset=utf-8");
+
+        Assertions.assertTrue(parser.isStructuredQueryJson());
+    }
+
+    @Test
+    void doesNotRecognizeTodoSpecificStructuredQueryJsonMediaType() {
+        ContentTypeHeaderParser parser =
+                new ContentTypeHeaderParser(
+                        "application/vnd.apichallenges." + "todo-" + "query+json");
+
+        Assertions.assertFalse(parser.isStructuredQueryJson());
+    }
+}

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/requests/ThingifierHttpApiAdditionalRepresentationsTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/requests/ThingifierHttpApiAdditionalRepresentationsTest.java
@@ -85,8 +85,7 @@ class ThingifierHttpApiAdditionalRepresentationsTest {
             HttpApiRequest request =
                     new HttpApiRequest("tasks")
                             .addHeader(
-                                    "Content-Type",
-                                    ThingifierHttpApi.STRUCTURED_TODO_QUERY_CONTENT_TYPE)
+                                    "Content-Type", ThingifierHttpApi.STRUCTURED_QUERY_CONTENT_TYPE)
                             .addHeader("Accept", expected.getKey())
                             .setBody("{\"filter\":{\"title\":\"Task\"}}");
             HttpApiResponse response = api.queryRequest(request);

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandlerTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandlerTest.java
@@ -401,8 +401,7 @@ public class RestApiQueryHandlerTest {
                 new HttpApiRequest("todos")
                         .addHeader(
                                 "Content-Type",
-                                ThingifierHttpApi.STRUCTURED_TODO_QUERY_CONTENT_TYPE
-                                        + "; charset=utf-8")
+                                ThingifierHttpApi.STRUCTURED_QUERY_CONTENT_TYPE + "; charset=utf-8")
                         .setBody("{\"filter\":{\"title\":\"Keep\"}}");
         HttpApiResponse response = new ThingifierHttpApi(thingifier).queryRequest(request);
 
@@ -897,7 +896,7 @@ public class RestApiQueryHandlerTest {
 
     private HttpApiRequest structuredJsonQuery(final String path, final String body) {
         return new HttpApiRequest(path)
-                .addHeader("Content-Type", ThingifierHttpApi.STRUCTURED_TODO_QUERY_CONTENT_TYPE)
+                .addHeader("Content-Type", ThingifierHttpApi.STRUCTURED_QUERY_CONTENT_TYPE)
                 .setBody(body);
     }
 }

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGeneratorTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGeneratorTest.java
@@ -244,7 +244,7 @@ class RestApiDocumentationGeneratorTest {
         Assertions.assertTrue(
                 docs.contains(
                         "QUERY structured JSON content uses <i>Content-Type: "
-                                + "application/vnd.apichallenges.todo-query+json</i>"));
+                                + "application/vnd.thingifier.query+json</i>"));
         Assertions.assertTrue(docs.contains("$['tasks'][?@['title'] == 'Task']"));
         Assertions.assertFalse(docs.contains("&amp;sortBy=-id"));
         Assertions.assertFalse(

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/OpenApi32FinalizerTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/OpenApi32FinalizerTest.java
@@ -28,7 +28,7 @@ class OpenApi32FinalizerTest {
                         "x-query-content-types": [
                           "application/x-www-form-urlencoded",
                           "application/jsonpath",
-                          "application/vnd.apichallenges.todo-query+json"
+                          "application/vnd.thingifier.query+json"
                         ],
                         "responses": {
                           "200": {
@@ -57,7 +57,7 @@ class OpenApi32FinalizerTest {
         final JsonObject structuredMediaType =
                 query.getAsJsonObject("requestBody")
                         .getAsJsonObject("content")
-                        .getAsJsonObject("application/vnd.apichallenges.todo-query+json");
+                        .getAsJsonObject("application/vnd.thingifier.query+json");
 
         Assertions.assertEquals("3.2.0", document.get("openapi").getAsString());
         Assertions.assertTrue(todos.has("get"));
@@ -152,7 +152,7 @@ class OpenApi32FinalizerTest {
                 "object",
                 query.getAsJsonObject("requestBody")
                         .getAsJsonObject("content")
-                        .getAsJsonObject("application/vnd.apichallenges.todo-query+json")
+                        .getAsJsonObject("application/vnd.thingifier.query+json")
                         .getAsJsonObject("schema")
                         .get("type")
                         .getAsString());

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerEntityDescriptionTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerEntityDescriptionTest.java
@@ -256,7 +256,7 @@ class SwaggerizerEntityDescriptionTest {
                 List.of(
                         "application/x-www-form-urlencoded",
                         "application/jsonpath",
-                        "application/vnd.apichallenges.todo-query+json"),
+                        "application/vnd.thingifier.query+json"),
                 contentTypes);
     }
 }


### PR DESCRIPTION
## Summary
- switch structured JSON QUERY support to `application/vnd.thingifier.query+json`
- rename the public structured query constant/helper away from todo-specific wording
- update Accept-Query, docs, OpenAPI output, and tests for the new media type
- add parser coverage that accepts `; charset=utf-8` on the new type and does not recognize the old todo-specific type

## Tests
- `mvn -q -pl thingifier spotless:apply`
- `mvn -q -pl thingifier,swaggerizer -am -DfailIfNoTests=false "-Dtest=ContentTypeHeaderParserTest,RestApiQueryHandlerTest,ThingifierHttpApiAdditionalRepresentationsTest,ApiRoutingDefinitionDocGeneratorTest,RestApiDocumentationGeneratorTest,OpenApi32FinalizerTest,SwaggerizerEntityDescriptionTest,SwaggerizerTest" test`
- `mvn -q -pl thingifier,swaggerizer -am -DfailIfNoTests=false verify`
- `git diff --check`
- full Maven verification via commit hook