### PR TITLE
Stabilize malformed structured query JSON errors

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/HttpApiRequestValidator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/HttpApiRequestValidator.java
@@ -14,6 +14,8 @@ import uk.co.compendiumdev.thingifier.apiconfig.ThingifierApiConfig;
 
 public class HttpApiRequestValidator {
 
+    private static final String MALFORMED_STRUCTURED_QUERY_JSON = "Malformed JSON query body";
+
     private final ThingifierApiConfig apiConfig;
     Boolean isValid;
     private ApiResponse errorResponse;
@@ -118,11 +120,15 @@ public class HttpApiRequestValidator {
             if (contentType.isJsonPath()) {
                 validateJsonPath(request.getBody());
             } else if (contentType.isStructuredQueryJson()) {
-                validateStructuredQueryJson(request.getBody());
+                try {
+                    validateStructuredQueryJson(request.getBody());
+                } catch (JsonProcessingException e) {
+                    return queryContentError(400, MALFORMED_STRUCTURED_QUERY_JSON);
+                }
             } else {
                 new UrlQueryParamParser().parseStrict(request.getBody());
             }
-        } catch (IllegalArgumentException | InvalidPathException | JsonProcessingException e) {
+        } catch (IllegalArgumentException | InvalidPathException e) {
             return queryContentError(400, e.getMessage());
         }
 

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandlerTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandlerTest.java
@@ -1,5 +1,6 @@
 package uk.co.compendiumdev.thingifier.api.restapihandlers;
 
+import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import uk.co.compendiumdev.thingifier.Thingifier;
@@ -420,6 +421,8 @@ public class RestApiQueryHandlerTest {
                         .queryRequest(structuredJsonQuery("todos", "{\"filter\":"));
 
         Assertions.assertEquals(400, response.getStatusCode());
+        Assertions.assertEquals(
+                List.of("Malformed JSON query body"), response.apiResponse().getErrorMessages());
     }
 
     @Test
@@ -431,6 +434,8 @@ public class RestApiQueryHandlerTest {
                         .queryRequest(structuredJsonQuery("todos", "{'filter':{'title':'Task'}}"));
 
         Assertions.assertEquals(400, response.getStatusCode());
+        Assertions.assertEquals(
+                List.of("Malformed JSON query body"), response.apiResponse().getErrorMessages());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- return a stable `Malformed JSON query body` message for malformed structured JSON QUERY bodies
- keep existing JSONPath and form QUERY validation messages unchanged
- add regression assertions for malformed structured JSON and single-quoted JSON bodies

## Validation
- `mvn -q -pl thingifier -Dtest=RestApiQueryHandlerTest test`
- `mvn -q -pl thingifier -DfailIfNoTests=false verify`
- full Maven verification via commit hook

Note: the first commit-hook run failed because a stale local `apichallenges.jar` process was already listening on port 4567. After stopping that local process, the hook passed cleanly.