### PR TITLE
Improve Accept header negotiation

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/httpserver/SimpleHttpRouteCreator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/httpserver/SimpleHttpRouteCreator.java
@@ -60,14 +60,14 @@ public class SimpleHttpRouteCreator {
                     (request, result) -> {
                         final AcceptHeaderParser acceptParser =
                                 new AcceptHeaderParser(request.header("Accept"));
-                        String preferred =
-                                new AcceptHeaderParser(request.header("Accept")).getPreferredType();
-                        if (preferred == null
-                                || preferred.trim().isEmpty()
-                                || acceptParser.willAcceptAnything()) {
-                            preferred = "application/json"; // hard coded default
+                        AcceptHeaderParser.ACCEPT_TYPE preferredType =
+                                acceptParser.preferredSupportedType(
+                                        AcceptHeaderParser.ACCEPT_TYPE.responseMediaTypes(),
+                                        AcceptHeaderParser.ACCEPT_TYPE.JSON);
+                        if (preferredType == AcceptHeaderParser.ACCEPT_TYPE.NO_MATCHING_TYPE) {
+                            preferredType = AcceptHeaderParser.ACCEPT_TYPE.JSON;
                         }
-                        result.header("Content-Type", preferred);
+                        result.header("Content-Type", preferredType.mediaType());
                         if (!allowResponseIndexing) {
                             result.header("x-robots-tag", "noindex");
                         }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/HttpApiResponse.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/HttpApiResponse.java
@@ -1,5 +1,7 @@
 package uk.co.compendiumdev.thingifier.api.http;
 
+import java.util.ArrayList;
+import java.util.List;
 import uk.co.compendiumdev.thingifier.api.ermodelconversion.JsonThing;
 import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
 import uk.co.compendiumdev.thingifier.api.http.headers.headerparser.AcceptHeaderParser;
@@ -53,7 +55,10 @@ public final class HttpApiResponse {
 
         AcceptHeaderParser accept = new AcceptHeaderParser(acceptHeader);
 
-        responseType = selectResponseType(accept);
+        responseType = accept.preferredSupportedType(allowedResponseTypes(), defaultResponseType());
+        if (responseType == AcceptHeaderParser.ACCEPT_TYPE.NO_MATCHING_TYPE) {
+            responseType = defaultResponseType();
+        }
         type = responseType.mediaType();
 
         apiResponseHeaders.putAll(originalApiResponseHeaders);
@@ -64,34 +69,31 @@ public final class HttpApiResponse {
         }
     }
 
-    private AcceptHeaderParser.ACCEPT_TYPE selectResponseType(final AcceptHeaderParser accept) {
-        for (AcceptHeaderParser.ACCEPT_TYPE candidate :
-                accept.getSupportedTypesInPreferenceOrder()) {
-            if (candidate == AcceptHeaderParser.ACCEPT_TYPE.ANYTHING) {
+    private List<AcceptHeaderParser.ACCEPT_TYPE> allowedResponseTypes() {
+        final List<AcceptHeaderParser.ACCEPT_TYPE> allowedTypes = new ArrayList<>();
+        for (AcceptHeaderParser.ACCEPT_TYPE type :
+                AcceptHeaderParser.ACCEPT_TYPE.responseMediaTypes()) {
+            if (type == AcceptHeaderParser.ACCEPT_TYPE.XML
+                    && !this.apiConfig.willApiAllowXmlForResponses()) {
                 continue;
             }
-            if (canRender(candidate)) {
-                return candidate;
+            if (type == AcceptHeaderParser.ACCEPT_TYPE.JSON
+                    && !this.apiConfig.willApiAllowJsonForResponses()) {
+                continue;
             }
+            allowedTypes.add(type);
         }
-        return defaultResponseType();
-    }
-
-    private boolean canRender(final AcceptHeaderParser.ACCEPT_TYPE candidate) {
-        if (candidate == AcceptHeaderParser.ACCEPT_TYPE.XML) {
-            return apiConfig.willApiAllowXmlForResponses();
-        }
-        if (candidate == AcceptHeaderParser.ACCEPT_TYPE.JSON) {
-            return apiConfig.willApiAllowJsonForResponses();
-        }
-        return candidate != AcceptHeaderParser.ACCEPT_TYPE.NO_MATCHING_TYPE;
+        return allowedTypes;
     }
 
     private AcceptHeaderParser.ACCEPT_TYPE defaultResponseType() {
         if (apiConfig.willApiAllowJsonForResponses()) {
             return AcceptHeaderParser.ACCEPT_TYPE.JSON;
         }
-        return AcceptHeaderParser.ACCEPT_TYPE.XML;
+        if (apiConfig.willApiAllowXmlForResponses()) {
+            return AcceptHeaderParser.ACCEPT_TYPE.XML;
+        }
+        return AcceptHeaderParser.ACCEPT_TYPE.CSV;
     }
 
     public String getBody() {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/AcceptHeaderParser.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/AcceptHeaderParser.java
@@ -1,10 +1,13 @@
 package uk.co.compendiumdev.thingifier.api.http.headers.headerparser;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
 
 public class AcceptHeaderParser {
     private final String acceptHeader;
-    private final List<String> acceptMediaTypeDefinitionsList;
+    private final List<AcceptedMediaRange> acceptMediaTypeDefinitionsList;
 
     public boolean willAcceptAnything() {
         return willAccept(ACCEPT_TYPE.ANYTHING);
@@ -91,19 +94,17 @@ public class AcceptHeaderParser {
     }
 
     public boolean isSupportedHeader() {
-        boolean supported = false;
-
         if (acceptMediaTypeDefinitionsList.size() == 0) {
             // we are allowed blank or missing accept - that counts as default
-            supported = true;
+            return true;
         }
 
-        for (String askedFor : acceptMediaTypeDefinitionsList) {
-            if (getMatchingType(askedFor) != ACCEPT_TYPE.NO_MATCHING_TYPE) {
-                supported = true;
+        for (AcceptedMediaRange askedFor : acceptMediaTypeDefinitionsList) {
+            if (askedFor.matchesAnyOf(ACCEPT_TYPE.responseMediaTypes())) {
+                return true;
             }
         }
-        return supported;
+        return false;
     }
 
     public enum ACCEPT_TYPE {
@@ -116,7 +117,7 @@ public class AcceptHeaderParser {
         JSONL("application/jsonl"),
         JSON_SEQ("application/json-seq"),
         TSV("text/tab-separated-values"),
-        ANYTHING("application/*", "*/*"),
+        ANYTHING("*/*"),
         NO_MATCHING_TYPE();
 
         private final List<String> mediaTypes;
@@ -159,12 +160,12 @@ public class AcceptHeaderParser {
             this.acceptHeader = acceptHeader.trim().toLowerCase();
         }
 
-        // TODO: use ;q=0.9 to sort items in the array
-        String[] acceptMediaTypeDefinitions = this.acceptHeader.split(",");
         acceptMediaTypeDefinitionsList = new ArrayList<>();
-        for (String type : acceptMediaTypeDefinitions) {
+        int order = 0;
+        for (String type : splitOutsideQuotes(this.acceptHeader, ',')) {
             if (type != null && type.trim().length() > 0) {
-                acceptMediaTypeDefinitionsList.add(type.trim());
+                acceptMediaTypeDefinitionsList.add(AcceptedMediaRange.from(type.trim(), order));
+                order++;
             }
         }
     }
@@ -173,52 +174,104 @@ public class AcceptHeaderParser {
         if (acceptMediaTypeDefinitionsList.size() == 0) {
             return "";
         }
-        return acceptMediaTypeDefinitionsList.get(0);
+        return acceptMediaTypeDefinitionsList.get(0).mediaRange();
     }
 
     public boolean hasAPreferenceFor(final ACCEPT_TYPE type) {
 
-        // if type is found in the array before any other type
-        // then assume this is a preference
-        // TODO: use ;q=0.9 to allow preferences to have a priority but listed in different order
-        for (String acceptedType : acceptMediaTypeDefinitionsList) {
-            ACCEPT_TYPE matchingType = getMatchingType(acceptedType);
-            if (matchingType != ACCEPT_TYPE.NO_MATCHING_TYPE
-                    && matchingType != ACCEPT_TYPE.ANYTHING) {
-                return matchingType == type;
-            }
+        final List<ACCEPT_TYPE> supportedTypes = getSupportedTypesInPreferenceOrder();
+        if (supportedTypes.isEmpty()) {
+            return false;
         }
-        return false;
+
+        return supportedTypes.get(0) == type;
     }
 
     public List<ACCEPT_TYPE> getSupportedTypesInPreferenceOrder() {
-        List<ACCEPT_TYPE> supportedTypes = new ArrayList<>();
-        for (String acceptedType : acceptMediaTypeDefinitionsList) {
-            ACCEPT_TYPE matchingType = getMatchingType(acceptedType);
-            if (matchingType != ACCEPT_TYPE.NO_MATCHING_TYPE) {
-                supportedTypes.add(matchingType);
-            }
-        }
-        return supportedTypes;
+        return getSupportedTypesInPreferenceOrder(ACCEPT_TYPE.responseMediaTypes());
     }
 
-    private ACCEPT_TYPE getMatchingType(final String matchMe) {
-        final String mediaType = mediaTypeFrom(matchMe);
-        for (ACCEPT_TYPE type : ACCEPT_TYPE.values()) {
-            for (String possibleMatch : type.mediaTypes()) {
-                if (mediaType.equals(possibleMatch)) {
-                    return type;
-                }
-            }
+    public ACCEPT_TYPE preferredSupportedType(
+            final List<ACCEPT_TYPE> supportedTypes, final ACCEPT_TYPE defaultType) {
+        final List<ACCEPT_TYPE> concreteSupportedTypes = concreteSupportedTypes(supportedTypes);
+
+        if (concreteSupportedTypes.isEmpty()) {
+            return ACCEPT_TYPE.NO_MATCHING_TYPE;
         }
-        return ACCEPT_TYPE.NO_MATCHING_TYPE;
+
+        if (acceptMediaTypeDefinitionsList.isEmpty()) {
+            return defaultOrFirstSupported(concreteSupportedTypes, defaultType);
+        }
+
+        final List<ACCEPT_TYPE> orderedTypes =
+                getSupportedTypesInPreferenceOrder(concreteSupportedTypes);
+        if (orderedTypes.isEmpty()) {
+            return ACCEPT_TYPE.NO_MATCHING_TYPE;
+        }
+
+        return orderedTypes.get(0);
     }
 
-    private String mediaTypeFrom(final String acceptMediaTypeDefinition) {
-        if (acceptMediaTypeDefinition == null) {
-            return "";
+    private List<ACCEPT_TYPE> getSupportedTypesInPreferenceOrder(
+            final List<ACCEPT_TYPE> candidateTypes) {
+        final List<NegotiatedAcceptType> supportedTypes = new ArrayList<>();
+
+        for (ACCEPT_TYPE type : candidateTypes) {
+            bestMatchFor(type).ifPresent(match -> supportedTypes.add(match.negotiatedType()));
         }
-        return acceptMediaTypeDefinition.split(";", 2)[0].trim();
+
+        supportedTypes.sort(NegotiatedAcceptType.preferenceComparator());
+
+        final List<ACCEPT_TYPE> responseTypes = new ArrayList<>();
+        for (NegotiatedAcceptType supportedType : supportedTypes) {
+            responseTypes.add(supportedType.type());
+        }
+        return responseTypes;
+    }
+
+    private List<ACCEPT_TYPE> concreteSupportedTypes(final List<ACCEPT_TYPE> supportedTypes) {
+        final List<ACCEPT_TYPE> concreteSupportedTypes = new ArrayList<>();
+        if (supportedTypes == null) {
+            return concreteSupportedTypes;
+        }
+        for (ACCEPT_TYPE type : supportedTypes) {
+            if (type != null && type.hasConcreteResponseMediaType()) {
+                concreteSupportedTypes.add(type);
+            }
+        }
+        return concreteSupportedTypes;
+    }
+
+    private ACCEPT_TYPE defaultOrFirstSupported(
+            final List<ACCEPT_TYPE> supportedTypes, final ACCEPT_TYPE defaultType) {
+        if (defaultType != null && supportedTypes.contains(defaultType)) {
+            return defaultType;
+        }
+        return supportedTypes.get(0);
+    }
+
+    private Optional<AcceptedMediaRangeMatch> bestMatchFor(final ACCEPT_TYPE type) {
+        if (type == null || !type.hasConcreteResponseMediaType()) {
+            return Optional.empty();
+        }
+
+        AcceptedMediaRangeMatch bestMatch = null;
+        for (AcceptedMediaRange acceptedType : acceptMediaTypeDefinitionsList) {
+            final Optional<AcceptedMediaRangeMatch> match = acceptedType.match(type);
+            if (match.isEmpty()) {
+                continue;
+            }
+
+            if (bestMatch == null || match.get().isBetterEffectiveMatchThan(bestMatch)) {
+                bestMatch = match.get();
+            }
+        }
+
+        if (bestMatch == null || !bestMatch.isAcceptable()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(bestMatch);
     }
 
     public boolean hasAPreferenceForXml() {
@@ -264,25 +317,293 @@ public class AcceptHeaderParser {
             return true;
         }
 
-        boolean askedFor = hasAskedFor(type);
-        if (askedFor) {
-            return true;
+        if (type == ACCEPT_TYPE.ANYTHING) {
+            return hasAskedFor(ACCEPT_TYPE.ANYTHING);
         }
 
-        // before we say no, check if it has asked for anything
-        return hasAskedFor(ACCEPT_TYPE.ANYTHING);
+        return bestMatchFor(type).isPresent();
     }
 
     public boolean hasAskedFor(final ACCEPT_TYPE type) {
         // look for specific type
-        for (String acceptedType : acceptMediaTypeDefinitionsList) {
-            String mediaType = mediaTypeFrom(acceptedType);
+        for (AcceptedMediaRange acceptedType : acceptMediaTypeDefinitionsList) {
             for (String typeValue : type.mediaTypes()) {
-                if (mediaType.equals(typeValue)) {
+                if (acceptedType.isAcceptable() && acceptedType.mediaRange().equals(typeValue)) {
                     return true;
                 }
             }
         }
         return false;
+    }
+
+    private static List<String> splitOutsideQuotes(final String value, final char separator) {
+        final List<String> parts = new ArrayList<>();
+        final StringBuilder currentPart = new StringBuilder();
+        boolean insideQuotes = false;
+        boolean escaped = false;
+
+        for (int i = 0; i < value.length(); i++) {
+            final char current = value.charAt(i);
+            if (current == '\\' && insideQuotes && !escaped) {
+                escaped = true;
+                currentPart.append(current);
+                continue;
+            }
+            if (current == '"' && !escaped) {
+                insideQuotes = !insideQuotes;
+            }
+            if (current == separator && !insideQuotes) {
+                parts.add(currentPart.toString());
+                currentPart.setLength(0);
+            } else {
+                currentPart.append(current);
+            }
+            escaped = false;
+        }
+
+        parts.add(currentPart.toString());
+        return parts;
+    }
+
+    private static final class AcceptedMediaRange {
+        private static final double DEFAULT_Q_VALUE = 1.0D;
+
+        private final String mediaRange;
+        private final double qValue;
+        private final boolean qValueIsValid;
+        private final int order;
+
+        private AcceptedMediaRange(
+                final String mediaRange,
+                final double qValue,
+                final boolean qValueIsValid,
+                final int order) {
+            this.mediaRange = mediaRange;
+            this.qValue = qValue;
+            this.qValueIsValid = qValueIsValid;
+            this.order = order;
+        }
+
+        static AcceptedMediaRange from(final String acceptDefinition, final int order) {
+            final List<String> acceptParts = splitOutsideQuotes(acceptDefinition, ';');
+            final String mediaRange = acceptParts.get(0).trim();
+            double qValue = DEFAULT_Q_VALUE;
+            boolean qValueIsValid = true;
+
+            for (int i = 1; i < acceptParts.size(); i++) {
+                final String parameter = acceptParts.get(i).trim();
+                final int separator = parameter.indexOf('=');
+                if (separator == -1) {
+                    continue;
+                }
+
+                final String name = parameter.substring(0, separator).trim();
+                final String value = unquote(parameter.substring(separator + 1).trim());
+                if ("q".equals(name)) {
+                    final Optional<Double> parsedQValue = parseQValue(value);
+                    if (parsedQValue.isEmpty()) {
+                        qValueIsValid = false;
+                    } else {
+                        qValue = parsedQValue.get();
+                    }
+                }
+            }
+
+            return new AcceptedMediaRange(mediaRange, qValue, qValueIsValid, order);
+        }
+
+        String mediaRange() {
+            return mediaRange;
+        }
+
+        boolean isAcceptable() {
+            return qValueIsValid && qValue > 0.0D;
+        }
+
+        boolean matchesAnyOf(final List<ACCEPT_TYPE> types) {
+            for (ACCEPT_TYPE type : types) {
+                if (match(type).isPresent()) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        Optional<AcceptedMediaRangeMatch> match(final ACCEPT_TYPE type) {
+            final int specificity = specificityFor(type);
+            if (specificity == AcceptedMediaRangeMatch.NO_MATCH) {
+                return Optional.empty();
+            }
+            return Optional.of(
+                    new AcceptedMediaRangeMatch(type, qValue, qValueIsValid, order, specificity));
+        }
+
+        private int specificityFor(final ACCEPT_TYPE type) {
+            for (String concreteMediaType : type.mediaTypes()) {
+                if (mediaRange.equals(concreteMediaType)) {
+                    return AcceptedMediaRangeMatch.EXACT_MATCH;
+                }
+                if (isStructuredSuffixWildcardMatch(concreteMediaType)) {
+                    return AcceptedMediaRangeMatch.STRUCTURED_SUFFIX_MATCH;
+                }
+                if (isTypeWildcardMatch(concreteMediaType)) {
+                    return AcceptedMediaRangeMatch.TYPE_WILDCARD_MATCH;
+                }
+                if (isAnythingWildcard()) {
+                    return AcceptedMediaRangeMatch.ANYTHING_MATCH;
+                }
+            }
+            return AcceptedMediaRangeMatch.NO_MATCH;
+        }
+
+        private boolean isStructuredSuffixWildcardMatch(final String concreteMediaType) {
+            final String[] rangeParts = mediaRangeParts(mediaRange);
+            final String[] concreteParts = mediaRangeParts(concreteMediaType);
+
+            if (rangeParts.length != 2 || concreteParts.length != 2) {
+                return false;
+            }
+
+            final String rangeType = rangeParts[0];
+            final String rangeSubtype = rangeParts[1];
+            if (!"*".equals(rangeType) && !rangeType.equals(concreteParts[0])) {
+                return false;
+            }
+
+            if (!rangeSubtype.startsWith("*+")) {
+                return false;
+            }
+
+            return concreteParts[1].endsWith(rangeSubtype.substring(1));
+        }
+
+        private boolean isTypeWildcardMatch(final String concreteMediaType) {
+            final String[] rangeParts = mediaRangeParts(mediaRange);
+            final String[] concreteParts = mediaRangeParts(concreteMediaType);
+
+            return rangeParts.length == 2
+                    && concreteParts.length == 2
+                    && rangeParts[0].equals(concreteParts[0])
+                    && "*".equals(rangeParts[1]);
+        }
+
+        private boolean isAnythingWildcard() {
+            return "*/*".equals(mediaRange);
+        }
+
+        private static String[] mediaRangeParts(final String mediaType) {
+            return mediaType.split("/", -1);
+        }
+
+        private static Optional<Double> parseQValue(final String value) {
+            try {
+                final double qValue = Double.parseDouble(value);
+                if (qValue < 0.0D || qValue > 1.0D) {
+                    return Optional.empty();
+                }
+                return Optional.of(qValue);
+            } catch (NumberFormatException e) {
+                return Optional.empty();
+            }
+        }
+
+        private static String unquote(final String value) {
+            if (value.length() >= 2 && value.startsWith("\"") && value.endsWith("\"")) {
+                return value.substring(1, value.length() - 1);
+            }
+            return value;
+        }
+    }
+
+    private static final class AcceptedMediaRangeMatch {
+        static final int NO_MATCH = -1;
+        static final int ANYTHING_MATCH = 0;
+        static final int TYPE_WILDCARD_MATCH = 1;
+        static final int STRUCTURED_SUFFIX_MATCH = 2;
+        static final int EXACT_MATCH = 3;
+
+        private final ACCEPT_TYPE type;
+        private final double qValue;
+        private final boolean qValueIsValid;
+        private final int order;
+        private final int specificity;
+
+        private AcceptedMediaRangeMatch(
+                final ACCEPT_TYPE type,
+                final double qValue,
+                final boolean qValueIsValid,
+                final int order,
+                final int specificity) {
+            this.type = type;
+            this.qValue = qValue;
+            this.qValueIsValid = qValueIsValid;
+            this.order = order;
+            this.specificity = specificity;
+        }
+
+        boolean isAcceptable() {
+            return qValueIsValid && qValue > 0.0D;
+        }
+
+        boolean isBetterEffectiveMatchThan(final AcceptedMediaRangeMatch other) {
+            if (specificity != other.specificity) {
+                return specificity > other.specificity;
+            }
+            if (Double.compare(qValue, other.qValue) != 0) {
+                return qValue > other.qValue;
+            }
+            return order < other.order;
+        }
+
+        NegotiatedAcceptType negotiatedType() {
+            return new NegotiatedAcceptType(type, qValue, order, specificity);
+        }
+    }
+
+    private static final class NegotiatedAcceptType {
+        private final ACCEPT_TYPE type;
+        private final double qValue;
+        private final int order;
+        private final int specificity;
+
+        private NegotiatedAcceptType(
+                final ACCEPT_TYPE type,
+                final double qValue,
+                final int order,
+                final int specificity) {
+            this.type = type;
+            this.qValue = qValue;
+            this.order = order;
+            this.specificity = specificity;
+        }
+
+        ACCEPT_TYPE type() {
+            return type;
+        }
+
+        static Comparator<NegotiatedAcceptType> preferenceComparator() {
+            return Comparator.comparingDouble(NegotiatedAcceptType::qValue)
+                    .reversed()
+                    .thenComparing(
+                            Comparator.comparingInt(NegotiatedAcceptType::specificity).reversed())
+                    .thenComparingInt(NegotiatedAcceptType::order)
+                    .thenComparingInt(NegotiatedAcceptType::serverPreference);
+        }
+
+        private double qValue() {
+            return qValue;
+        }
+
+        private int specificity() {
+            return specificity;
+        }
+
+        private int order() {
+            return order;
+        }
+
+        private int serverPreference() {
+            return ACCEPT_TYPE.responseMediaTypes().indexOf(type);
+        }
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headervalidator/AcceptHeaderValidator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headervalidator/AcceptHeaderValidator.java
@@ -1,5 +1,6 @@
 package uk.co.compendiumdev.thingifier.api.http.headers.headervalidator;
 
+import java.util.ArrayList;
 import java.util.List;
 import uk.co.compendiumdev.thingifier.api.http.headers.headerparser.AcceptHeaderParser;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
@@ -26,7 +27,8 @@ public class AcceptHeaderValidator {
         }
 
         if (apiResponse == null && this.apiConfig.willApiEnforceAcceptHeaderForResponses()) {
-            if (!hasAnyAllowedResponseType(accept)) {
+            if (preferredAllowedResponseType(accept)
+                    == AcceptHeaderParser.ACCEPT_TYPE.NO_MATCHING_TYPE) {
                 apiResponse =
                         ApiResponse.error(
                                 statusAcceptTypeNotSupported,
@@ -37,29 +39,36 @@ public class AcceptHeaderValidator {
         return apiResponse;
     }
 
-    private boolean hasAnyAllowedResponseType(final AcceptHeaderParser accept) {
-        final List<AcceptHeaderParser.ACCEPT_TYPE> supportedTypes =
-                accept.getSupportedTypesInPreferenceOrder();
-        if (supportedTypes.isEmpty()) {
-            return true;
-        }
+    private AcceptHeaderParser.ACCEPT_TYPE preferredAllowedResponseType(
+            final AcceptHeaderParser accept) {
+        return accept.preferredSupportedType(allowedResponseTypes(), defaultResponseType());
+    }
 
-        for (AcceptHeaderParser.ACCEPT_TYPE supportedType : supportedTypes) {
-            if (supportedType == AcceptHeaderParser.ACCEPT_TYPE.ANYTHING) {
-                return true;
-            }
-            if (supportedType == AcceptHeaderParser.ACCEPT_TYPE.XML
+    private List<AcceptHeaderParser.ACCEPT_TYPE> allowedResponseTypes() {
+        final List<AcceptHeaderParser.ACCEPT_TYPE> allowedTypes = new ArrayList<>();
+        for (AcceptHeaderParser.ACCEPT_TYPE type :
+                AcceptHeaderParser.ACCEPT_TYPE.responseMediaTypes()) {
+            if (type == AcceptHeaderParser.ACCEPT_TYPE.XML
                     && !this.apiConfig.willApiAllowXmlForResponses()) {
                 continue;
             }
-            if (supportedType == AcceptHeaderParser.ACCEPT_TYPE.JSON
+            if (type == AcceptHeaderParser.ACCEPT_TYPE.JSON
                     && !this.apiConfig.willApiAllowJsonForResponses()) {
                 continue;
             }
-            return true;
+            allowedTypes.add(type);
         }
+        return allowedTypes;
+    }
 
-        return false;
+    private AcceptHeaderParser.ACCEPT_TYPE defaultResponseType() {
+        if (apiConfig.willApiAllowJsonForResponses()) {
+            return AcceptHeaderParser.ACCEPT_TYPE.JSON;
+        }
+        if (apiConfig.willApiAllowXmlForResponses()) {
+            return AcceptHeaderParser.ACCEPT_TYPE.XML;
+        }
+        return AcceptHeaderParser.ACCEPT_TYPE.NO_MATCHING_TYPE;
     }
 
     private String unsupportedResponseTypeMessage(final AcceptHeaderParser accept) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseError.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseError.java
@@ -1,5 +1,6 @@
 package uk.co.compendiumdev.thingifier.api.response;
 
+import java.util.List;
 import uk.co.compendiumdev.thingifier.api.http.headers.headerparser.AcceptHeaderParser;
 
 public final class ApiResponseError {
@@ -10,11 +11,17 @@ public final class ApiResponseError {
 
         boolean isJson = true; // default to json
 
-        AcceptHeaderParser acceptable = new AcceptHeaderParser(accept);
+        final AcceptHeaderParser acceptable = new AcceptHeaderParser(accept);
+        final AcceptHeaderParser.ACCEPT_TYPE preferredType =
+                acceptable.preferredSupportedType(
+                        List.of(
+                                AcceptHeaderParser.ACCEPT_TYPE.JSON,
+                                AcceptHeaderParser.ACCEPT_TYPE.XML),
+                        AcceptHeaderParser.ACCEPT_TYPE.JSON);
 
         // TODO: should be able to configure a default API response type rather than assume it is
         // JSON
-        if (acceptable.hasAPreferenceForXml()) {
+        if (preferredType == AcceptHeaderParser.ACCEPT_TYPE.XML) {
             isJson = false;
         }
 

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/AcceptHeaderParserTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/AcceptHeaderParserTest.java
@@ -196,9 +196,122 @@ public class AcceptHeaderParserTest {
     }
 
     @Test
-    public void textWildcardIsNotASupportedResponseRepresentation() {
+    public void textWildcardMatchesTextResponseRepresentations() {
         final AcceptHeaderParser accept = new AcceptHeaderParser("text/*");
 
+        Assertions.assertTrue(accept.isSupportedHeader());
+        Assertions.assertEquals(
+                List.of(
+                        AcceptHeaderParser.ACCEPT_TYPE.CSV,
+                        AcceptHeaderParser.ACCEPT_TYPE.TEXT,
+                        AcceptHeaderParser.ACCEPT_TYPE.HTML,
+                        AcceptHeaderParser.ACCEPT_TYPE.TSV),
+                accept.getSupportedTypesInPreferenceOrder());
+        Assertions.assertTrue(accept.willAcceptText());
+        Assertions.assertFalse(accept.willAcceptJson());
+    }
+
+    @Test
+    public void applicationWildcardMatchesApplicationResponseRepresentations() {
+        final AcceptHeaderParser accept = new AcceptHeaderParser("application/*");
+
+        Assertions.assertTrue(accept.isSupportedHeader());
+        Assertions.assertEquals(
+                List.of(
+                        AcceptHeaderParser.ACCEPT_TYPE.JSON,
+                        AcceptHeaderParser.ACCEPT_TYPE.XML,
+                        AcceptHeaderParser.ACCEPT_TYPE.NDJSON,
+                        AcceptHeaderParser.ACCEPT_TYPE.JSONL,
+                        AcceptHeaderParser.ACCEPT_TYPE.JSON_SEQ),
+                accept.getSupportedTypesInPreferenceOrder());
+        Assertions.assertTrue(accept.willAcceptJson());
+        Assertions.assertTrue(accept.willAcceptXml());
+        Assertions.assertFalse(accept.willAcceptCsv());
+    }
+
+    @Test
+    public void qValuesControlPreferenceOrder() {
+        final AcceptHeaderParser accept =
+                new AcceptHeaderParser("application/xml;q=0.2, application/json;q=0.9");
+
+        Assertions.assertEquals(
+                List.of(AcceptHeaderParser.ACCEPT_TYPE.JSON, AcceptHeaderParser.ACCEPT_TYPE.XML),
+                accept.getSupportedTypesInPreferenceOrder());
+        Assertions.assertTrue(accept.hasAPreferenceForJson());
+        Assertions.assertFalse(accept.hasAPreferenceForXml());
+    }
+
+    @Test
+    public void qZeroExcludesMediaTypeFromNegotiation() {
+        final AcceptHeaderParser accept =
+                new AcceptHeaderParser("application/json;q=0, application/xml");
+
+        Assertions.assertTrue(accept.isSupportedHeader());
+        Assertions.assertFalse(accept.willAcceptJson());
+        Assertions.assertTrue(accept.willAcceptXml());
+        Assertions.assertEquals(
+                List.of(AcceptHeaderParser.ACCEPT_TYPE.XML),
+                accept.getSupportedTypesInPreferenceOrder());
+    }
+
+    @Test
+    public void qZeroExactMatchOverridesWildcardForThatMediaType() {
+        final AcceptHeaderParser accept = new AcceptHeaderParser("application/json;q=0, */*");
+
+        Assertions.assertFalse(accept.willAcceptJson());
+        Assertions.assertTrue(accept.willAcceptXml());
+        Assertions.assertEquals(
+                AcceptHeaderParser.ACCEPT_TYPE.XML,
+                accept.getSupportedTypesInPreferenceOrder().get(0));
+    }
+
+    @Test
+    public void unsupportedMediaTypesAreIgnoredWhenSupportedAlternativeExists() {
+        final AcceptHeaderParser accept =
+                new AcceptHeaderParser("application/problem+json, application/json;q=0.5");
+
+        Assertions.assertEquals(
+                List.of(AcceptHeaderParser.ACCEPT_TYPE.JSON),
+                accept.getSupportedTypesInPreferenceOrder());
+        Assertions.assertTrue(accept.willAcceptJson());
+    }
+
+    @Test
+    public void concreteStructuredJsonTypesDoNotMatchPlainJson() {
+        Assertions.assertFalse(new AcceptHeaderParser("application/problem+json").willAcceptJson());
+        Assertions.assertFalse(new AcceptHeaderParser("application/vnd.api+json").willAcceptJson());
+        Assertions.assertFalse(new AcceptHeaderParser("application/hal+json").willAcceptJson());
+    }
+
+    @Test
+    public void structuredJsonWildcardDoesNotMatchPlainJson() {
+        final AcceptHeaderParser accept = new AcceptHeaderParser("application/*+json");
+
         Assertions.assertFalse(accept.isSupportedHeader());
+        Assertions.assertFalse(accept.willAcceptJson());
+        Assertions.assertTrue(accept.getSupportedTypesInPreferenceOrder().isEmpty());
+    }
+
+    @Test
+    public void parametersDoNotPreventQValueProcessing() {
+        final AcceptHeaderParser accept =
+                new AcceptHeaderParser(
+                        "application/json; charset=utf-8; q=0.3, "
+                                + "application/xml; version=1; q=0.8");
+
+        Assertions.assertEquals(
+                List.of(AcceptHeaderParser.ACCEPT_TYPE.XML, AcceptHeaderParser.ACCEPT_TYPE.JSON),
+                accept.getSupportedTypesInPreferenceOrder());
+    }
+
+    @Test
+    public void invalidQValuesMakeMediaRangesUnacceptable() {
+        final AcceptHeaderParser accept =
+                new AcceptHeaderParser("application/json;q=nope, application/xml;q=1.1");
+
+        Assertions.assertTrue(accept.isSupportedHeader());
+        Assertions.assertFalse(accept.willAcceptJson());
+        Assertions.assertFalse(accept.willAcceptXml());
+        Assertions.assertTrue(accept.getSupportedTypesInPreferenceOrder().isEmpty());
     }
 }

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/headers/headervalidator/AcceptHeaderValidatorTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/headers/headervalidator/AcceptHeaderValidatorTest.java
@@ -19,13 +19,15 @@ class AcceptHeaderValidatorTest {
         Assertions.assertNull(validator.validate("application/jsonl"));
         Assertions.assertNull(validator.validate("application/json-seq"));
         Assertions.assertNull(validator.validate("text/tab-separated-values"));
+        Assertions.assertNull(validator.validate("text/*"));
     }
 
     @Test
     void rejectsUnsupportedHeaderWhenEnforced() {
         ThingifierApiConfig config = new ThingifierApiConfig("");
 
-        ApiResponse response = new AcceptHeaderValidator(config).validate("text/*");
+        ApiResponse response =
+                new AcceptHeaderValidator(config).validate("application/problem+json");
 
         Assertions.assertEquals(406, response.getStatusCode());
         Assertions.assertTrue(response.getErrorMessages().contains("Unrecognised Accept Type"));
@@ -38,6 +40,59 @@ class AcceptHeaderValidatorTest {
 
         ApiResponse response =
                 new AcceptHeaderValidator(config).validate("application/xml, text/csv");
+
+        Assertions.assertNull(response);
+    }
+
+    @Test
+    void unsupportedMediaTypesAreIgnoredWhenSupportedAlternativeExists() {
+        ThingifierApiConfig config = new ThingifierApiConfig("");
+
+        ApiResponse response =
+                new AcceptHeaderValidator(config)
+                        .validate("application/problem+json, application/json;q=0.5");
+
+        Assertions.assertNull(response);
+    }
+
+    @Test
+    void rejectsStructuredJsonWildcardUntilConcreteRepresentationExists() {
+        ThingifierApiConfig config = new ThingifierApiConfig("");
+
+        ApiResponse response = new AcceptHeaderValidator(config).validate("application/*+json");
+
+        Assertions.assertEquals(406, response.getStatusCode());
+        Assertions.assertTrue(response.getErrorMessages().contains("Unrecognised Accept Type"));
+    }
+
+    @Test
+    void qZeroCanFallThroughToSupportedAlternative() {
+        ThingifierApiConfig config = new ThingifierApiConfig("");
+
+        ApiResponse response =
+                new AcceptHeaderValidator(config).validate("application/json;q=0, application/xml");
+
+        Assertions.assertNull(response);
+    }
+
+    @Test
+    void qZeroWithoutAlternativeIsNotAcceptable() {
+        ThingifierApiConfig config = new ThingifierApiConfig("");
+
+        ApiResponse response = new AcceptHeaderValidator(config).validate("application/json;q=0");
+
+        Assertions.assertEquals(406, response.getStatusCode());
+        Assertions.assertTrue(
+                response.getErrorMessages().contains("No acceptable response type supported"));
+    }
+
+    @Test
+    void qValuesChooseAllowedAlternativeEvenWhenItIsLowerInHeaderOrder() {
+        ThingifierApiConfig config = new ThingifierApiConfig("");
+
+        ApiResponse response =
+                new AcceptHeaderValidator(config)
+                        .validate("application/xml;q=0.1, application/json;q=0.9");
 
         Assertions.assertNull(response);
     }

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/requests/ThingifierHttpApiAdditionalRepresentationsTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/requests/ThingifierHttpApiAdditionalRepresentationsTest.java
@@ -35,6 +35,38 @@ class ThingifierHttpApiAdditionalRepresentationsTest {
     }
 
     @Test
+    void getNegotiatesAcceptHeaderQualityValuesWildcardsAndStructuredJsonTypes() {
+        Thingifier thingifier = taskThingifier();
+        createTask(thingifier, "Task");
+        ThingifierHttpApi api = new ThingifierHttpApi(thingifier);
+
+        assertNegotiatedGet(api, null, 200, "application/json", "\"tasks\"");
+        assertNegotiatedGet(api, "*/*", 200, "application/json", "\"tasks\"");
+        assertNegotiatedGet(api, "application/*", 200, "application/json", "\"tasks\"");
+        assertNegotiatedGet(api, "text/*", 200, "text/csv", "id,title");
+        assertNegotiatedGet(api, "application/json", 200, "application/json", "\"tasks\"");
+        assertNegotiatedGet(api, "application/xml", 200, "application/xml", "<tasks>");
+        assertNegotiatedGet(
+                api,
+                "application/json, application/problem+json",
+                200,
+                "application/json",
+                "\"tasks\"");
+        assertNegotiatedGet(
+                api,
+                "application/problem+json, application/json;q=0.5",
+                200,
+                "application/json",
+                "\"tasks\"");
+        assertNegotiatedGet(
+                api, "application/json;q=0, application/xml", 200, "application/xml", "<tasks>");
+        assertNegotiatedGet(
+                api, "application/problem+json", 406, "application/json", "errorMessages");
+        assertNegotiatedGet(api, "application/*+json", 406, "application/json", "errorMessages");
+        assertNegotiatedGet(api, "application/json;q=0", 406, "application/json", "errorMessages");
+    }
+
+    @Test
     void querySelectsAdditionalResponseRepresentationsFromAcceptHeader() {
         Thingifier thingifier = taskThingifier();
         createTask(thingifier, "Task");
@@ -109,6 +141,24 @@ class ThingifierHttpApiAdditionalRepresentationsTest {
         expectedBodies.put("application/json-seq", "\u001E{\"id\":1,\"title\":\"Task\"}\n");
         expectedBodies.put("text/tab-separated-values", "id\ttitle\n1\tTask");
         return expectedBodies;
+    }
+
+    private void assertNegotiatedGet(
+            final ThingifierHttpApi api,
+            final String acceptHeader,
+            final int statusCode,
+            final String contentType,
+            final String bodyFragment) {
+        HttpApiRequest request = new HttpApiRequest("tasks");
+        if (acceptHeader != null) {
+            request.addHeader("Accept", acceptHeader);
+        }
+
+        HttpApiResponse response = api.get(request);
+
+        Assertions.assertEquals(statusCode, response.getStatusCode(), acceptHeader);
+        Assertions.assertEquals(contentType, response.getType(), acceptHeader);
+        Assertions.assertTrue(response.getBody().contains(bodyFragment), response.getBody());
     }
 
     private Thingifier taskThingifier() {

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseTest.java
@@ -44,6 +44,20 @@ public class ApiResponseTest {
     }
 
     @Test
+    public void errorFormatterUsesAcceptQualityValuesForJsonAndXml() {
+        Assertions.assertTrue(
+                ApiResponseError.asAppropriate("application/json;q=0, application/xml", "oopsy")
+                        .startsWith("<"));
+        Assertions.assertTrue(
+                ApiResponseError.asAppropriate(
+                                "application/xml;q=0.1, application/json;q=0.9", "oopsy")
+                        .startsWith("{"));
+        Assertions.assertTrue(
+                ApiResponseError.asAppropriate("application/problem+json", "oopsy")
+                        .startsWith("{"));
+    }
+
+    @Test
     public void responseErrors() {
 
         List<String> errors = new ArrayList();

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandlerTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandlerTest.java
@@ -521,7 +521,7 @@ public class RestApiQueryHandlerTest {
         Thingifier thingifier = todoThingifier();
         HttpApiRequest request =
                 structuredJsonQuery("todos", "{\"filter\":{\"doneStatus\":false}}")
-                        .addHeader("Accept", "text/*");
+                        .addHeader("Accept", "application/problem+json");
 
         HttpApiResponse response = new ThingifierHttpApi(thingifier).queryRequest(request);
 


### PR DESCRIPTION
## Summary
- Implement q-aware Accept header negotiation across validation and response rendering.
- Preserve JSON defaults for missing Accept and */*, while returning 406 for unsupported negotiated representations.
- Keep structured suffix ranges such as application/*+json from matching plain application/json unless a concrete writer is added.

## Verification
- `mvn -pl thingifier -am '-Dtest=AcceptHeaderParserTest,AcceptHeaderValidatorTest,ThingifierHttpApiAdditionalRepresentationsTest,HttpApiResponseToInternalHttpResponseTest' -DfailIfNoTests=false test`
- `mvn -pl thingifier -am test`
- Commit hook full Maven verification completed successfully.

Closes #102