### PR TITLE
Stabilize null structured query JSON errors

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/HttpApiRequestValidator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/HttpApiRequestValidator.java
@@ -122,7 +122,7 @@ public class HttpApiRequestValidator {
             } else if (contentType.isStructuredQueryJson()) {
                 try {
                     validateStructuredQueryJson(request.getBody());
-                } catch (JsonProcessingException e) {
+                } catch (JsonProcessingException | IllegalArgumentException e) {
                     return queryContentError(400, MALFORMED_STRUCTURED_QUERY_JSON);
                 }
             } else {

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandlerTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandlerTest.java
@@ -439,6 +439,18 @@ public class RestApiQueryHandlerTest {
     }
 
     @Test
+    public void structuredJsonQueryRejectsNullBody() {
+        Thingifier thingifier = todoThingifier();
+
+        HttpApiResponse response =
+                new ThingifierHttpApi(thingifier).queryRequest(structuredJsonQuery("todos", null));
+
+        Assertions.assertEquals(400, response.getStatusCode());
+        Assertions.assertEquals(
+                List.of("Malformed JSON query body"), response.apiResponse().getErrorMessages());
+    }
+
+    @Test
     public void structuredJsonQueryRejectsUnknownFields() {
         Thingifier thingifier = todoThingifier();
 


### PR DESCRIPTION
## Summary
- include `IllegalArgumentException` in the structured JSON QUERY malformed-body catch path
- keep the public 400 response message stable as `Malformed JSON query body`
- add a null-body regression test for structured JSON QUERY requests

## Validation
- `mvn -q -pl thingifier -Dtest=RestApiQueryHandlerTest test`
- `mvn -q -pl thingifier spotless:apply`
- `mvn -q -pl thingifier -DfailIfNoTests=false verify`
- full Maven verification via commit hook