### PR TITLE
Implement XML-compatible media types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+## Test Design Rules
+
+When adding or changing tests, write tests around domain rules and meaningful data
+combinations, not around code coverage.
+
+A test method should cover one behavior or decision rule. Multiple assertions are
+fine when they verify different outcomes of the same behavior, but do not combine
+multiple independent conditions, scenarios, or rules into one test method.
+
+Prefer splitting tests when:
+- the test name needs "and" to describe what it verifies
+- different inputs exercise different domain rules
+- one failure would make it unclear which scenario broke
+- a helper method hides a list of separate scenarios inside one test
+- setup has to be repeated or reset inside a loop
+
+Use parameterized/data-driven tests when:
+- the same rule is being checked against multiple equivalent examples
+- the setup and expected outcome shape are the same for each row
+- the data table makes the domain combinations easier to see
+
+Do not use one broad test plus a helper containing many assertions to cover a
+scenario matrix. Either expose the matrix as a parameterized test or split the
+scenarios into named tests.
+
+For content negotiation tests, separate these rules unless a single test is
+explicitly proving their interaction:
+- exact media type selection
+- wildcard fallback
+- structured suffix matching
+- q-value priority
+- q=0 exclusion
+- unsupported media type fallback
+- specificity tie-breaking
+- client order tie-breaking
+- final HTTP status/content-type/body assertions
+
+Before finishing, review every amended test class and split any test that combines
+separable conditions.

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/RoutingDefinition.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/RoutingDefinition.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import uk.co.compendiumdev.thingifier.api.http.headers.headerparser.ContentTypeHeaderParser;
 import uk.co.compendiumdev.thingifier.api.response.ResponseHeader;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.Field;
@@ -213,7 +214,10 @@ public class RoutingDefinition {
 
     public List<String> getRequestContentTypes() {
         if (requestContentTypes.isEmpty()) {
-            return List.of("application/json", "application/xml");
+            return List.of(
+                    "application/json",
+                    ContentTypeHeaderParser.APPLICATION_XML,
+                    ContentTypeHeaderParser.TEXT_XML);
         }
         return new ArrayList<>(requestContentTypes);
     }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/HttpApiRequestValidator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/HttpApiRequestValidator.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.jayway.jsonpath.InvalidPathException;
 import com.jayway.jsonpath.JsonPath;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.BodyParser;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.JsonBodyValueConverter;
 import uk.co.compendiumdev.thingifier.api.http.headers.headerparser.ContentTypeHeaderParser;
@@ -17,11 +19,18 @@ public class HttpApiRequestValidator {
     private static final String MALFORMED_STRUCTURED_QUERY_JSON = "Malformed JSON query body";
 
     private final ThingifierApiConfig apiConfig;
+    private final Collection<String> xmlEntityNames;
     Boolean isValid;
     private ApiResponse errorResponse;
 
     public HttpApiRequestValidator(final ThingifierApiConfig apiConfig) {
+        this(apiConfig, List.of());
+    }
+
+    public HttpApiRequestValidator(
+            final ThingifierApiConfig apiConfig, final Collection<String> xmlEntityNames) {
         this.apiConfig = apiConfig;
+        this.xmlEntityNames = xmlEntityNames == null ? List.of() : List.copyOf(xmlEntityNames);
     }
 
     public boolean validateSyntax(
@@ -29,7 +38,8 @@ public class HttpApiRequestValidator {
         // Config Validation
 
         ApiResponse apiResponse =
-                new AcceptHeaderValidator(this.apiConfig).validate(request.getAcceptHeader());
+                new AcceptHeaderValidator(this.apiConfig, xmlEntityNames)
+                        .validate(request.getAcceptHeader());
         ;
 
         if (apiResponse == null) {
@@ -66,7 +76,7 @@ public class HttpApiRequestValidator {
                 if (apiResponse == null
                         && (verb == ThingifierHttpApi.HttpVerb.POST
                                 || verb == ThingifierHttpApi.HttpVerb.PUT)) {
-                    BodyParser parser = new BodyParser(request, new ArrayList<>());
+                    BodyParser parser = new BodyParser(request, new ArrayList<>(xmlEntityNames));
                     String parsingError = "";
                     if (!apiConfig.willAllowJsonAsDefaultContentType()) {
                         parsingError = parser.validBodyBasedOnContentType();
@@ -93,7 +103,7 @@ public class HttpApiRequestValidator {
             return null;
         }
 
-        return new ContentTypeHeaderValidator(this.apiConfig)
+        return new ContentTypeHeaderValidator(this.apiConfig, xmlEntityNames)
                 .validate(request.getContentTypeHeader());
     }
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/HttpApiResponse.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/HttpApiResponse.java
@@ -1,6 +1,7 @@
 package uk.co.compendiumdev.thingifier.api.http;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import uk.co.compendiumdev.thingifier.api.ermodelconversion.JsonThing;
 import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
@@ -24,6 +25,7 @@ public final class HttpApiResponse {
     private final HttpHeadersBlock apiResponseHeaders;
     private final JsonThing jsonThing;
     private final ThingifierApiConfig apiConfig;
+    private final Collection<String> xmlEntityNames;
 
     private String type;
     private AcceptHeaderParser.ACCEPT_TYPE responseType;
@@ -33,10 +35,20 @@ public final class HttpApiResponse {
             final ApiResponse anApiResponse,
             JsonThing jsonThing,
             ThingifierApiConfig apiConfig) {
+        this(requestHeaders, anApiResponse, jsonThing, apiConfig, List.of());
+    }
+
+    public HttpApiResponse(
+            final HttpHeadersBlock requestHeaders,
+            final ApiResponse anApiResponse,
+            JsonThing jsonThing,
+            ThingifierApiConfig apiConfig,
+            final Collection<String> xmlEntityNames) {
         this.apiResponse = anApiResponse;
         this.apiResponseHeaders = new HttpHeadersBlock();
         this.jsonThing = jsonThing;
         this.apiConfig = apiConfig;
+        this.xmlEntityNames = xmlEntityNames == null ? List.of() : List.copyOf(xmlEntityNames);
         responseType = AcceptHeaderParser.ACCEPT_TYPE.JSON;
 
         HttpHeadersBlock useRequestHeaders =
@@ -55,11 +67,16 @@ public final class HttpApiResponse {
 
         AcceptHeaderParser accept = new AcceptHeaderParser(acceptHeader);
 
-        responseType = accept.preferredSupportedType(allowedResponseTypes(), defaultResponseType());
+        final AcceptHeaderParser.PreferredMediaType preferredMediaType =
+                accept.preferredSupportedMediaType(
+                        allowedResponseTypes(), defaultResponseType(), effectiveXmlEntityNames());
+        responseType = preferredMediaType.type();
         if (responseType == AcceptHeaderParser.ACCEPT_TYPE.NO_MATCHING_TYPE) {
             responseType = defaultResponseType();
+            type = responseType.mediaType();
+        } else {
+            type = preferredMediaType.mediaType();
         }
-        type = responseType.mediaType();
 
         apiResponseHeaders.putAll(originalApiResponseHeaders);
         apiResponseHeaders.put("Content-Type", type);
@@ -73,7 +90,7 @@ public final class HttpApiResponse {
         final List<AcceptHeaderParser.ACCEPT_TYPE> allowedTypes = new ArrayList<>();
         for (AcceptHeaderParser.ACCEPT_TYPE type :
                 AcceptHeaderParser.ACCEPT_TYPE.responseMediaTypes()) {
-            if (type == AcceptHeaderParser.ACCEPT_TYPE.XML
+            if (type.rendersAsXml()
                     && !this.apiConfig.willApiAllowXmlForResponses()) {
                 continue;
             }
@@ -84,6 +101,18 @@ public final class HttpApiResponse {
             allowedTypes.add(type);
         }
         return allowedTypes;
+    }
+
+    private Collection<String> effectiveXmlEntityNames() {
+        if (!xmlEntityNames.isEmpty() || apiResponse == null || apiResponse.isErrorResponse()) {
+            return xmlEntityNames;
+        }
+        if (apiResponse.getTypeOfThingReturned() == null) {
+            return xmlEntityNames;
+        }
+        return List.of(
+                apiResponse.getTypeOfThingReturned().getName(),
+                apiResponse.getTypeOfThingReturned().getPlural());
     }
 
     private AcceptHeaderParser.ACCEPT_TYPE defaultResponseType() {
@@ -101,9 +130,11 @@ public final class HttpApiResponse {
             return apiResponse.getBody();
         }
 
+        if (responseType.rendersAsXml()) {
+            return new ApiResponseAsXml(apiResponse, jsonThing).getXml();
+        }
+
         switch (responseType) {
-            case XML:
-                return new ApiResponseAsXml(apiResponse, jsonThing).getXml();
             case CSV:
                 return new ApiResponseAsDelimitedText(apiResponse, ',').getText();
             case TEXT:

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/HttpApiResponse.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/HttpApiResponse.java
@@ -90,8 +90,7 @@ public final class HttpApiResponse {
         final List<AcceptHeaderParser.ACCEPT_TYPE> allowedTypes = new ArrayList<>();
         for (AcceptHeaderParser.ACCEPT_TYPE type :
                 AcceptHeaderParser.ACCEPT_TYPE.responseMediaTypes()) {
-            if (type.rendersAsXml()
-                    && !this.apiConfig.willApiAllowXmlForResponses()) {
+            if (type.rendersAsXml() && !this.apiConfig.willApiAllowXmlForResponses()) {
                 continue;
             }
             if (type == AcceptHeaderParser.ACCEPT_TYPE.JSON

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
@@ -14,6 +14,7 @@ import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierSchemaC
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.CollectionRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.InstanceRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.RelationshipCollectionRoute;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.RelationshipInstanceRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRouteMapper;
 import uk.co.compendiumdev.thingifier.adapter.http.messagehooks.HttpApiRequestHook;
@@ -131,7 +132,11 @@ public final class ThingifierHttpApi {
 
             httpResponse =
                     new HttpApiResponse(
-                            request.getHeaders(), apiResponse, jsonThing, thingifier.apiConfig());
+                            request.getHeaders(),
+                            apiResponse,
+                            jsonThing,
+                            thingifier.apiConfig(),
+                            xmlEntityNamesFor(request.getPath()));
 
             if (effectiveVerb == HttpVerb.HEAD) {
                 final int bodyLength =
@@ -143,7 +148,8 @@ public final class ThingifierHttpApi {
                                 request.getHeaders(),
                                 apiResponse,
                                 jsonThing,
-                                thingifier.apiConfig());
+                                thingifier.apiConfig(),
+                                xmlEntityNamesFor(request.getPath()));
             }
         }
 
@@ -174,7 +180,8 @@ public final class ThingifierHttpApi {
                 request.getHeaders(),
                 ApiResponse.error404("Could not find any instances with " + request.getPath()),
                 jsonThing,
-                thingifier.apiConfig());
+                thingifier.apiConfig(),
+                xmlEntityNamesFor(request.getPath()));
     }
 
     /** return an error response if the request is invalid, null if valid */
@@ -182,7 +189,8 @@ public final class ThingifierHttpApi {
             final HttpApiRequest request, final HttpVerb verb) {
 
         final HttpApiRequestValidator requestValidator =
-                new HttpApiRequestValidator(thingifier.apiConfig());
+                new HttpApiRequestValidator(
+                        thingifier.apiConfig(), xmlEntityNamesFor(request.getPath()));
 
         HttpApiResponse httpResponse = null;
 
@@ -193,7 +201,8 @@ public final class ThingifierHttpApi {
                             request.getHeaders(),
                             requestValidator.getErrorApiResponse(),
                             jsonThing,
-                            thingifier.apiConfig());
+                            thingifier.apiConfig(),
+                            xmlEntityNamesFor(request.getPath()));
         }
 
         return httpResponse;
@@ -203,7 +212,7 @@ public final class ThingifierHttpApi {
 
         ApiResponse apiResponse = null;
         ApiRequestEnvelope envelope =
-                ApiRequestEnvelope.from(request, verb, thingifier.getThingNames());
+                ApiRequestEnvelope.from(request, verb, xmlEntityNamesFor(request.getPath()));
 
         switch (verb) {
             case GET:
@@ -261,7 +270,8 @@ public final class ThingifierHttpApi {
                                     "Entity view %s is not defined for %s",
                                     viewName, entity.getName())),
                     jsonThing,
-                    thingifier.apiConfig());
+                    thingifier.apiConfig(),
+                    xmlEntityNamesFor(request.getPath()));
         }
 
         final EntityViewDefinition view = entity.getViewNamed(viewName);
@@ -284,7 +294,8 @@ public final class ThingifierHttpApi {
                                 "Fields are not allowed by %s: %s",
                                 viewName, String.join(", ", disallowedFields))),
                 jsonThing,
-                thingifier.apiConfig());
+                thingifier.apiConfig(),
+                xmlEntityNamesFor(request.getPath()));
     }
 
     private List<ApiBodyField> entityViewInputFields(
@@ -293,7 +304,7 @@ public final class ThingifierHttpApi {
             return patchInputFields(request, entity);
         }
 
-        return ApiRequestEnvelope.from(request, verb, thingifier.getThingNames())
+        return ApiRequestEnvelope.from(request, verb, xmlEntityNamesFor(request.getPath()))
                 .bodyFields()
                 .topLevelFields();
     }
@@ -515,7 +526,23 @@ public final class ThingifierHttpApi {
                 }
             }
         }
+        if (route instanceof RelationshipInstanceRoute) {
+            final RelationshipInstanceRoute relationship = (RelationshipInstanceRoute) route;
+            for (RelationshipSpec spec : relationship.parentEntity().relationships()) {
+                if (spec.name().equals(relationship.relationshipName())) {
+                    return schema.definitionWithSingularOrPluralNamed(spec.toEntityName());
+                }
+            }
+        }
         return null;
+    }
+
+    private List<String> xmlEntityNamesFor(final String path) {
+        final EntityDefinition entity = targetEntityFor(path);
+        if (entity == null) {
+            return List.of();
+        }
+        return List.of(entity.getName(), entity.getPlural());
     }
 
     public HttpApiResponse get(final HttpApiRequest request) {
@@ -557,7 +584,11 @@ public final class ThingifierHttpApi {
                             .get(query, request.getFilterableQueryParams(), request.getHeaders());
             httpResponse =
                     new HttpApiResponse(
-                            request.getHeaders(), apiResponse, jsonThing, thingifier.apiConfig());
+                            request.getHeaders(),
+                            apiResponse,
+                            jsonThing,
+                            thingifier.apiConfig(),
+                            xmlEntityNamesFor(request.getPath()));
         }
 
         return runTheHttpApiResponseHooksOn(request, httpResponse);

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/bodyparser/BodyParser.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/bodyparser/BodyParser.java
@@ -75,7 +75,7 @@ public class BodyParser {
     public String validBodyBasedOnContentType() {
         final ContentTypeHeaderParser contentTypeParser =
                 new ContentTypeHeaderParser(request.getHeader("content-type"));
-        if (contentTypeParser.isXML()) {
+        if (contentTypeParser.isXML(thingNames)) {
             String validateResultsErrorReport = this.xmlParser.validateXML();
             if (!validateResultsErrorReport.isEmpty()) {
                 return "Invalid XML Payload: " + validateResultsErrorReport;
@@ -122,7 +122,7 @@ public class BodyParser {
         // the same
         final ContentTypeHeaderParser contentTypeParser =
                 new ContentTypeHeaderParser(request.getHeader("content-type"));
-        if (contentTypeParser.isXML()) {
+        if (contentTypeParser.isXML(thingNames)) {
             System.out.println(request.getBody());
             args = this.xmlParser.xmlAsMap();
         } else {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/AcceptHeaderParser.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/AcceptHeaderParser.java
@@ -169,17 +169,7 @@ public class AcceptHeaderParser {
         }
 
         public static List<ACCEPT_TYPE> responseMediaTypes() {
-            return List.of(
-                    JSON,
-                    XML,
-                    CSV,
-                    TEXT,
-                    HTML,
-                    NDJSON,
-                    JSONL,
-                    JSON_SEQ,
-                    TSV,
-                    TEXT_XML);
+            return List.of(JSON, XML, CSV, TEXT, HTML, NDJSON, JSONL, JSON_SEQ, TSV, TEXT_XML);
         }
     };
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/AcceptHeaderParser.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/AcceptHeaderParser.java
@@ -1,9 +1,12 @@
 package uk.co.compendiumdev.thingifier.api.http.headers.headerparser;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public class AcceptHeaderParser {
     private final String acceptHeader;
@@ -14,7 +17,12 @@ public class AcceptHeaderParser {
     }
 
     public boolean willAcceptXml() {
-        return willAccept(ACCEPT_TYPE.XML);
+        for (ACCEPT_TYPE type : ACCEPT_TYPE.xmlResponseMediaTypes()) {
+            if (willAccept(type)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public boolean willAcceptJson() {
@@ -50,7 +58,7 @@ public class AcceptHeaderParser {
     }
 
     public boolean hasAskedForXML() {
-        return hasAskedFor(AcceptHeaderParser.ACCEPT_TYPE.XML);
+        return hasAskedForXmlResponse();
     }
 
     public boolean hasAskedForJSON() {
@@ -94,13 +102,19 @@ public class AcceptHeaderParser {
     }
 
     public boolean isSupportedHeader() {
+        return isSupportedHeader(List.of());
+    }
+
+    public boolean isSupportedHeader(final Collection<String> xmlEntityNames) {
         if (acceptMediaTypeDefinitionsList.size() == 0) {
             // we are allowed blank or missing accept - that counts as default
             return true;
         }
 
+        final List<String> structuredXmlMediaTypes = structuredXmlMediaTypesFor(xmlEntityNames);
         for (AcceptedMediaRange askedFor : acceptMediaTypeDefinitionsList) {
-            if (askedFor.matchesAnyOf(ACCEPT_TYPE.responseMediaTypes())) {
+            if (askedFor.matchesAnyOf(ACCEPT_TYPE.responseMediaTypes())
+                    || askedFor.matchesAnyOf(structuredXmlMediaTypes)) {
                 return true;
             }
         }
@@ -109,6 +123,7 @@ public class AcceptHeaderParser {
 
     public enum ACCEPT_TYPE {
         XML("application/xml"),
+        TEXT_XML("text/xml"),
         JSON("application/json"),
         CSV("text/csv"),
         TEXT("text/plain"),
@@ -141,12 +156,30 @@ public class AcceptHeaderParser {
             return this != ANYTHING && this != NO_MATCHING_TYPE;
         }
 
+        public boolean rendersAsXml() {
+            return this == XML || this == TEXT_XML;
+        }
+
         public boolean usesComponentSchemaInDocumentation() {
-            return this == JSON || this == XML;
+            return this == JSON || rendersAsXml();
+        }
+
+        public static List<ACCEPT_TYPE> xmlResponseMediaTypes() {
+            return List.of(XML, TEXT_XML);
         }
 
         public static List<ACCEPT_TYPE> responseMediaTypes() {
-            return List.of(JSON, XML, CSV, TEXT, HTML, NDJSON, JSONL, JSON_SEQ, TSV);
+            return List.of(
+                    JSON,
+                    XML,
+                    CSV,
+                    TEXT,
+                    HTML,
+                    NDJSON,
+                    JSONL,
+                    JSON_SEQ,
+                    TSV,
+                    TEXT_XML);
         }
     };
 
@@ -193,40 +226,62 @@ public class AcceptHeaderParser {
 
     public ACCEPT_TYPE preferredSupportedType(
             final List<ACCEPT_TYPE> supportedTypes, final ACCEPT_TYPE defaultType) {
+        return preferredSupportedMediaType(supportedTypes, defaultType, List.of()).type();
+    }
+
+    public PreferredMediaType preferredSupportedMediaType(
+            final List<ACCEPT_TYPE> supportedTypes,
+            final ACCEPT_TYPE defaultType,
+            final Collection<String> xmlEntityNames) {
         final List<ACCEPT_TYPE> concreteSupportedTypes = concreteSupportedTypes(supportedTypes);
 
         if (concreteSupportedTypes.isEmpty()) {
-            return ACCEPT_TYPE.NO_MATCHING_TYPE;
+            return PreferredMediaType.noMatch();
         }
 
         if (acceptMediaTypeDefinitionsList.isEmpty()) {
-            return defaultOrFirstSupported(concreteSupportedTypes, defaultType);
+            return PreferredMediaType.forType(
+                    defaultOrFirstSupported(concreteSupportedTypes, defaultType));
         }
 
-        final List<ACCEPT_TYPE> orderedTypes =
-                getSupportedTypesInPreferenceOrder(concreteSupportedTypes);
+        final List<NegotiatedAcceptType> orderedTypes =
+                getNegotiatedTypesInPreferenceOrder(
+                        concreteSupportedTypes, structuredXmlMediaTypesFor(xmlEntityNames));
         if (orderedTypes.isEmpty()) {
-            return ACCEPT_TYPE.NO_MATCHING_TYPE;
+            return PreferredMediaType.noMatch();
         }
 
-        return orderedTypes.get(0);
+        return orderedTypes.get(0).preferredMediaType();
     }
 
     private List<ACCEPT_TYPE> getSupportedTypesInPreferenceOrder(
             final List<ACCEPT_TYPE> candidateTypes) {
-        final List<NegotiatedAcceptType> supportedTypes = new ArrayList<>();
-
-        for (ACCEPT_TYPE type : candidateTypes) {
-            bestMatchFor(type).ifPresent(match -> supportedTypes.add(match.negotiatedType()));
-        }
-
-        supportedTypes.sort(NegotiatedAcceptType.preferenceComparator());
+        final List<NegotiatedAcceptType> supportedTypes =
+                getNegotiatedTypesInPreferenceOrder(candidateTypes, List.of());
 
         final List<ACCEPT_TYPE> responseTypes = new ArrayList<>();
         for (NegotiatedAcceptType supportedType : supportedTypes) {
             responseTypes.add(supportedType.type());
         }
         return responseTypes;
+    }
+
+    private List<NegotiatedAcceptType> getNegotiatedTypesInPreferenceOrder(
+            final List<ACCEPT_TYPE> candidateTypes, final List<String> structuredXmlMediaTypes) {
+        final List<NegotiatedAcceptType> supportedTypes = new ArrayList<>();
+
+        for (ACCEPT_TYPE type : candidateTypes) {
+            bestMatchFor(type).ifPresent(match -> supportedTypes.add(match.negotiatedType()));
+        }
+        if (candidateTypes.contains(ACCEPT_TYPE.XML)) {
+            for (String mediaType : structuredXmlMediaTypes) {
+                bestMatchFor(ACCEPT_TYPE.XML, mediaType)
+                        .ifPresent(match -> supportedTypes.add(match.negotiatedType()));
+            }
+        }
+
+        supportedTypes.sort(NegotiatedAcceptType.preferenceComparator());
+        return supportedTypes;
     }
 
     private List<ACCEPT_TYPE> concreteSupportedTypes(final List<ACCEPT_TYPE> supportedTypes) {
@@ -251,13 +306,18 @@ public class AcceptHeaderParser {
     }
 
     private Optional<AcceptedMediaRangeMatch> bestMatchFor(final ACCEPT_TYPE type) {
+        return bestMatchFor(type, type == null ? "" : type.mediaType());
+    }
+
+    private Optional<AcceptedMediaRangeMatch> bestMatchFor(
+            final ACCEPT_TYPE type, final String mediaType) {
         if (type == null || !type.hasConcreteResponseMediaType()) {
             return Optional.empty();
         }
 
         AcceptedMediaRangeMatch bestMatch = null;
         for (AcceptedMediaRange acceptedType : acceptMediaTypeDefinitionsList) {
-            final Optional<AcceptedMediaRangeMatch> match = acceptedType.match(type);
+            final Optional<AcceptedMediaRangeMatch> match = acceptedType.match(type, mediaType);
             if (match.isEmpty()) {
                 continue;
             }
@@ -275,7 +335,8 @@ public class AcceptHeaderParser {
     }
 
     public boolean hasAPreferenceForXml() {
-        return hasAPreferenceFor(ACCEPT_TYPE.XML);
+        final List<ACCEPT_TYPE> supportedTypes = getSupportedTypesInPreferenceOrder();
+        return !supportedTypes.isEmpty() && supportedTypes.get(0).rendersAsXml();
     }
 
     public boolean hasAPreferenceForJson() {
@@ -334,6 +395,39 @@ public class AcceptHeaderParser {
             }
         }
         return false;
+    }
+
+    public boolean hasAskedForXmlResponse() {
+        return hasAskedForXmlResponse(List.of());
+    }
+
+    public boolean hasAskedForXmlResponse(final Collection<String> xmlEntityNames) {
+        for (ACCEPT_TYPE type : ACCEPT_TYPE.xmlResponseMediaTypes()) {
+            if (bestMatchFor(type).isPresent()) {
+                return true;
+            }
+        }
+        for (String mediaType : structuredXmlMediaTypesFor(xmlEntityNames)) {
+            if (bestMatchFor(ACCEPT_TYPE.XML, mediaType).isPresent()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private List<String> structuredXmlMediaTypesFor(final Collection<String> xmlEntityNames) {
+        final Set<String> mediaTypes = new LinkedHashSet<>();
+        for (AcceptedMediaRange acceptedType : acceptMediaTypeDefinitionsList) {
+            final ContentTypeHeaderParser parser =
+                    new ContentTypeHeaderParser(acceptedType.mediaRange());
+            if (parser.isStructuredXmlForEntity(xmlEntityNames)) {
+                mediaTypes.add(parser.mediaType());
+            } else if (acceptedType.isStructuredXmlWildcard()) {
+                ContentTypeHeaderParser.defaultStructuredXmlMediaTypeFor(xmlEntityNames)
+                        .ifPresent(mediaTypes::add);
+            }
+        }
+        return new ArrayList<>(mediaTypes);
     }
 
     private static List<String> splitOutsideQuotes(final String value, final char separator) {
@@ -429,29 +523,41 @@ public class AcceptHeaderParser {
             return false;
         }
 
+        boolean matchesAnyOf(final Collection<String> mediaTypes) {
+            for (String mediaType : mediaTypes) {
+                if (match(ACCEPT_TYPE.XML, mediaType).isPresent()) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         Optional<AcceptedMediaRangeMatch> match(final ACCEPT_TYPE type) {
-            final int specificity = specificityFor(type);
+            return match(type, type.mediaType());
+        }
+
+        Optional<AcceptedMediaRangeMatch> match(final ACCEPT_TYPE type, final String mediaType) {
+            final int specificity = specificityFor(mediaType);
             if (specificity == AcceptedMediaRangeMatch.NO_MATCH) {
                 return Optional.empty();
             }
             return Optional.of(
-                    new AcceptedMediaRangeMatch(type, qValue, qValueIsValid, order, specificity));
+                    new AcceptedMediaRangeMatch(
+                            type, mediaType, qValue, qValueIsValid, order, specificity));
         }
 
-        private int specificityFor(final ACCEPT_TYPE type) {
-            for (String concreteMediaType : type.mediaTypes()) {
-                if (mediaRange.equals(concreteMediaType)) {
-                    return AcceptedMediaRangeMatch.EXACT_MATCH;
-                }
-                if (isStructuredSuffixWildcardMatch(concreteMediaType)) {
-                    return AcceptedMediaRangeMatch.STRUCTURED_SUFFIX_MATCH;
-                }
-                if (isTypeWildcardMatch(concreteMediaType)) {
-                    return AcceptedMediaRangeMatch.TYPE_WILDCARD_MATCH;
-                }
-                if (isAnythingWildcard()) {
-                    return AcceptedMediaRangeMatch.ANYTHING_MATCH;
-                }
+        private int specificityFor(final String concreteMediaType) {
+            if (mediaRange.equals(concreteMediaType)) {
+                return AcceptedMediaRangeMatch.EXACT_MATCH;
+            }
+            if (isStructuredSuffixWildcardMatch(concreteMediaType)) {
+                return AcceptedMediaRangeMatch.STRUCTURED_SUFFIX_MATCH;
+            }
+            if (isTypeWildcardMatch(concreteMediaType)) {
+                return AcceptedMediaRangeMatch.TYPE_WILDCARD_MATCH;
+            }
+            if (isAnythingWildcard()) {
+                return AcceptedMediaRangeMatch.ANYTHING_MATCH;
             }
             return AcceptedMediaRangeMatch.NO_MATCH;
         }
@@ -491,6 +597,10 @@ public class AcceptHeaderParser {
             return "*/*".equals(mediaRange);
         }
 
+        private boolean isStructuredXmlWildcard() {
+            return "application/*+xml".equals(mediaRange);
+        }
+
         private static String[] mediaRangeParts(final String mediaType) {
             return mediaType.split("/", -1);
         }
@@ -523,6 +633,7 @@ public class AcceptHeaderParser {
         static final int EXACT_MATCH = 3;
 
         private final ACCEPT_TYPE type;
+        private final String mediaType;
         private final double qValue;
         private final boolean qValueIsValid;
         private final int order;
@@ -530,11 +641,13 @@ public class AcceptHeaderParser {
 
         private AcceptedMediaRangeMatch(
                 final ACCEPT_TYPE type,
+                final String mediaType,
                 final double qValue,
                 final boolean qValueIsValid,
                 final int order,
                 final int specificity) {
             this.type = type;
+            this.mediaType = mediaType;
             this.qValue = qValue;
             this.qValueIsValid = qValueIsValid;
             this.order = order;
@@ -556,22 +669,25 @@ public class AcceptHeaderParser {
         }
 
         NegotiatedAcceptType negotiatedType() {
-            return new NegotiatedAcceptType(type, qValue, order, specificity);
+            return new NegotiatedAcceptType(type, mediaType, qValue, order, specificity);
         }
     }
 
     private static final class NegotiatedAcceptType {
         private final ACCEPT_TYPE type;
+        private final String mediaType;
         private final double qValue;
         private final int order;
         private final int specificity;
 
         private NegotiatedAcceptType(
                 final ACCEPT_TYPE type,
+                final String mediaType,
                 final double qValue,
                 final int order,
                 final int specificity) {
             this.type = type;
+            this.mediaType = mediaType;
             this.qValue = qValue;
             this.order = order;
             this.specificity = specificity;
@@ -579,6 +695,10 @@ public class AcceptHeaderParser {
 
         ACCEPT_TYPE type() {
             return type;
+        }
+
+        PreferredMediaType preferredMediaType() {
+            return new PreferredMediaType(type, mediaType);
         }
 
         static Comparator<NegotiatedAcceptType> preferenceComparator() {
@@ -604,6 +724,36 @@ public class AcceptHeaderParser {
 
         private int serverPreference() {
             return ACCEPT_TYPE.responseMediaTypes().indexOf(type);
+        }
+    }
+
+    public static final class PreferredMediaType {
+        private final ACCEPT_TYPE type;
+        private final String mediaType;
+
+        private PreferredMediaType(final ACCEPT_TYPE type, final String mediaType) {
+            this.type = type;
+            this.mediaType = mediaType;
+        }
+
+        static PreferredMediaType forType(final ACCEPT_TYPE type) {
+            return new PreferredMediaType(type, type.mediaType());
+        }
+
+        static PreferredMediaType noMatch() {
+            return new PreferredMediaType(ACCEPT_TYPE.NO_MATCHING_TYPE, "");
+        }
+
+        public ACCEPT_TYPE type() {
+            return type;
+        }
+
+        public String mediaType() {
+            return mediaType;
+        }
+
+        public boolean rendersAsXml() {
+            return type.rendersAsXml();
         }
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/ContentTypeHeaderParser.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/ContentTypeHeaderParser.java
@@ -1,6 +1,16 @@
 package uk.co.compendiumdev.thingifier.api.http.headers.headerparser;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
 public class ContentTypeHeaderParser {
+    public static final String APPLICATION_XML = "application/xml";
+    public static final String TEXT_XML = "text/xml";
+    private static final List<String> RESERVED_STRUCTURED_XML_SUBTYPES =
+            List.of("problem", "soap", "xhtml", "atom", "rss", "svg");
+
     private final String header;
 
     public ContentTypeHeaderParser(final String header) {
@@ -13,7 +23,85 @@ public class ContentTypeHeaderParser {
 
     public boolean isXML() {
         // text/xml in standard https://datatracker.ietf.org/doc/html/rfc3023
-        return isMediaType("application/xml") || isMediaType("text/xml");
+        return supportedXmlMediaTypes().contains(mediaType());
+    }
+
+    public boolean isXML(final Collection<String> entityNames) {
+        return isXML() || isStructuredXmlForEntity(entityNames);
+    }
+
+    public static List<String> supportedXmlMediaTypes() {
+        return List.of(APPLICATION_XML, TEXT_XML);
+    }
+
+    public boolean isStructuredXmlForEntity(final Collection<String> entityNames) {
+        return structuredXmlEntityName(entityNames).isPresent();
+    }
+
+    public Optional<String> structuredXmlEntityName(final Collection<String> entityNames) {
+        final String[] parts = mediaRangeParts(mediaType());
+        if (parts.length != 2 || !"application".equals(parts[0])) {
+            return Optional.empty();
+        }
+
+        final String subtype = parts[1];
+        if (subtype.contains("*") || !subtype.endsWith("+xml")) {
+            return Optional.empty();
+        }
+
+        final String baseSubtype = subtype.substring(0, subtype.length() - "+xml".length());
+        final String subtypeEntityToken = entityTokenFrom(baseSubtype);
+        if (RESERVED_STRUCTURED_XML_SUBTYPES.contains(subtypeEntityToken)) {
+            return Optional.empty();
+        }
+
+        if (entityNames == null) {
+            return Optional.empty();
+        }
+        for (String entityName : entityNames) {
+            final String normalizedEntity = normalizeEntityName(entityName);
+            if (!normalizedEntity.isEmpty() && subtypeEntityToken.equals(normalizedEntity)) {
+                return Optional.of(normalizedEntity);
+            }
+        }
+        return Optional.empty();
+    }
+
+    public static Optional<String> defaultStructuredXmlMediaTypeFor(
+            final Collection<String> entityNames) {
+        if (entityNames == null) {
+            return Optional.empty();
+        }
+        for (String entityName : entityNames) {
+            final String normalizedEntity = normalizeEntityName(entityName);
+            if (!normalizedEntity.isEmpty()
+                    && !RESERVED_STRUCTURED_XML_SUBTYPES.contains(normalizedEntity)) {
+                return Optional.of("application/" + normalizedEntity + "+xml");
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static String entityTokenFrom(final String subtypeWithoutSuffix) {
+        int lastSeparator =
+                Math.max(
+                        subtypeWithoutSuffix.lastIndexOf('.'),
+                        subtypeWithoutSuffix.lastIndexOf('-'));
+        if (lastSeparator == -1) {
+            return subtypeWithoutSuffix;
+        }
+        return subtypeWithoutSuffix.substring(lastSeparator + 1);
+    }
+
+    private static String normalizeEntityName(final String entityName) {
+        if (entityName == null) {
+            return "";
+        }
+        return entityName.trim().toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9._-]", "-");
+    }
+
+    private static String[] mediaRangeParts(final String mediaType) {
+        return mediaType.split("/", -1);
     }
 
     public boolean isJSON() {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headervalidator/AcceptHeaderValidator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headervalidator/AcceptHeaderValidator.java
@@ -58,8 +58,7 @@ public class AcceptHeaderValidator {
         final List<AcceptHeaderParser.ACCEPT_TYPE> allowedTypes = new ArrayList<>();
         for (AcceptHeaderParser.ACCEPT_TYPE type :
                 AcceptHeaderParser.ACCEPT_TYPE.responseMediaTypes()) {
-            if (type.rendersAsXml()
-                    && !this.apiConfig.willApiAllowXmlForResponses()) {
+            if (type.rendersAsXml() && !this.apiConfig.willApiAllowXmlForResponses()) {
                 continue;
             }
             if (type == AcceptHeaderParser.ACCEPT_TYPE.JSON

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headervalidator/AcceptHeaderValidator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headervalidator/AcceptHeaderValidator.java
@@ -1,6 +1,7 @@
 package uk.co.compendiumdev.thingifier.api.http.headers.headervalidator;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import uk.co.compendiumdev.thingifier.api.http.headers.headerparser.AcceptHeaderParser;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
@@ -8,9 +9,16 @@ import uk.co.compendiumdev.thingifier.apiconfig.ThingifierApiConfig;
 
 public class AcceptHeaderValidator {
     private final ThingifierApiConfig apiConfig;
+    private final Collection<String> xmlEntityNames;
 
     public AcceptHeaderValidator(final ThingifierApiConfig apiConfig) {
+        this(apiConfig, List.of());
+    }
+
+    public AcceptHeaderValidator(
+            final ThingifierApiConfig apiConfig, final Collection<String> xmlEntityNames) {
         this.apiConfig = apiConfig;
+        this.xmlEntityNames = xmlEntityNames == null ? List.of() : List.copyOf(xmlEntityNames);
     }
 
     public ApiResponse validate(final String acceptHeader) {
@@ -20,7 +28,7 @@ public class AcceptHeaderValidator {
         int statusAcceptTypeNotSupported = this.apiConfig.statusCodes().acceptTypeNotSupported();
 
         if (this.apiConfig.willApiEnforceAcceptHeaderForResponses()) {
-            if (!accept.isSupportedHeader()) {
+            if (!accept.isSupportedHeader(xmlEntityNames)) {
                 apiResponse =
                         ApiResponse.error(statusAcceptTypeNotSupported, "Unrecognised Accept Type");
             }
@@ -41,14 +49,16 @@ public class AcceptHeaderValidator {
 
     private AcceptHeaderParser.ACCEPT_TYPE preferredAllowedResponseType(
             final AcceptHeaderParser accept) {
-        return accept.preferredSupportedType(allowedResponseTypes(), defaultResponseType());
+        return accept.preferredSupportedMediaType(
+                        allowedResponseTypes(), defaultResponseType(), xmlEntityNames)
+                .type();
     }
 
     private List<AcceptHeaderParser.ACCEPT_TYPE> allowedResponseTypes() {
         final List<AcceptHeaderParser.ACCEPT_TYPE> allowedTypes = new ArrayList<>();
         for (AcceptHeaderParser.ACCEPT_TYPE type :
                 AcceptHeaderParser.ACCEPT_TYPE.responseMediaTypes()) {
-            if (type == AcceptHeaderParser.ACCEPT_TYPE.XML
+            if (type.rendersAsXml()
                     && !this.apiConfig.willApiAllowXmlForResponses()) {
                 continue;
             }
@@ -72,7 +82,7 @@ public class AcceptHeaderValidator {
     }
 
     private String unsupportedResponseTypeMessage(final AcceptHeaderParser accept) {
-        if (accept.hasAskedFor(AcceptHeaderParser.ACCEPT_TYPE.XML) && !accept.willAcceptJson()) {
+        if (accept.hasAskedForXmlResponse(xmlEntityNames) && !accept.willAcceptJson()) {
             return "XML not supported";
         }
         if (accept.hasAskedFor(AcceptHeaderParser.ACCEPT_TYPE.JSON) && !accept.willAcceptXml()) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headervalidator/ContentTypeHeaderValidator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headervalidator/ContentTypeHeaderValidator.java
@@ -1,14 +1,23 @@
 package uk.co.compendiumdev.thingifier.api.http.headers.headervalidator;
 
+import java.util.Collection;
+import java.util.List;
 import uk.co.compendiumdev.thingifier.api.http.headers.headerparser.ContentTypeHeaderParser;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
 import uk.co.compendiumdev.thingifier.apiconfig.ThingifierApiConfig;
 
 public class ContentTypeHeaderValidator {
     private final ThingifierApiConfig apiConfig;
+    private final Collection<String> xmlEntityNames;
 
     public ContentTypeHeaderValidator(final ThingifierApiConfig apiConfig) {
+        this(apiConfig, List.of());
+    }
+
+    public ContentTypeHeaderValidator(
+            final ThingifierApiConfig apiConfig, final Collection<String> xmlEntityNames) {
         this.apiConfig = apiConfig;
+        this.xmlEntityNames = xmlEntityNames == null ? List.of() : List.copyOf(xmlEntityNames);
     }
 
     public ApiResponse validate(final String header) {
@@ -18,21 +27,24 @@ public class ContentTypeHeaderValidator {
         }
 
         final ContentTypeHeaderParser accept = new ContentTypeHeaderParser(header);
+        final boolean isXml = accept.isXML(xmlEntityNames);
 
         if (accept.isMissing()
-                || accept.isText() && apiConfig.willAllowJsonAsDefaultContentType()) {
+                || (!isXml
+                        && accept.isText()
+                        && apiConfig.willAllowJsonAsDefaultContentType())) {
             // assume that we can derive content type from the actual content
             return null;
         }
 
         int statusContentTypeNotSupported = this.apiConfig.statusCodes().contentTypeNotSupported();
 
-        if (!accept.isXML() && !accept.isJSON()) {
+        if (!isXml && !accept.isJSON()) {
             return ApiResponse.error(
                     statusContentTypeNotSupported, "Unsupported Content Type - " + header);
         }
 
-        if (accept.isXML() && !this.apiConfig.willAcceptXMLContent()) {
+        if (isXml && !this.apiConfig.willAcceptXMLContent()) {
             return ApiResponse.error(statusContentTypeNotSupported, "XML Not Supported");
         }
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headervalidator/ContentTypeHeaderValidator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headervalidator/ContentTypeHeaderValidator.java
@@ -30,9 +30,7 @@ public class ContentTypeHeaderValidator {
         final boolean isXml = accept.isXML(xmlEntityNames);
 
         if (accept.isMissing()
-                || (!isXml
-                        && accept.isText()
-                        && apiConfig.willAllowJsonAsDefaultContentType())) {
+                || (!isXml && accept.isText() && apiConfig.willAllowJsonAsDefaultContentType())) {
             // assume that we can derive content type from the actual content
             return null;
         }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseError.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseError.java
@@ -16,12 +16,13 @@ public final class ApiResponseError {
                 acceptable.preferredSupportedType(
                         List.of(
                                 AcceptHeaderParser.ACCEPT_TYPE.JSON,
-                                AcceptHeaderParser.ACCEPT_TYPE.XML),
+                                AcceptHeaderParser.ACCEPT_TYPE.XML,
+                                AcceptHeaderParser.ACCEPT_TYPE.TEXT_XML),
                         AcceptHeaderParser.ACCEPT_TYPE.JSON);
 
         // TODO: should be able to configure a default API response type rather than assume it is
         // JSON
-        if (preferredType == AcceptHeaderParser.ACCEPT_TYPE.XML) {
+        if (preferredType.rendersAsXml()) {
             isJson = false;
         }
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGenerator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGenerator.java
@@ -114,8 +114,7 @@ public class RestApiDocumentationGenerator {
                                 "Set Content-Type header to application/xml, text/xml, or a model-matching application/*+xml media type if you want to send in XML."));
                 output.append(paragraph("<i>Content-Type: application/xml</i>"));
                 output.append(paragraph("<i>Content-Type: text/xml</i>"));
-                output.append(
-                        paragraph("<i>Content-Type: application/todo+xml</i>"));
+                output.append(paragraph("<i>Content-Type: application/todo+xml</i>"));
 
                 if (thingifier.apiConfig().willApiAllowXmlForResponses()
                         && thingifier.apiConfig().willApiAllowJsonForResponses()) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGenerator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/htmlgui/htmlgen/RestApiDocumentationGenerator.java
@@ -111,8 +111,11 @@ public class RestApiDocumentationGenerator {
                 output.append(paragraph("<i>Content-Type: application/json</i>"));
                 output.append(
                         paragraph(
-                                "Set Content-Type header to application/xml if you want to send in XML."));
+                                "Set Content-Type header to application/xml, text/xml, or a model-matching application/*+xml media type if you want to send in XML."));
                 output.append(paragraph("<i>Content-Type: application/xml</i>"));
+                output.append(paragraph("<i>Content-Type: text/xml</i>"));
+                output.append(
+                        paragraph("<i>Content-Type: application/todo+xml</i>"));
 
                 if (thingifier.apiConfig().willApiAllowXmlForResponses()
                         && thingifier.apiConfig().willApiAllowJsonForResponses()) {
@@ -134,6 +137,11 @@ public class RestApiDocumentationGenerator {
                     output.append(
                             paragraph(
                                     acceptHeaderExample(AcceptHeaderParser.ACCEPT_TYPE.XML)
+                                            + "<br/>\n"
+                                            + acceptHeaderExample(
+                                                    AcceptHeaderParser.ACCEPT_TYPE.TEXT_XML)
+                                            + "<br/>\n"
+                                            + "<i>Accept: application/*+xml</i>"
                                             + "<br/><br/>\n"));
                 }
 
@@ -966,7 +974,7 @@ public class RestApiDocumentationGenerator {
         for (AcceptHeaderParser.ACCEPT_TYPE responseType :
                 AcceptHeaderParser.ACCEPT_TYPE.responseMediaTypes()) {
             if (responseType == AcceptHeaderParser.ACCEPT_TYPE.JSON
-                    || responseType == AcceptHeaderParser.ACCEPT_TYPE.XML) {
+                    || responseType.rendersAsXml()) {
                 continue;
             }
             headers.append(acceptHeaderExample(responseType)).append("<br/>\n");

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/Swaggerizer.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/Swaggerizer.java
@@ -583,10 +583,7 @@ public class Swaggerizer {
                 AcceptHeaderParser.ACCEPT_TYPE.responseMediaTypes()) {
             if (responseType.usesComponentSchemaInDocumentation()) {
                 MediaType schema = new MediaType();
-                schema.setSchema(
-                        responseType.rendersAsXml()
-                                ? xmlSchema
-                                : refSchemaFor(jsonRef));
+                schema.setSchema(responseType.rendersAsXml() ? xmlSchema : refSchemaFor(jsonRef));
                 content.addMediaType(responseType.mediaType(), schema);
             } else {
                 MediaType textSchema = new MediaType();

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/Swaggerizer.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/Swaggerizer.java
@@ -584,7 +584,7 @@ public class Swaggerizer {
             if (responseType.usesComponentSchemaInDocumentation()) {
                 MediaType schema = new MediaType();
                 schema.setSchema(
-                        responseType == AcceptHeaderParser.ACCEPT_TYPE.XML
+                        responseType.rendersAsXml()
                                 ? xmlSchema
                                 : refSchemaFor(jsonRef));
                 content.addMediaType(responseType.mediaType(), schema);

--- a/thingifier/src/test/java/uk/co/compendiumdev/casestudy/todomanager/http_api/XmlRequestResponseTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/casestudy/todomanager/http_api/XmlRequestResponseTest.java
@@ -70,6 +70,30 @@ public class XmlRequestResponseTest {
     }
 
     @Test
+    public void canGetXmlItemsWhenAskedForXmlCompatibleMediaTypes() {
+
+        todoManager
+                .getStore(EntityRelModel.DEFAULT_DATABASE_NAME)
+                .entities()
+                .create(EntityInstanceDraft.forEntity(todo).withField("title", "my title"));
+
+        for (String accept :
+                java.util.List.of(
+                        "text/xml",
+                        "application/vnd.example.todo+xml",
+                        "application/*+xml")) {
+            HttpApiRequest request = new HttpApiRequest("todos");
+            request.getHeaders().put("accept", accept);
+
+            final HttpApiResponse response = new ThingifierHttpApi(todoManager).get(request);
+
+            Assertions.assertEquals(200, response.getStatusCode(), accept);
+            Assertions.assertEquals(expectedXmlContentTypeFor(accept), response.getType());
+            Assertions.assertTrue(response.getBody().startsWith("<todos><todo>"));
+        }
+    }
+
+    @Test
     public void canGetXmlErrorMessagesWhenAskedForXml() {
 
         todoManager
@@ -141,6 +165,68 @@ public class XmlRequestResponseTest {
         Assertions.assertTrue(
                 response.getBody().startsWith("<todo><doneStatus>false</doneStatus>"),
                 "Should have returned xml as body: " + response.getBody());
+    }
+
+    @Test
+    public void canPostAndCreateAnItemWithXmlCompatibleContentTypes() {
+
+        for (String contentType :
+                java.util.List.of("text/xml", "application/vnd.example.todo+xml")) {
+            createDefinitions();
+            todoManager.apiConfig().setApiToEnforceContentTypeForRequests(true);
+
+            HttpApiRequest request = new HttpApiRequest("todos");
+            request.getHeaders().putAll(HeadersSupport.acceptXml());
+            request.getHeaders().put("content-type", contentType);
+
+            request.setBody("<todo><title>test title</title></todo>");
+
+            final HttpApiResponse response = new ThingifierHttpApi(todoManager).post(request);
+
+            Assertions.assertEquals(201, response.getStatusCode(), contentType);
+            Assertions.assertEquals(
+                    1,
+                    todoManager
+                            .getStore(EntityRelModel.DEFAULT_DATABASE_NAME)
+                            .entityQueries()
+                            .count(todo));
+            Assertions.assertTrue(
+                    response.getBody().startsWith("<todo><doneStatus>false</doneStatus>"),
+                    "Should have returned xml as body: " + response.getBody());
+        }
+    }
+
+    @Test
+    public void unsupportedXmlBasedContentTypesAreRejectedForPosts() {
+
+        for (String contentType :
+                java.util.List.of(
+                        "application/problem+xml",
+                        "application/soap+xml",
+                        "application/xhtml+xml",
+                        "image/svg+xml",
+                        "application/atom+xml",
+                        "application/rss+xml",
+                        "application/*+xml")) {
+            createDefinitions();
+            todoManager.apiConfig().setApiToEnforceContentTypeForRequests(true);
+
+            HttpApiRequest request = new HttpApiRequest("todos");
+            request.getHeaders().putAll(HeadersSupport.acceptJson());
+            request.getHeaders().put("content-type", contentType);
+            request.setBody("<todo><title>test title</title></todo>");
+
+            final HttpApiResponse response = new ThingifierHttpApi(todoManager).post(request);
+
+            Assertions.assertEquals(415, response.getStatusCode(), contentType);
+            Assertions.assertTrue(response.getBody().contains("Unsupported Content Type"));
+            Assertions.assertEquals(
+                    0,
+                    todoManager
+                            .getStore(EntityRelModel.DEFAULT_DATABASE_NAME)
+                            .entityQueries()
+                            .count(todo));
+        }
     }
 
     @Test
@@ -307,5 +393,15 @@ public class XmlRequestResponseTest {
     private class ErrorMessages {
 
         String[] errorMessages;
+    }
+
+    private String expectedXmlContentTypeFor(final String accept) {
+        if ("text/xml".equals(accept)) {
+            return "text/xml";
+        }
+        if ("application/*+xml".equals(accept)) {
+            return "application/todo+xml";
+        }
+        return accept;
     }
 }

--- a/thingifier/src/test/java/uk/co/compendiumdev/casestudy/todomanager/http_api/XmlRequestResponseTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/casestudy/todomanager/http_api/XmlRequestResponseTest.java
@@ -1,8 +1,12 @@
 package uk.co.compendiumdev.casestudy.todomanager.http_api;
 
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import uk.co.compendiumdev.casestudy.todomanager.TodoManagerModel;
 import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.api.http.HttpApiRequest;
@@ -69,26 +73,24 @@ public class XmlRequestResponseTest {
         Assertions.assertTrue(response.getBody().startsWith("<todos><todo>"));
     }
 
-    @Test
-    public void canGetXmlItemsWhenAskedForXmlCompatibleMediaTypes() {
+    @ParameterizedTest
+    @MethodSource("xmlCompatibleAcceptHeaders")
+    public void canGetXmlItemsWhenAskedForXmlCompatibleMediaType(
+            final String accept, final String expectedContentType) {
 
         todoManager
                 .getStore(EntityRelModel.DEFAULT_DATABASE_NAME)
                 .entities()
                 .create(EntityInstanceDraft.forEntity(todo).withField("title", "my title"));
 
-        for (String accept :
-                java.util.List.of(
-                        "text/xml", "application/vnd.example.todo+xml", "application/*+xml")) {
-            HttpApiRequest request = new HttpApiRequest("todos");
-            request.getHeaders().put("accept", accept);
+        HttpApiRequest request = new HttpApiRequest("todos");
+        request.getHeaders().put("accept", accept);
 
-            final HttpApiResponse response = new ThingifierHttpApi(todoManager).get(request);
+        final HttpApiResponse response = new ThingifierHttpApi(todoManager).get(request);
 
-            Assertions.assertEquals(200, response.getStatusCode(), accept);
-            Assertions.assertEquals(expectedXmlContentTypeFor(accept), response.getType());
-            Assertions.assertTrue(response.getBody().startsWith("<todos><todo>"));
-        }
+        Assertions.assertEquals(200, response.getStatusCode(), accept);
+        Assertions.assertEquals(expectedContentType, response.getType());
+        Assertions.assertTrue(response.getBody().startsWith("<todos><todo>"));
     }
 
     @Test
@@ -165,66 +167,53 @@ public class XmlRequestResponseTest {
                 "Should have returned xml as body: " + response.getBody());
     }
 
-    @Test
-    public void canPostAndCreateAnItemWithXmlCompatibleContentTypes() {
+    @ParameterizedTest
+    @MethodSource("xmlCompatibleContentTypes")
+    public void canPostAndCreateAnItemWithXmlCompatibleContentType(final String contentType) {
 
-        for (String contentType :
-                java.util.List.of("text/xml", "application/vnd.example.todo+xml")) {
-            createDefinitions();
-            todoManager.apiConfig().setApiToEnforceContentTypeForRequests(true);
+        todoManager.apiConfig().setApiToEnforceContentTypeForRequests(true);
 
-            HttpApiRequest request = new HttpApiRequest("todos");
-            request.getHeaders().putAll(HeadersSupport.acceptXml());
-            request.getHeaders().put("content-type", contentType);
+        HttpApiRequest request = new HttpApiRequest("todos");
+        request.getHeaders().putAll(HeadersSupport.acceptXml());
+        request.getHeaders().put("content-type", contentType);
 
-            request.setBody("<todo><title>test title</title></todo>");
+        request.setBody("<todo><title>test title</title></todo>");
 
-            final HttpApiResponse response = new ThingifierHttpApi(todoManager).post(request);
+        final HttpApiResponse response = new ThingifierHttpApi(todoManager).post(request);
 
-            Assertions.assertEquals(201, response.getStatusCode(), contentType);
-            Assertions.assertEquals(
-                    1,
-                    todoManager
-                            .getStore(EntityRelModel.DEFAULT_DATABASE_NAME)
-                            .entityQueries()
-                            .count(todo));
-            Assertions.assertTrue(
-                    response.getBody().startsWith("<todo><doneStatus>false</doneStatus>"),
-                    "Should have returned xml as body: " + response.getBody());
-        }
+        Assertions.assertEquals(201, response.getStatusCode(), contentType);
+        Assertions.assertEquals(
+                1,
+                todoManager
+                        .getStore(EntityRelModel.DEFAULT_DATABASE_NAME)
+                        .entityQueries()
+                        .count(todo));
+        Assertions.assertTrue(
+                response.getBody().startsWith("<todo><doneStatus>false</doneStatus>"),
+                "Should have returned xml as body: " + response.getBody());
     }
 
-    @Test
-    public void unsupportedXmlBasedContentTypesAreRejectedForPosts() {
+    @ParameterizedTest
+    @MethodSource("unsupportedXmlBasedContentTypes")
+    public void unsupportedXmlBasedContentTypeIsRejectedForPosts(final String contentType) {
 
-        for (String contentType :
-                java.util.List.of(
-                        "application/problem+xml",
-                        "application/soap+xml",
-                        "application/xhtml+xml",
-                        "image/svg+xml",
-                        "application/atom+xml",
-                        "application/rss+xml",
-                        "application/*+xml")) {
-            createDefinitions();
-            todoManager.apiConfig().setApiToEnforceContentTypeForRequests(true);
+        todoManager.apiConfig().setApiToEnforceContentTypeForRequests(true);
 
-            HttpApiRequest request = new HttpApiRequest("todos");
-            request.getHeaders().putAll(HeadersSupport.acceptJson());
-            request.getHeaders().put("content-type", contentType);
-            request.setBody("<todo><title>test title</title></todo>");
+        HttpApiRequest request = new HttpApiRequest("todos");
+        request.getHeaders().putAll(HeadersSupport.acceptJson());
+        request.getHeaders().put("content-type", contentType);
+        request.setBody("<todo><title>test title</title></todo>");
 
-            final HttpApiResponse response = new ThingifierHttpApi(todoManager).post(request);
+        final HttpApiResponse response = new ThingifierHttpApi(todoManager).post(request);
 
-            Assertions.assertEquals(415, response.getStatusCode(), contentType);
-            Assertions.assertTrue(response.getBody().contains("Unsupported Content Type"));
-            Assertions.assertEquals(
-                    0,
-                    todoManager
-                            .getStore(EntityRelModel.DEFAULT_DATABASE_NAME)
-                            .entityQueries()
-                            .count(todo));
-        }
+        Assertions.assertEquals(415, response.getStatusCode(), contentType);
+        Assertions.assertTrue(response.getBody().contains("Unsupported Content Type"));
+        Assertions.assertEquals(
+                0,
+                todoManager
+                        .getStore(EntityRelModel.DEFAULT_DATABASE_NAME)
+                        .entityQueries()
+                        .count(todo));
     }
 
     @Test
@@ -393,13 +382,26 @@ public class XmlRequestResponseTest {
         String[] errorMessages;
     }
 
-    private String expectedXmlContentTypeFor(final String accept) {
-        if ("text/xml".equals(accept)) {
-            return "text/xml";
-        }
-        if ("application/*+xml".equals(accept)) {
-            return "application/todo+xml";
-        }
-        return accept;
+    private static Stream<Arguments> xmlCompatibleAcceptHeaders() {
+        return Stream.of(
+                Arguments.of("text/xml", "text/xml"),
+                Arguments.of(
+                        "application/vnd.example.todo+xml", "application/vnd.example.todo+xml"),
+                Arguments.of("application/*+xml", "application/todo+xml"));
+    }
+
+    private static Stream<String> xmlCompatibleContentTypes() {
+        return Stream.of("text/xml", "application/vnd.example.todo+xml");
+    }
+
+    private static Stream<String> unsupportedXmlBasedContentTypes() {
+        return Stream.of(
+                "application/problem+xml",
+                "application/soap+xml",
+                "application/xhtml+xml",
+                "image/svg+xml",
+                "application/atom+xml",
+                "application/rss+xml",
+                "application/*+xml");
     }
 }

--- a/thingifier/src/test/java/uk/co/compendiumdev/casestudy/todomanager/http_api/XmlRequestResponseTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/casestudy/todomanager/http_api/XmlRequestResponseTest.java
@@ -79,9 +79,7 @@ public class XmlRequestResponseTest {
 
         for (String accept :
                 java.util.List.of(
-                        "text/xml",
-                        "application/vnd.example.todo+xml",
-                        "application/*+xml")) {
+                        "text/xml", "application/vnd.example.todo+xml", "application/*+xml")) {
             HttpApiRequest request = new HttpApiRequest("todos");
             request.getHeaders().put("accept", accept);
 

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/AcceptHeaderParserTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/AcceptHeaderParserTest.java
@@ -1,8 +1,12 @@
 package uk.co.compendiumdev.thingifier.api;
 
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import uk.co.compendiumdev.thingifier.api.http.headers.headerparser.AcceptHeaderParser;
 
 public class AcceptHeaderParserTest {
@@ -172,6 +176,9 @@ public class AcceptHeaderParserTest {
         Assertions.assertTrue(
                 new AcceptHeaderParser("text/tab-separated-values")
                         .willAccept(AcceptHeaderParser.ACCEPT_TYPE.TSV));
+        Assertions.assertTrue(
+                new AcceptHeaderParser("text/xml")
+                        .willAccept(AcceptHeaderParser.ACCEPT_TYPE.TEXT_XML));
     }
 
     @Test
@@ -205,9 +212,11 @@ public class AcceptHeaderParserTest {
                         AcceptHeaderParser.ACCEPT_TYPE.CSV,
                         AcceptHeaderParser.ACCEPT_TYPE.TEXT,
                         AcceptHeaderParser.ACCEPT_TYPE.HTML,
-                        AcceptHeaderParser.ACCEPT_TYPE.TSV),
+                        AcceptHeaderParser.ACCEPT_TYPE.TSV,
+                        AcceptHeaderParser.ACCEPT_TYPE.TEXT_XML),
                 accept.getSupportedTypesInPreferenceOrder());
         Assertions.assertTrue(accept.willAcceptText());
+        Assertions.assertTrue(accept.willAcceptXml());
         Assertions.assertFalse(accept.willAcceptJson());
     }
 
@@ -227,6 +236,198 @@ public class AcceptHeaderParserTest {
         Assertions.assertTrue(accept.willAcceptJson());
         Assertions.assertTrue(accept.willAcceptXml());
         Assertions.assertFalse(accept.willAcceptCsv());
+    }
+
+    @Test
+    public void textXmlNegotiatesToXmlRepresentation() {
+        final AcceptHeaderParser textXml = new AcceptHeaderParser("text/xml");
+
+        Assertions.assertTrue(textXml.isSupportedHeader());
+        Assertions.assertTrue(textXml.willAcceptXml());
+        Assertions.assertTrue(textXml.hasAPreferenceForXml());
+        Assertions.assertEquals(
+                List.of(AcceptHeaderParser.ACCEPT_TYPE.TEXT_XML),
+                textXml.getSupportedTypesInPreferenceOrder());
+    }
+
+    @Test
+    public void modelMatchingStructuredXmlMediaTypeNegotiatesToXmlRepresentation() {
+        final AcceptHeaderParser vendorXml = new AcceptHeaderParser("application/vnd.example.todo+xml");
+
+        Assertions.assertFalse(vendorXml.isSupportedHeader());
+        Assertions.assertTrue(vendorXml.isSupportedHeader(List.of("todo", "todos")));
+        Assertions.assertEquals(
+                "application/vnd.example.todo+xml",
+                vendorXml
+                        .preferredSupportedMediaType(
+                                AcceptHeaderParser.ACCEPT_TYPE.responseMediaTypes(),
+                                AcceptHeaderParser.ACCEPT_TYPE.JSON,
+                                List.of("todo", "todos"))
+                        .mediaType());
+    }
+
+    @Test
+    public void structuredXmlWildcardNegotiatesToModelDerivedXmlRepresentation() {
+        final AcceptHeaderParser suffixWildcard = new AcceptHeaderParser("application/*+xml");
+
+        Assertions.assertFalse(suffixWildcard.isSupportedHeader());
+        Assertions.assertTrue(suffixWildcard.isSupportedHeader(List.of("todo", "todos")));
+        Assertions.assertEquals(
+                "application/todo+xml",
+                suffixWildcard
+                        .preferredSupportedMediaType(
+                                AcceptHeaderParser.ACCEPT_TYPE.responseMediaTypes(),
+                                AcceptHeaderParser.ACCEPT_TYPE.JSON,
+                                List.of("todo", "todos"))
+                        .mediaType());
+    }
+
+    @Test
+    public void unsupportedXmlBasedMediaTypesAreNotNormalXmlRepresentations() {
+        for (String mediaType :
+                List.of(
+                        "application/problem+xml",
+                        "application/soap+xml",
+                        "application/xhtml+xml",
+                        "image/svg+xml",
+                        "application/atom+xml",
+                        "application/rss+xml")) {
+            final AcceptHeaderParser accept = new AcceptHeaderParser(mediaType);
+
+            Assertions.assertFalse(accept.isSupportedHeader(), mediaType);
+            Assertions.assertFalse(accept.willAcceptXml(), mediaType);
+            Assertions.assertTrue(accept.getSupportedTypesInPreferenceOrder().isEmpty(), mediaType);
+        }
+    }
+
+    @Test
+    public void qValuesControlPreferenceOrderForXmlCompatibleTypes() {
+        final AcceptHeaderParser accept =
+                new AcceptHeaderParser(
+                        "application/json;q=0.5, "
+                                + "application/xml;q=0.6, "
+                                + "text/xml;q=0.9, "
+                                + "application/vnd.example.todo+xml;q=0.8");
+
+        Assertions.assertEquals(
+                "text/xml",
+                accept
+                        .preferredSupportedMediaType(
+                                AcceptHeaderParser.ACCEPT_TYPE.responseMediaTypes(),
+                                AcceptHeaderParser.ACCEPT_TYPE.JSON,
+                                List.of("todo", "todos"))
+                        .mediaType());
+        Assertions.assertEquals(
+                List.of(
+                        AcceptHeaderParser.ACCEPT_TYPE.TEXT_XML,
+                        AcceptHeaderParser.ACCEPT_TYPE.XML,
+                        AcceptHeaderParser.ACCEPT_TYPE.JSON),
+                accept.getSupportedTypesInPreferenceOrder());
+        Assertions.assertTrue(accept.hasAPreferenceForXml());
+        Assertions.assertFalse(accept.hasAPreferenceForJson());
+    }
+
+    @ParameterizedTest
+    @MethodSource("issue103QualityValueExamples")
+    public void issue103ExamplesNegotiateSupportedTypesByQualityValues(
+            final String acceptHeader, final AcceptHeaderParser.ACCEPT_TYPE expectedType) {
+        assertPreferredType(
+                acceptHeader,
+                expectedType);
+    }
+
+    @Test
+    public void issue103ExampleWithOnlyQZeroSupportedTypesHasNoAcceptableRepresentation() {
+        final AcceptHeaderParser allRejected =
+                new AcceptHeaderParser("application/json;q=0, application/xml;q=0");
+
+        Assertions.assertTrue(allRejected.isSupportedHeader());
+        Assertions.assertTrue(allRejected.getSupportedTypesInPreferenceOrder().isEmpty());
+        Assertions.assertEquals(
+                AcceptHeaderParser.ACCEPT_TYPE.NO_MATCHING_TYPE,
+                allRejected.preferredSupportedType(
+                        AcceptHeaderParser.ACCEPT_TYPE.responseMediaTypes(),
+                        AcceptHeaderParser.ACCEPT_TYPE.JSON));
+    }
+
+    @Test
+    public void qValuesSelectBetweenXmlCompatibleMediaTypes() {
+        assertPreferredMediaType(
+                "application/json;q=0.5, "
+                        + "application/xml;q=0.6, "
+                        + "text/xml;q=0.8, "
+                        + "application/vnd.example.todo+xml;q=0.9",
+                "application/vnd.example.todo+xml");
+        assertPreferredMediaType(
+                "application/json;q=0.5, "
+                        + "application/xml;q=0.6, "
+                        + "text/xml;q=0.8, "
+                        + "application/*+xml;q=0.9",
+                "application/todo+xml");
+    }
+
+    @Test
+    public void unsupportedHigherQualityMediaRangesFallThroughToSupportedTypes() {
+        assertPreferredMediaType(
+                "application/problem+xml;q=1, text/xml;q=0.4",
+                "text/xml");
+        assertPreferredMediaType(
+                "application/soap+xml;q=1, application/*+xml;q=0.4",
+                "application/todo+xml");
+        assertPreferredMediaType(
+                "application/problem+json;q=1, application/vnd.example.todo+xml;q=0.4",
+                "application/vnd.example.todo+xml");
+    }
+
+    @Test
+    public void specificityBeatsHeaderOrderWhenQualityValuesTie() {
+        assertPreferredMediaType(
+                "application/*;q=0.8, application/xml;q=0.8",
+                "application/xml");
+        assertPreferredMediaType(
+                "text/*;q=0.8, text/xml;q=0.8",
+                "text/xml");
+        assertPreferredMediaType(
+                "application/*+xml;q=0.8, application/vnd.example.todo+xml;q=0.8",
+                "application/vnd.example.todo+xml");
+    }
+
+    @Test
+    public void clientOrderBreaksTiesWhenQualityAndSpecificityAreTheSame() {
+        assertPreferredMediaType(
+                "text/xml;q=0.8, application/xml;q=0.8",
+                "text/xml");
+        assertPreferredMediaType(
+                "application/xml;q=0.8, text/xml;q=0.8",
+                "application/xml");
+        assertPreferredMediaType(
+                "application/vnd.example.todo+xml;q=0.8, text/xml;q=0.8",
+                "application/vnd.example.todo+xml");
+        assertPreferredMediaType(
+                "text/xml;q=0.8, application/vnd.example.todo+xml;q=0.8",
+                "text/xml");
+    }
+
+    @Test
+    public void qZeroExcludesExactXmlCompatibleMediaTypesBeforeWildcardFallback() {
+        assertPreferredMediaType(
+                "text/xml;q=0, text/*;q=0.8",
+                "text/csv");
+        assertPreferredMediaType(
+                "application/xml;q=0, application/*;q=0.8",
+                "application/json");
+
+        final AcceptHeaderParser structuredXml =
+                new AcceptHeaderParser("application/todo+xml;q=0, application/*+xml;q=0.8");
+
+        Assertions.assertEquals(
+                AcceptHeaderParser.ACCEPT_TYPE.NO_MATCHING_TYPE,
+                structuredXml
+                        .preferredSupportedMediaType(
+                                AcceptHeaderParser.ACCEPT_TYPE.responseMediaTypes(),
+                                AcceptHeaderParser.ACCEPT_TYPE.JSON,
+                                List.of("todo", "todos"))
+                        .type());
     }
 
     @Test
@@ -313,5 +514,57 @@ public class AcceptHeaderParserTest {
         Assertions.assertFalse(accept.willAcceptJson());
         Assertions.assertFalse(accept.willAcceptXml());
         Assertions.assertTrue(accept.getSupportedTypesInPreferenceOrder().isEmpty());
+    }
+
+    private void assertPreferredType(
+            final String acceptHeader, final AcceptHeaderParser.ACCEPT_TYPE expectedType) {
+        final AcceptHeaderParser accept = new AcceptHeaderParser(acceptHeader);
+
+        Assertions.assertTrue(accept.isSupportedHeader(), acceptHeader);
+        Assertions.assertEquals(expectedType, accept.getSupportedTypesInPreferenceOrder().get(0));
+        Assertions.assertEquals(
+                expectedType,
+                accept.preferredSupportedType(
+                        AcceptHeaderParser.ACCEPT_TYPE.responseMediaTypes(),
+                        AcceptHeaderParser.ACCEPT_TYPE.JSON));
+    }
+
+    private void assertPreferredMediaType(final String acceptHeader, final String mediaType) {
+        final AcceptHeaderParser accept = new AcceptHeaderParser(acceptHeader);
+
+        Assertions.assertTrue(accept.isSupportedHeader(List.of("todo", "todos")), acceptHeader);
+        Assertions.assertEquals(
+                mediaType,
+                accept
+                        .preferredSupportedMediaType(
+                                AcceptHeaderParser.ACCEPT_TYPE.responseMediaTypes(),
+                                AcceptHeaderParser.ACCEPT_TYPE.JSON,
+                                List.of("todo", "todos"))
+                        .mediaType());
+    }
+
+    private static Stream<Arguments> issue103QualityValueExamples() {
+        return Stream.of(
+                Arguments.of(
+                        "application/xml;q=1, application/json;q=0.5",
+                        AcceptHeaderParser.ACCEPT_TYPE.XML),
+                Arguments.of(
+                        "application/json;q=1, application/xml;q=0.5",
+                        AcceptHeaderParser.ACCEPT_TYPE.JSON),
+                Arguments.of(
+                        "application/xml;q=0.2, application/json;q=0.9",
+                        AcceptHeaderParser.ACCEPT_TYPE.JSON),
+                Arguments.of(
+                        "application/json;q=0, application/xml;q=1",
+                        AcceptHeaderParser.ACCEPT_TYPE.XML),
+                Arguments.of(
+                        "application/xml, application/json;q=0.5",
+                        AcceptHeaderParser.ACCEPT_TYPE.XML),
+                Arguments.of(
+                        "*/*;q=0.8, application/xml;q=0.9",
+                        AcceptHeaderParser.ACCEPT_TYPE.XML),
+                Arguments.of(
+                        "application/gzip;q=1, application/json;q=0.5",
+                        AcceptHeaderParser.ACCEPT_TYPE.JSON));
     }
 }

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/AcceptHeaderParserTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/AcceptHeaderParserTest.java
@@ -156,29 +156,11 @@ public class AcceptHeaderParserTest {
         Assertions.assertFalse(accept.hasAskedFor(AcceptHeaderParser.ACCEPT_TYPE.JSON));
     }
 
-    @Test
-    public void willAcceptAdditionalResponseRepresentations() {
-        Assertions.assertTrue(
-                new AcceptHeaderParser("text/csv").willAccept(AcceptHeaderParser.ACCEPT_TYPE.CSV));
-        Assertions.assertTrue(new AcceptHeaderParser("text/plain").willAcceptText());
-        Assertions.assertTrue(
-                new AcceptHeaderParser("text/html")
-                        .willAccept(AcceptHeaderParser.ACCEPT_TYPE.HTML));
-        Assertions.assertTrue(
-                new AcceptHeaderParser("application/x-ndjson")
-                        .willAccept(AcceptHeaderParser.ACCEPT_TYPE.NDJSON));
-        Assertions.assertTrue(
-                new AcceptHeaderParser("application/jsonl")
-                        .willAccept(AcceptHeaderParser.ACCEPT_TYPE.JSONL));
-        Assertions.assertTrue(
-                new AcceptHeaderParser("application/json-seq")
-                        .willAccept(AcceptHeaderParser.ACCEPT_TYPE.JSON_SEQ));
-        Assertions.assertTrue(
-                new AcceptHeaderParser("text/tab-separated-values")
-                        .willAccept(AcceptHeaderParser.ACCEPT_TYPE.TSV));
-        Assertions.assertTrue(
-                new AcceptHeaderParser("text/xml")
-                        .willAccept(AcceptHeaderParser.ACCEPT_TYPE.TEXT_XML));
+    @ParameterizedTest
+    @MethodSource("additionalResponseRepresentationExamples")
+    public void willAcceptAdditionalResponseRepresentation(
+            final String acceptHeader, final AcceptHeaderParser.ACCEPT_TYPE expectedType) {
+        Assertions.assertTrue(new AcceptHeaderParser(acceptHeader).willAccept(expectedType));
     }
 
     @Test
@@ -283,22 +265,15 @@ public class AcceptHeaderParserTest {
                         .mediaType());
     }
 
-    @Test
-    public void unsupportedXmlBasedMediaTypesAreNotNormalXmlRepresentations() {
-        for (String mediaType :
-                List.of(
-                        "application/problem+xml",
-                        "application/soap+xml",
-                        "application/xhtml+xml",
-                        "image/svg+xml",
-                        "application/atom+xml",
-                        "application/rss+xml")) {
-            final AcceptHeaderParser accept = new AcceptHeaderParser(mediaType);
+    @ParameterizedTest
+    @MethodSource("unsupportedXmlMediaTypes")
+    public void unsupportedXmlBasedMediaTypesAreNotNormalXmlRepresentations(
+            final String mediaType) {
+        final AcceptHeaderParser accept = new AcceptHeaderParser(mediaType);
 
-            Assertions.assertFalse(accept.isSupportedHeader(), mediaType);
-            Assertions.assertFalse(accept.willAcceptXml(), mediaType);
-            Assertions.assertTrue(accept.getSupportedTypesInPreferenceOrder().isEmpty(), mediaType);
-        }
+        Assertions.assertFalse(accept.isSupportedHeader(), mediaType);
+        Assertions.assertFalse(accept.willAcceptXml(), mediaType);
+        Assertions.assertTrue(accept.getSupportedTypesInPreferenceOrder().isEmpty(), mediaType);
     }
 
     @Test
@@ -349,13 +324,17 @@ public class AcceptHeaderParserTest {
     }
 
     @Test
-    public void qValuesSelectBetweenXmlCompatibleMediaTypes() {
+    public void qValuesSelectExactStructuredXmlOverOtherXmlCompatibleMediaTypes() {
         assertPreferredMediaType(
                 "application/json;q=0.5, "
                         + "application/xml;q=0.6, "
                         + "text/xml;q=0.8, "
                         + "application/vnd.example.todo+xml;q=0.9",
                 "application/vnd.example.todo+xml");
+    }
+
+    @Test
+    public void qValuesSelectStructuredXmlWildcardOverOtherXmlCompatibleMediaTypes() {
         assertPreferredMediaType(
                 "application/json;q=0.5, "
                         + "application/xml;q=0.6, "
@@ -364,41 +343,36 @@ public class AcceptHeaderParserTest {
                 "application/todo+xml");
     }
 
-    @Test
-    public void unsupportedHigherQualityMediaRangesFallThroughToSupportedTypes() {
-        assertPreferredMediaType("application/problem+xml;q=1, text/xml;q=0.4", "text/xml");
-        assertPreferredMediaType(
-                "application/soap+xml;q=1, application/*+xml;q=0.4", "application/todo+xml");
-        assertPreferredMediaType(
-                "application/problem+json;q=1, application/vnd.example.todo+xml;q=0.4",
-                "application/vnd.example.todo+xml");
+    @ParameterizedTest
+    @MethodSource("unsupportedHigherQualityFallbackExamples")
+    public void unsupportedHigherQualityMediaRangesFallThroughToSupportedTypes(
+            final String acceptHeader, final String expectedMediaType) {
+        assertPreferredMediaType(acceptHeader, expectedMediaType);
+    }
+
+    @ParameterizedTest
+    @MethodSource("specificityTieBreakerExamples")
+    public void specificityBeatsHeaderOrderWhenQualityValuesTie(
+            final String acceptHeader, final String expectedMediaType) {
+        assertPreferredMediaType(acceptHeader, expectedMediaType);
+    }
+
+    @ParameterizedTest
+    @MethodSource("clientOrderTieBreakerExamples")
+    public void clientOrderBreaksTiesWhenQualityAndSpecificityAreTheSame(
+            final String acceptHeader, final String expectedMediaType) {
+        assertPreferredMediaType(acceptHeader, expectedMediaType);
+    }
+
+    @ParameterizedTest
+    @MethodSource("qZeroWildcardFallbackExamples")
+    public void qZeroExcludesExactXmlCompatibleMediaTypeBeforeWildcardFallback(
+            final String acceptHeader, final String expectedMediaType) {
+        assertPreferredMediaType(acceptHeader, expectedMediaType);
     }
 
     @Test
-    public void specificityBeatsHeaderOrderWhenQualityValuesTie() {
-        assertPreferredMediaType("application/*;q=0.8, application/xml;q=0.8", "application/xml");
-        assertPreferredMediaType("text/*;q=0.8, text/xml;q=0.8", "text/xml");
-        assertPreferredMediaType(
-                "application/*+xml;q=0.8, application/vnd.example.todo+xml;q=0.8",
-                "application/vnd.example.todo+xml");
-    }
-
-    @Test
-    public void clientOrderBreaksTiesWhenQualityAndSpecificityAreTheSame() {
-        assertPreferredMediaType("text/xml;q=0.8, application/xml;q=0.8", "text/xml");
-        assertPreferredMediaType("application/xml;q=0.8, text/xml;q=0.8", "application/xml");
-        assertPreferredMediaType(
-                "application/vnd.example.todo+xml;q=0.8, text/xml;q=0.8",
-                "application/vnd.example.todo+xml");
-        assertPreferredMediaType(
-                "text/xml;q=0.8, application/vnd.example.todo+xml;q=0.8", "text/xml");
-    }
-
-    @Test
-    public void qZeroExcludesExactXmlCompatibleMediaTypesBeforeWildcardFallback() {
-        assertPreferredMediaType("text/xml;q=0, text/*;q=0.8", "text/csv");
-        assertPreferredMediaType("application/xml;q=0, application/*;q=0.8", "application/json");
-
+    public void qZeroStructuredXmlExactMatchBlocksStructuredXmlWildcardFallback() {
         final AcceptHeaderParser structuredXml =
                 new AcceptHeaderParser("application/todo+xml;q=0, application/*+xml;q=0.8");
 
@@ -459,11 +433,10 @@ public class AcceptHeaderParserTest {
         Assertions.assertTrue(accept.willAcceptJson());
     }
 
-    @Test
-    public void concreteStructuredJsonTypesDoNotMatchPlainJson() {
-        Assertions.assertFalse(new AcceptHeaderParser("application/problem+json").willAcceptJson());
-        Assertions.assertFalse(new AcceptHeaderParser("application/vnd.api+json").willAcceptJson());
-        Assertions.assertFalse(new AcceptHeaderParser("application/hal+json").willAcceptJson());
+    @ParameterizedTest
+    @MethodSource("unsupportedStructuredJsonMediaTypes")
+    public void concreteStructuredJsonTypesDoNotMatchPlainJson(final String mediaType) {
+        Assertions.assertFalse(new AcceptHeaderParser(mediaType).willAcceptJson());
     }
 
     @Test
@@ -546,5 +519,70 @@ public class AcceptHeaderParserTest {
                 Arguments.of(
                         "application/gzip;q=1, application/json;q=0.5",
                         AcceptHeaderParser.ACCEPT_TYPE.JSON));
+    }
+
+    private static Stream<Arguments> additionalResponseRepresentationExamples() {
+        return Stream.of(
+                Arguments.of("text/csv", AcceptHeaderParser.ACCEPT_TYPE.CSV),
+                Arguments.of("text/plain", AcceptHeaderParser.ACCEPT_TYPE.TEXT),
+                Arguments.of("text/html", AcceptHeaderParser.ACCEPT_TYPE.HTML),
+                Arguments.of("application/x-ndjson", AcceptHeaderParser.ACCEPT_TYPE.NDJSON),
+                Arguments.of("application/jsonl", AcceptHeaderParser.ACCEPT_TYPE.JSONL),
+                Arguments.of("application/json-seq", AcceptHeaderParser.ACCEPT_TYPE.JSON_SEQ),
+                Arguments.of("text/tab-separated-values", AcceptHeaderParser.ACCEPT_TYPE.TSV),
+                Arguments.of("text/xml", AcceptHeaderParser.ACCEPT_TYPE.TEXT_XML));
+    }
+
+    private static Stream<Arguments> unsupportedXmlMediaTypes() {
+        return Stream.of(
+                Arguments.of("application/problem+xml"),
+                Arguments.of("application/soap+xml"),
+                Arguments.of("application/xhtml+xml"),
+                Arguments.of("image/svg+xml"),
+                Arguments.of("application/atom+xml"),
+                Arguments.of("application/rss+xml"));
+    }
+
+    private static Stream<Arguments> unsupportedHigherQualityFallbackExamples() {
+        return Stream.of(
+                Arguments.of("application/problem+xml;q=1, text/xml;q=0.4", "text/xml"),
+                Arguments.of(
+                        "application/soap+xml;q=1, application/*+xml;q=0.4",
+                        "application/todo+xml"),
+                Arguments.of(
+                        "application/problem+json;q=1, application/vnd.example.todo+xml;q=0.4",
+                        "application/vnd.example.todo+xml"));
+    }
+
+    private static Stream<Arguments> specificityTieBreakerExamples() {
+        return Stream.of(
+                Arguments.of("application/*;q=0.8, application/xml;q=0.8", "application/xml"),
+                Arguments.of("text/*;q=0.8, text/xml;q=0.8", "text/xml"),
+                Arguments.of(
+                        "application/*+xml;q=0.8, application/vnd.example.todo+xml;q=0.8",
+                        "application/vnd.example.todo+xml"));
+    }
+
+    private static Stream<Arguments> clientOrderTieBreakerExamples() {
+        return Stream.of(
+                Arguments.of("text/xml;q=0.8, application/xml;q=0.8", "text/xml"),
+                Arguments.of("application/xml;q=0.8, text/xml;q=0.8", "application/xml"),
+                Arguments.of(
+                        "application/vnd.example.todo+xml;q=0.8, text/xml;q=0.8",
+                        "application/vnd.example.todo+xml"),
+                Arguments.of("text/xml;q=0.8, application/vnd.example.todo+xml;q=0.8", "text/xml"));
+    }
+
+    private static Stream<Arguments> qZeroWildcardFallbackExamples() {
+        return Stream.of(
+                Arguments.of("text/xml;q=0, text/*;q=0.8", "text/csv"),
+                Arguments.of("application/xml;q=0, application/*;q=0.8", "application/json"));
+    }
+
+    private static Stream<Arguments> unsupportedStructuredJsonMediaTypes() {
+        return Stream.of(
+                Arguments.of("application/problem+json"),
+                Arguments.of("application/vnd.api+json"),
+                Arguments.of("application/hal+json"));
     }
 }

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/AcceptHeaderParserTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/AcceptHeaderParserTest.java
@@ -252,7 +252,8 @@ public class AcceptHeaderParserTest {
 
     @Test
     public void modelMatchingStructuredXmlMediaTypeNegotiatesToXmlRepresentation() {
-        final AcceptHeaderParser vendorXml = new AcceptHeaderParser("application/vnd.example.todo+xml");
+        final AcceptHeaderParser vendorXml =
+                new AcceptHeaderParser("application/vnd.example.todo+xml");
 
         Assertions.assertFalse(vendorXml.isSupportedHeader());
         Assertions.assertTrue(vendorXml.isSupportedHeader(List.of("todo", "todos")));
@@ -311,8 +312,7 @@ public class AcceptHeaderParserTest {
 
         Assertions.assertEquals(
                 "text/xml",
-                accept
-                        .preferredSupportedMediaType(
+                accept.preferredSupportedMediaType(
                                 AcceptHeaderParser.ACCEPT_TYPE.responseMediaTypes(),
                                 AcceptHeaderParser.ACCEPT_TYPE.JSON,
                                 List.of("todo", "todos"))
@@ -331,9 +331,7 @@ public class AcceptHeaderParserTest {
     @MethodSource("issue103QualityValueExamples")
     public void issue103ExamplesNegotiateSupportedTypesByQualityValues(
             final String acceptHeader, final AcceptHeaderParser.ACCEPT_TYPE expectedType) {
-        assertPreferredType(
-                acceptHeader,
-                expectedType);
+        assertPreferredType(acceptHeader, expectedType);
     }
 
     @Test
@@ -368,12 +366,9 @@ public class AcceptHeaderParserTest {
 
     @Test
     public void unsupportedHigherQualityMediaRangesFallThroughToSupportedTypes() {
+        assertPreferredMediaType("application/problem+xml;q=1, text/xml;q=0.4", "text/xml");
         assertPreferredMediaType(
-                "application/problem+xml;q=1, text/xml;q=0.4",
-                "text/xml");
-        assertPreferredMediaType(
-                "application/soap+xml;q=1, application/*+xml;q=0.4",
-                "application/todo+xml");
+                "application/soap+xml;q=1, application/*+xml;q=0.4", "application/todo+xml");
         assertPreferredMediaType(
                 "application/problem+json;q=1, application/vnd.example.todo+xml;q=0.4",
                 "application/vnd.example.todo+xml");
@@ -381,12 +376,8 @@ public class AcceptHeaderParserTest {
 
     @Test
     public void specificityBeatsHeaderOrderWhenQualityValuesTie() {
-        assertPreferredMediaType(
-                "application/*;q=0.8, application/xml;q=0.8",
-                "application/xml");
-        assertPreferredMediaType(
-                "text/*;q=0.8, text/xml;q=0.8",
-                "text/xml");
+        assertPreferredMediaType("application/*;q=0.8, application/xml;q=0.8", "application/xml");
+        assertPreferredMediaType("text/*;q=0.8, text/xml;q=0.8", "text/xml");
         assertPreferredMediaType(
                 "application/*+xml;q=0.8, application/vnd.example.todo+xml;q=0.8",
                 "application/vnd.example.todo+xml");
@@ -394,28 +385,19 @@ public class AcceptHeaderParserTest {
 
     @Test
     public void clientOrderBreaksTiesWhenQualityAndSpecificityAreTheSame() {
-        assertPreferredMediaType(
-                "text/xml;q=0.8, application/xml;q=0.8",
-                "text/xml");
-        assertPreferredMediaType(
-                "application/xml;q=0.8, text/xml;q=0.8",
-                "application/xml");
+        assertPreferredMediaType("text/xml;q=0.8, application/xml;q=0.8", "text/xml");
+        assertPreferredMediaType("application/xml;q=0.8, text/xml;q=0.8", "application/xml");
         assertPreferredMediaType(
                 "application/vnd.example.todo+xml;q=0.8, text/xml;q=0.8",
                 "application/vnd.example.todo+xml");
         assertPreferredMediaType(
-                "text/xml;q=0.8, application/vnd.example.todo+xml;q=0.8",
-                "text/xml");
+                "text/xml;q=0.8, application/vnd.example.todo+xml;q=0.8", "text/xml");
     }
 
     @Test
     public void qZeroExcludesExactXmlCompatibleMediaTypesBeforeWildcardFallback() {
-        assertPreferredMediaType(
-                "text/xml;q=0, text/*;q=0.8",
-                "text/csv");
-        assertPreferredMediaType(
-                "application/xml;q=0, application/*;q=0.8",
-                "application/json");
+        assertPreferredMediaType("text/xml;q=0, text/*;q=0.8", "text/csv");
+        assertPreferredMediaType("application/xml;q=0, application/*;q=0.8", "application/json");
 
         final AcceptHeaderParser structuredXml =
                 new AcceptHeaderParser("application/todo+xml;q=0, application/*+xml;q=0.8");
@@ -535,8 +517,7 @@ public class AcceptHeaderParserTest {
         Assertions.assertTrue(accept.isSupportedHeader(List.of("todo", "todos")), acceptHeader);
         Assertions.assertEquals(
                 mediaType,
-                accept
-                        .preferredSupportedMediaType(
+                accept.preferredSupportedMediaType(
                                 AcceptHeaderParser.ACCEPT_TYPE.responseMediaTypes(),
                                 AcceptHeaderParser.ACCEPT_TYPE.JSON,
                                 List.of("todo", "todos"))
@@ -561,8 +542,7 @@ public class AcceptHeaderParserTest {
                         "application/xml, application/json;q=0.5",
                         AcceptHeaderParser.ACCEPT_TYPE.XML),
                 Arguments.of(
-                        "*/*;q=0.8, application/xml;q=0.9",
-                        AcceptHeaderParser.ACCEPT_TYPE.XML),
+                        "*/*;q=0.8, application/xml;q=0.9", AcceptHeaderParser.ACCEPT_TYPE.XML),
                 Arguments.of(
                         "application/gzip;q=1, application/json;q=0.5",
                         AcceptHeaderParser.ACCEPT_TYPE.JSON));

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/bodyparser/BodyParserTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/bodyparser/BodyParserTest.java
@@ -144,6 +144,42 @@ public class BodyParserTest {
     }
 
     @Test
+    public void simpleVendorXmlParseErrorMessage() {
+
+        HttpApiRequest request = new HttpApiRequest("/estimates");
+        request.setHeaders(
+                Map.of("content-type", "application/vnd.example.estimate+xml; charset=utf-8"));
+        request.setBody("<estimate><duration>5</duration>");
+
+        List<String> names = new ArrayList<>();
+
+        names.add("estimate");
+
+        final String validated = new BodyParser(request, names).validBodyBasedOnContentType();
+
+        Assertions.assertEquals(
+                "Invalid XML Payload: Unclosed tag estimate at 32 [character 33 line 1]",
+                validated);
+    }
+
+    @Test
+    public void unsupportedXmlBasedContentTypeIsNotParsedAsXml() {
+
+        HttpApiRequest request = new HttpApiRequest("/estimates");
+        request.setHeaders(Map.of("content-type", "application/problem+xml"));
+        request.setBody("<estimate><duration>5</duration></estimate>");
+
+        List<String> names = new ArrayList<>();
+
+        names.add("estimate");
+
+        final String validated = new BodyParser(request, names).validBodyBasedOnContentType();
+
+        Assertions.assertEquals(
+                "Unknown content Type: API cannot parse application/problem+xml", validated);
+    }
+
+    @Test
     public void simpleUnknownContentParseErrorMessage() {
 
         HttpApiRequest request = new HttpApiRequest("/estimates");
@@ -302,6 +338,38 @@ public class BodyParserTest {
         Assertions.assertEquals("estimate", objects.get(0));
 
         // estimate is a LinkedTreeMap
+    }
+
+    @Test
+    public void embeddedCollectionOfObjectFromVendorXML() {
+
+        HttpApiRequest request = new HttpApiRequest("/estimates");
+        request.addHeader("Content-Type", "application/vnd.example.estimate+xml");
+        request.setBody(
+                "<estimate><duration>5</duration><estimate><todo><guid>1234567890</guid></todo></estimate></estimate>");
+
+        List<String> names = new ArrayList<>();
+
+        names.add("estimate");
+
+        final BodyParser bodyParser = new BodyParser(request, names);
+
+        final Map<String, String> valuesmap = bodyParser.getStringMap();
+
+        Assertions.assertEquals(1, valuesmap.keySet().size());
+        Assertions.assertTrue(valuesmap.keySet().contains("duration"));
+        Assertions.assertEquals("5.0", valuesmap.get("duration"));
+
+        final Map<String, Object> map = bodyParser.getMap();
+
+        Assertions.assertEquals(2, map.keySet().size());
+        Assertions.assertTrue(map.keySet().contains("duration"));
+        Assertions.assertEquals(5.0, map.get("duration"));
+        Assertions.assertTrue(map.keySet().contains("estimate"));
+
+        final List<String> objects = bodyParser.getObjectNames();
+        Assertions.assertEquals(1, objects.size());
+        Assertions.assertEquals("estimate", objects.get(0));
     }
 
     @Test

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/ContentTypeHeaderParserTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/ContentTypeHeaderParserTest.java
@@ -1,10 +1,50 @@
 package uk.co.compendiumdev.thingifier.api.http.headers.headerparser;
 
+import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierHttpApi;
 
 class ContentTypeHeaderParserTest {
+
+    @Test
+    void recognizesSupportedXmlMediaTypes() {
+        for (String mediaType : List.of("application/xml", "text/xml")) {
+            Assertions.assertTrue(new ContentTypeHeaderParser(mediaType).isXML(), mediaType);
+        }
+    }
+
+    @Test
+    void recognizesModelMatchingStructuredXmlMediaTypes() {
+        for (String mediaType :
+                List.of(
+                        "application/todo+xml",
+                        "application/todos+xml",
+                        "application/vnd.example.todo+xml",
+                        "application/vnd.example.todo+xml; charset=utf-8")) {
+            Assertions.assertTrue(
+                    new ContentTypeHeaderParser(mediaType).isXML(List.of("todo", "todos")),
+                    mediaType);
+        }
+    }
+
+    @Test
+    void doesNotTreatUnsupportedXmlBasedMediaTypesAsNormalXml() {
+        for (String mediaType :
+                List.of(
+                        "application/vnd.example.project+xml",
+                        "application/problem+xml",
+                        "application/soap+xml",
+                        "application/xhtml+xml",
+                        "image/svg+xml",
+                        "application/atom+xml",
+                        "application/rss+xml",
+                        "application/*+xml")) {
+            Assertions.assertFalse(
+                    new ContentTypeHeaderParser(mediaType).isXML(List.of("todo", "todos")),
+                    mediaType);
+        }
+    }
 
     @Test
     void recognizesThingifierStructuredQueryJsonMediaType() {

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/ContentTypeHeaderParserTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/ContentTypeHeaderParserTest.java
@@ -1,49 +1,33 @@
 package uk.co.compendiumdev.thingifier.api.http.headers.headerparser;
 
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierHttpApi;
 
 class ContentTypeHeaderParserTest {
 
-    @Test
-    void recognizesSupportedXmlMediaTypes() {
-        for (String mediaType : List.of("application/xml", "text/xml")) {
-            Assertions.assertTrue(new ContentTypeHeaderParser(mediaType).isXML(), mediaType);
-        }
+    @ParameterizedTest
+    @MethodSource("supportedXmlMediaTypes")
+    void recognizesSupportedXmlMediaType(final String mediaType) {
+        Assertions.assertTrue(new ContentTypeHeaderParser(mediaType).isXML(), mediaType);
     }
 
-    @Test
-    void recognizesModelMatchingStructuredXmlMediaTypes() {
-        for (String mediaType :
-                List.of(
-                        "application/todo+xml",
-                        "application/todos+xml",
-                        "application/vnd.example.todo+xml",
-                        "application/vnd.example.todo+xml; charset=utf-8")) {
-            Assertions.assertTrue(
-                    new ContentTypeHeaderParser(mediaType).isXML(List.of("todo", "todos")),
-                    mediaType);
-        }
+    @ParameterizedTest
+    @MethodSource("modelMatchingStructuredXmlMediaTypes")
+    void recognizesModelMatchingStructuredXmlMediaType(final String mediaType) {
+        Assertions.assertTrue(
+                new ContentTypeHeaderParser(mediaType).isXML(List.of("todo", "todos")), mediaType);
     }
 
-    @Test
-    void doesNotTreatUnsupportedXmlBasedMediaTypesAsNormalXml() {
-        for (String mediaType :
-                List.of(
-                        "application/vnd.example.project+xml",
-                        "application/problem+xml",
-                        "application/soap+xml",
-                        "application/xhtml+xml",
-                        "image/svg+xml",
-                        "application/atom+xml",
-                        "application/rss+xml",
-                        "application/*+xml")) {
-            Assertions.assertFalse(
-                    new ContentTypeHeaderParser(mediaType).isXML(List.of("todo", "todos")),
-                    mediaType);
-        }
+    @ParameterizedTest
+    @MethodSource("unsupportedXmlBasedMediaTypes")
+    void doesNotTreatUnsupportedXmlBasedMediaTypeAsNormalXml(final String mediaType) {
+        Assertions.assertFalse(
+                new ContentTypeHeaderParser(mediaType).isXML(List.of("todo", "todos")), mediaType);
     }
 
     @Test
@@ -62,5 +46,29 @@ class ContentTypeHeaderParserTest {
                         "application/vnd.apichallenges." + "todo-" + "query+json");
 
         Assertions.assertFalse(parser.isStructuredQueryJson());
+    }
+
+    private static Stream<String> supportedXmlMediaTypes() {
+        return Stream.of("application/xml", "text/xml");
+    }
+
+    private static Stream<String> modelMatchingStructuredXmlMediaTypes() {
+        return Stream.of(
+                "application/todo+xml",
+                "application/todos+xml",
+                "application/vnd.example.todo+xml",
+                "application/vnd.example.todo+xml; charset=utf-8");
+    }
+
+    private static Stream<String> unsupportedXmlBasedMediaTypes() {
+        return Stream.of(
+                "application/vnd.example.project+xml",
+                "application/problem+xml",
+                "application/soap+xml",
+                "application/xhtml+xml",
+                "image/svg+xml",
+                "application/atom+xml",
+                "application/rss+xml",
+                "application/*+xml");
     }
 }

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/headers/headervalidator/AcceptHeaderValidatorTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/headers/headervalidator/AcceptHeaderValidatorTest.java
@@ -1,45 +1,42 @@
 package uk.co.compendiumdev.thingifier.api.http.headers.headervalidator;
 
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
 import uk.co.compendiumdev.thingifier.apiconfig.ThingifierApiConfig;
 
 class AcceptHeaderValidatorTest {
 
-    @Test
-    void acceptsAdditionalResponseRepresentations() {
+    @ParameterizedTest
+    @MethodSource("additionalResponseRepresentationMediaTypes")
+    void acceptsAdditionalResponseRepresentation(final String mediaType) {
         ThingifierApiConfig config = new ThingifierApiConfig("");
         AcceptHeaderValidator validator = new AcceptHeaderValidator(config);
 
-        Assertions.assertNull(validator.validate("text/csv"));
-        Assertions.assertNull(validator.validate("text/plain"));
-        Assertions.assertNull(validator.validate("text/html"));
-        Assertions.assertNull(validator.validate("application/x-ndjson"));
-        Assertions.assertNull(validator.validate("application/jsonl"));
-        Assertions.assertNull(validator.validate("application/json-seq"));
-        Assertions.assertNull(validator.validate("text/tab-separated-values"));
-        Assertions.assertNull(validator.validate("text/*"));
+        Assertions.assertNull(validator.validate(mediaType));
     }
 
-    @Test
-    void acceptsXmlCompatibleResponseRepresentations() {
+    @ParameterizedTest
+    @MethodSource("xmlCompatibleResponseMediaTypes")
+    void acceptsXmlCompatibleResponseRepresentation(final String mediaType) {
         ThingifierApiConfig config = new ThingifierApiConfig("");
         AcceptHeaderValidator validator = new AcceptHeaderValidator(config);
 
-        Assertions.assertNull(validator.validate("application/xml"));
-        Assertions.assertNull(validator.validate("text/xml"));
+        Assertions.assertNull(validator.validate(mediaType));
     }
 
-    @Test
-    void acceptsModelMatchingStructuredXmlResponseRepresentations() {
+    @ParameterizedTest
+    @MethodSource("modelMatchingStructuredXmlResponseMediaTypes")
+    void acceptsModelMatchingStructuredXmlResponseRepresentation(final String mediaType) {
         ThingifierApiConfig config = new ThingifierApiConfig("");
         AcceptHeaderValidator validator =
                 new AcceptHeaderValidator(config, List.of("todo", "todos"));
 
-        Assertions.assertNull(validator.validate("application/vnd.example.todo+xml"));
-        Assertions.assertNull(validator.validate("application/*+xml"));
+        Assertions.assertNull(validator.validate(mediaType));
     }
 
     @Test
@@ -85,41 +82,31 @@ class AcceptHeaderValidatorTest {
         Assertions.assertTrue(response.getErrorMessages().contains("Unrecognised Accept Type"));
     }
 
-    @Test
-    void rejectsUnsupportedXmlBasedMediaTypes() {
+    @ParameterizedTest
+    @MethodSource("unsupportedXmlMediaTypes")
+    void rejectsUnsupportedXmlBasedMediaType(final String mediaType) {
         ThingifierApiConfig config = new ThingifierApiConfig("");
         AcceptHeaderValidator validator = new AcceptHeaderValidator(config);
 
-        for (String mediaType :
-                List.of(
-                        "application/problem+xml",
-                        "application/soap+xml",
-                        "application/xhtml+xml",
-                        "image/svg+xml",
-                        "application/atom+xml",
-                        "application/rss+xml")) {
-            ApiResponse response = validator.validate(mediaType);
+        ApiResponse response = validator.validate(mediaType);
 
-            Assertions.assertEquals(406, response.getStatusCode(), mediaType);
-            Assertions.assertTrue(
-                    response.getErrorMessages().contains("Unrecognised Accept Type"), mediaType);
-        }
+        Assertions.assertEquals(406, response.getStatusCode(), mediaType);
+        Assertions.assertTrue(
+                response.getErrorMessages().contains("Unrecognised Accept Type"), mediaType);
     }
 
-    @Test
-    void xmlCompatibleResponseTypesHonorDisabledXmlResponses() {
+    @ParameterizedTest
+    @MethodSource("xmlResponseMediaTypes")
+    void xmlCompatibleResponseTypeHonorsDisabledXmlResponses(final String mediaType) {
         ThingifierApiConfig config = new ThingifierApiConfig("");
         config.setApiToAllowXmlForResponses(false);
         AcceptHeaderValidator validator =
                 new AcceptHeaderValidator(config, List.of("todo", "todos"));
 
-        for (String mediaType :
-                List.of("application/xml", "text/xml", "application/vnd.example.todo+xml")) {
-            ApiResponse response = validator.validate(mediaType);
+        ApiResponse response = validator.validate(mediaType);
 
-            Assertions.assertEquals(406, response.getStatusCode(), mediaType);
-            Assertions.assertTrue(response.getErrorMessages().contains("XML not supported"));
-        }
+        Assertions.assertEquals(406, response.getStatusCode(), mediaType);
+        Assertions.assertTrue(response.getErrorMessages().contains("XML not supported"));
     }
 
     @Test
@@ -162,5 +149,39 @@ class AcceptHeaderValidatorTest {
         ApiResponse response = new AcceptHeaderValidator(config).validate("application/json-seq");
 
         Assertions.assertNull(response);
+    }
+
+    private static Stream<String> additionalResponseRepresentationMediaTypes() {
+        return Stream.of(
+                "text/csv",
+                "text/plain",
+                "text/html",
+                "application/x-ndjson",
+                "application/jsonl",
+                "application/json-seq",
+                "text/tab-separated-values",
+                "text/*");
+    }
+
+    private static Stream<String> xmlCompatibleResponseMediaTypes() {
+        return Stream.of("application/xml", "text/xml");
+    }
+
+    private static Stream<String> modelMatchingStructuredXmlResponseMediaTypes() {
+        return Stream.of("application/vnd.example.todo+xml", "application/*+xml");
+    }
+
+    private static Stream<String> unsupportedXmlMediaTypes() {
+        return Stream.of(
+                "application/problem+xml",
+                "application/soap+xml",
+                "application/xhtml+xml",
+                "image/svg+xml",
+                "application/atom+xml",
+                "application/rss+xml");
+    }
+
+    private static Stream<String> xmlResponseMediaTypes() {
+        return Stream.of("application/xml", "text/xml", "application/vnd.example.todo+xml");
     }
 }

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/headers/headervalidator/AcceptHeaderValidatorTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/headers/headervalidator/AcceptHeaderValidatorTest.java
@@ -1,5 +1,6 @@
 package uk.co.compendiumdev.thingifier.api.http.headers.headervalidator;
 
+import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
@@ -20,6 +21,25 @@ class AcceptHeaderValidatorTest {
         Assertions.assertNull(validator.validate("application/json-seq"));
         Assertions.assertNull(validator.validate("text/tab-separated-values"));
         Assertions.assertNull(validator.validate("text/*"));
+    }
+
+    @Test
+    void acceptsXmlCompatibleResponseRepresentations() {
+        ThingifierApiConfig config = new ThingifierApiConfig("");
+        AcceptHeaderValidator validator = new AcceptHeaderValidator(config);
+
+        Assertions.assertNull(validator.validate("application/xml"));
+        Assertions.assertNull(validator.validate("text/xml"));
+    }
+
+    @Test
+    void acceptsModelMatchingStructuredXmlResponseRepresentations() {
+        ThingifierApiConfig config = new ThingifierApiConfig("");
+        AcceptHeaderValidator validator =
+                new AcceptHeaderValidator(config, List.of("todo", "todos"));
+
+        Assertions.assertNull(validator.validate("application/vnd.example.todo+xml"));
+        Assertions.assertNull(validator.validate("application/*+xml"));
     }
 
     @Test
@@ -63,6 +83,43 @@ class AcceptHeaderValidatorTest {
 
         Assertions.assertEquals(406, response.getStatusCode());
         Assertions.assertTrue(response.getErrorMessages().contains("Unrecognised Accept Type"));
+    }
+
+    @Test
+    void rejectsUnsupportedXmlBasedMediaTypes() {
+        ThingifierApiConfig config = new ThingifierApiConfig("");
+        AcceptHeaderValidator validator = new AcceptHeaderValidator(config);
+
+        for (String mediaType :
+                List.of(
+                        "application/problem+xml",
+                        "application/soap+xml",
+                        "application/xhtml+xml",
+                        "image/svg+xml",
+                        "application/atom+xml",
+                        "application/rss+xml")) {
+            ApiResponse response = validator.validate(mediaType);
+
+            Assertions.assertEquals(406, response.getStatusCode(), mediaType);
+            Assertions.assertTrue(
+                    response.getErrorMessages().contains("Unrecognised Accept Type"),
+                    mediaType);
+        }
+    }
+
+    @Test
+    void xmlCompatibleResponseTypesHonorDisabledXmlResponses() {
+        ThingifierApiConfig config = new ThingifierApiConfig("");
+        config.setApiToAllowXmlForResponses(false);
+        AcceptHeaderValidator validator = new AcceptHeaderValidator(config, List.of("todo", "todos"));
+
+        for (String mediaType :
+                List.of("application/xml", "text/xml", "application/vnd.example.todo+xml")) {
+            ApiResponse response = validator.validate(mediaType);
+
+            Assertions.assertEquals(406, response.getStatusCode(), mediaType);
+            Assertions.assertTrue(response.getErrorMessages().contains("XML not supported"));
+        }
     }
 
     @Test

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/headers/headervalidator/AcceptHeaderValidatorTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/headers/headervalidator/AcceptHeaderValidatorTest.java
@@ -102,8 +102,7 @@ class AcceptHeaderValidatorTest {
 
             Assertions.assertEquals(406, response.getStatusCode(), mediaType);
             Assertions.assertTrue(
-                    response.getErrorMessages().contains("Unrecognised Accept Type"),
-                    mediaType);
+                    response.getErrorMessages().contains("Unrecognised Accept Type"), mediaType);
         }
     }
 
@@ -111,7 +110,8 @@ class AcceptHeaderValidatorTest {
     void xmlCompatibleResponseTypesHonorDisabledXmlResponses() {
         ThingifierApiConfig config = new ThingifierApiConfig("");
         config.setApiToAllowXmlForResponses(false);
-        AcceptHeaderValidator validator = new AcceptHeaderValidator(config, List.of("todo", "todos"));
+        AcceptHeaderValidator validator =
+                new AcceptHeaderValidator(config, List.of("todo", "todos"));
 
         for (String mediaType :
                 List.of("application/xml", "text/xml", "application/vnd.example.todo+xml")) {

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/headers/headervalidator/ContentTypeHeaderValidatorTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/headers/headervalidator/ContentTypeHeaderValidatorTest.java
@@ -1,71 +1,86 @@
 package uk.co.compendiumdev.thingifier.api.http.headers.headervalidator;
 
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
 import uk.co.compendiumdev.thingifier.apiconfig.ThingifierApiConfig;
 
 class ContentTypeHeaderValidatorTest {
 
-    @Test
-    void acceptsSupportedXmlContentTypes() {
+    @ParameterizedTest
+    @MethodSource("supportedXmlContentTypes")
+    void acceptsSupportedXmlContentType(final String contentType) {
         ThingifierApiConfig config = new ThingifierApiConfig("");
         ContentTypeHeaderValidator validator =
                 new ContentTypeHeaderValidator(config, List.of("todo", "todos"));
 
-        Assertions.assertNull(validator.validate("application/xml"));
-        Assertions.assertNull(validator.validate("text/xml"));
+        Assertions.assertNull(validator.validate(contentType));
     }
 
-    @Test
-    void acceptsModelMatchingStructuredXmlContentTypes() {
+    @ParameterizedTest
+    @MethodSource("modelMatchingStructuredXmlContentTypes")
+    void acceptsModelMatchingStructuredXmlContentType(final String contentType) {
         ThingifierApiConfig config = new ThingifierApiConfig("");
         ContentTypeHeaderValidator validator =
                 new ContentTypeHeaderValidator(config, List.of("todo", "todos"));
 
-        Assertions.assertNull(validator.validate("application/vnd.example.todo+xml"));
-        Assertions.assertNull(
-                validator.validate("application/vnd.example.todo+xml; charset=utf-8"));
+        Assertions.assertNull(validator.validate(contentType));
     }
 
-    @Test
-    void rejectsUnsupportedXmlBasedContentTypes() {
+    @ParameterizedTest
+    @MethodSource("unsupportedXmlBasedContentTypes")
+    void rejectsUnsupportedXmlBasedContentType(final String mediaType) {
         ThingifierApiConfig config = new ThingifierApiConfig("");
         ContentTypeHeaderValidator validator = new ContentTypeHeaderValidator(config);
 
-        for (String mediaType :
-                List.of(
-                        "application/problem+xml",
-                        "application/soap+xml",
-                        "application/xhtml+xml",
-                        "image/svg+xml",
-                        "application/atom+xml",
-                        "application/rss+xml",
-                        "application/*+xml")) {
-            ApiResponse response = validator.validate(mediaType);
+        ApiResponse response = validator.validate(mediaType);
 
-            Assertions.assertEquals(415, response.getStatusCode(), mediaType);
-            Assertions.assertTrue(
-                    response.getErrorMessages().contains("Unsupported Content Type - " + mediaType),
-                    mediaType);
-        }
+        Assertions.assertEquals(415, response.getStatusCode(), mediaType);
+        Assertions.assertTrue(
+                response.getErrorMessages().contains("Unsupported Content Type - " + mediaType),
+                mediaType);
     }
 
-    @Test
-    void textXmlDoesNotBypassDisabledXmlContentValidation() {
+    @ParameterizedTest
+    @MethodSource("xmlContentTypes")
+    void xmlContentTypeDoesNotBypassDisabledXmlContentValidation(final String mediaType) {
         ThingifierApiConfig config = new ThingifierApiConfig("");
         config.setDefaultContentTypeAsJson(true);
         config.setApiToAllowXmlForContentType(false);
         ContentTypeHeaderValidator validator =
                 new ContentTypeHeaderValidator(config, List.of("todo", "todos"));
 
-        for (String mediaType :
-                List.of("application/xml", "text/xml", "application/vnd.example.todo+xml")) {
-            ApiResponse response = validator.validate(mediaType);
+        ApiResponse response = validator.validate(mediaType);
 
-            Assertions.assertEquals(415, response.getStatusCode(), mediaType);
-            Assertions.assertTrue(response.getErrorMessages().contains("XML Not Supported"));
-        }
+        Assertions.assertEquals(415, response.getStatusCode(), mediaType);
+        Assertions.assertTrue(response.getErrorMessages().contains("XML Not Supported"));
+    }
+
+    private static Stream<String> supportedXmlContentTypes() {
+        return Stream.of("application/xml", "text/xml");
+    }
+
+    private static Stream<String> modelMatchingStructuredXmlContentTypes() {
+        return Stream.of(
+                "application/vnd.example.todo+xml",
+                "application/vnd.example.todo+xml; charset=utf-8");
+    }
+
+    private static Stream<String> unsupportedXmlBasedContentTypes() {
+        return Stream.of(
+                "application/problem+xml",
+                "application/soap+xml",
+                "application/xhtml+xml",
+                "image/svg+xml",
+                "application/atom+xml",
+                "application/rss+xml",
+                "application/*+xml");
+    }
+
+    private static Stream<String> xmlContentTypes() {
+        return Stream.of("application/xml", "text/xml", "application/vnd.example.todo+xml");
     }
 }

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/headers/headervalidator/ContentTypeHeaderValidatorTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/headers/headervalidator/ContentTypeHeaderValidatorTest.java
@@ -1,0 +1,72 @@
+package uk.co.compendiumdev.thingifier.api.http.headers.headervalidator;
+
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
+import uk.co.compendiumdev.thingifier.apiconfig.ThingifierApiConfig;
+
+class ContentTypeHeaderValidatorTest {
+
+    @Test
+    void acceptsSupportedXmlContentTypes() {
+        ThingifierApiConfig config = new ThingifierApiConfig("");
+        ContentTypeHeaderValidator validator =
+                new ContentTypeHeaderValidator(config, List.of("todo", "todos"));
+
+        Assertions.assertNull(validator.validate("application/xml"));
+        Assertions.assertNull(validator.validate("text/xml"));
+    }
+
+    @Test
+    void acceptsModelMatchingStructuredXmlContentTypes() {
+        ThingifierApiConfig config = new ThingifierApiConfig("");
+        ContentTypeHeaderValidator validator =
+                new ContentTypeHeaderValidator(config, List.of("todo", "todos"));
+
+        Assertions.assertNull(validator.validate("application/vnd.example.todo+xml"));
+        Assertions.assertNull(
+                validator.validate("application/vnd.example.todo+xml; charset=utf-8"));
+    }
+
+    @Test
+    void rejectsUnsupportedXmlBasedContentTypes() {
+        ThingifierApiConfig config = new ThingifierApiConfig("");
+        ContentTypeHeaderValidator validator = new ContentTypeHeaderValidator(config);
+
+        for (String mediaType :
+                List.of(
+                        "application/problem+xml",
+                        "application/soap+xml",
+                        "application/xhtml+xml",
+                        "image/svg+xml",
+                        "application/atom+xml",
+                        "application/rss+xml",
+                        "application/*+xml")) {
+            ApiResponse response = validator.validate(mediaType);
+
+            Assertions.assertEquals(415, response.getStatusCode(), mediaType);
+            Assertions.assertTrue(
+                    response.getErrorMessages()
+                            .contains("Unsupported Content Type - " + mediaType),
+                    mediaType);
+        }
+    }
+
+    @Test
+    void textXmlDoesNotBypassDisabledXmlContentValidation() {
+        ThingifierApiConfig config = new ThingifierApiConfig("");
+        config.setDefaultContentTypeAsJson(true);
+        config.setApiToAllowXmlForContentType(false);
+        ContentTypeHeaderValidator validator =
+                new ContentTypeHeaderValidator(config, List.of("todo", "todos"));
+
+        for (String mediaType :
+                List.of("application/xml", "text/xml", "application/vnd.example.todo+xml")) {
+            ApiResponse response = validator.validate(mediaType);
+
+            Assertions.assertEquals(415, response.getStatusCode(), mediaType);
+            Assertions.assertTrue(response.getErrorMessages().contains("XML Not Supported"));
+        }
+    }
+}

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/headers/headervalidator/ContentTypeHeaderValidatorTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/headers/headervalidator/ContentTypeHeaderValidatorTest.java
@@ -47,8 +47,7 @@ class ContentTypeHeaderValidatorTest {
 
             Assertions.assertEquals(415, response.getStatusCode(), mediaType);
             Assertions.assertTrue(
-                    response.getErrorMessages()
-                            .contains("Unsupported Content Type - " + mediaType),
+                    response.getErrorMessages().contains("Unsupported Content Type - " + mediaType),
                     mediaType);
         }
     }

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/requests/ThingifierHttpApiAdditionalRepresentationsTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/requests/ThingifierHttpApiAdditionalRepresentationsTest.java
@@ -3,10 +3,11 @@ package uk.co.compendiumdev.thingifier.api.http.requests;
 import static uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldType.AUTO_INCREMENT;
 import static uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldType.STRING;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.api.http.HttpApiRequest;
 import uk.co.compendiumdev.thingifier.api.http.HttpApiResponse;
@@ -18,267 +19,351 @@ import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstanceDraft;
 
 class ThingifierHttpApiAdditionalRepresentationsTest {
 
-    @Test
-    void getSelectsAdditionalResponseRepresentationsFromAcceptHeader() {
-        Thingifier thingifier = taskThingifier();
-        createTask(thingifier, "Task");
-        ThingifierHttpApi api = new ThingifierHttpApi(thingifier);
+    @ParameterizedTest
+    @MethodSource("additionalRepresentationBodies")
+    void getSelectsAdditionalResponseRepresentationFromAcceptHeader(
+            final String acceptHeader, final String expectedBody) {
+        ThingifierHttpApi api = taskApiWithOneTask();
 
-        for (Map.Entry<String, String> expected : expectedBodies().entrySet()) {
-            HttpApiResponse response =
-                    api.get(new HttpApiRequest("tasks").addHeader("Accept", expected.getKey()));
+        HttpApiResponse response =
+                api.get(new HttpApiRequest("tasks").addHeader("Accept", acceptHeader));
 
-            Assertions.assertEquals(200, response.getStatusCode());
-            Assertions.assertEquals(expected.getKey(), response.getType());
-            Assertions.assertEquals(expected.getValue(), response.getBody());
-        }
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(acceptHeader, response.getType());
+        Assertions.assertEquals(expectedBody, response.getBody());
     }
 
-    @Test
-    void getNegotiatesAcceptHeaderQualityValuesWildcardsAndStructuredJsonTypes() {
-        Thingifier thingifier = taskThingifier();
-        createTask(thingifier, "Task");
-        ThingifierHttpApi api = new ThingifierHttpApi(thingifier);
-
-        assertNegotiatedGet(api, null, 200, "application/json", "\"tasks\"");
-        assertNegotiatedGet(api, "*/*", 200, "application/json", "\"tasks\"");
-        assertNegotiatedGet(api, "application/*", 200, "application/json", "\"tasks\"");
-        assertNegotiatedGet(api, "text/*", 200, "text/csv", "id,title");
-        assertNegotiatedGet(api, "application/json", 200, "application/json", "\"tasks\"");
-        assertNegotiatedGet(api, "application/xml", 200, "application/xml", "<tasks>");
-        assertNegotiatedGet(api, "text/xml", 200, "text/xml", "<tasks>");
+    @ParameterizedTest
+    @MethodSource("defaultAndWildcardAcceptHeaders")
+    void getDefaultsToJsonForMissingAndWildcardAcceptHeaders(final String acceptHeader) {
         assertNegotiatedGet(
-                api,
-                "application/vnd.example.task+xml",
-                200,
-                "application/vnd.example.task+xml",
-                "<tasks>");
-        assertNegotiatedGet(api, "application/*+xml", 200, "application/task+xml", "<tasks>");
-        assertNegotiatedGet(
-                api,
-                "application/json, application/problem+json",
-                200,
-                "application/json",
-                "\"tasks\"");
-        assertNegotiatedGet(
-                api,
-                "application/problem+json, application/json;q=0.5",
-                200,
-                "application/json",
-                "\"tasks\"");
-        assertNegotiatedGet(
-                api, "application/json;q=0, application/xml", 200, "application/xml", "<tasks>");
-        assertNegotiatedGet(
-                api, "application/problem+json", 406, "application/json", "errorMessages");
-        assertNegotiatedGet(api, "application/*+json", 406, "application/json", "errorMessages");
-        assertNegotiatedGet(api, "application/json;q=0", 406, "application/json", "errorMessages");
-        assertIssue103AcceptHeaderQualityValueExamples(api);
-        assertXmlCompatibleAcceptHeaderQualityValueCombinations(api);
-        assertUnsupportedXmlBasedMediaTypesAreNotNormalResourceXml(api);
+                taskApiWithOneTask(), acceptHeader, 200, "application/json", "\"tasks\"");
     }
 
-    @Test
-    void querySelectsAdditionalResponseRepresentationsFromAcceptHeader() {
-        Thingifier thingifier = taskThingifier();
-        createTask(thingifier, "Task");
-        ThingifierHttpApi api = new ThingifierHttpApi(thingifier);
-
-        for (Map.Entry<String, String> expected : expectedBodies().entrySet()) {
-            HttpApiRequest request =
-                    new HttpApiRequest("tasks")
-                            .addHeader("Content-Type", ThingifierHttpApi.QUERY_CONTENT_TYPE)
-                            .addHeader("Accept", expected.getKey())
-                            .setBody("title=Task");
-            HttpApiResponse response = api.queryRequest(request);
-
-            Assertions.assertEquals(200, response.getStatusCode());
-            Assertions.assertEquals(expected.getKey(), response.getType());
-            Assertions.assertEquals(expected.getValue(), response.getBody());
-        }
+    @ParameterizedTest
+    @MethodSource("exactRepresentationAcceptHeaders")
+    void getSelectsExactRepresentationFromAcceptHeader(
+            final String acceptHeader,
+            final String expectedContentType,
+            final String bodyFragment) {
+        assertNegotiatedGet(
+                taskApiWithOneTask(), acceptHeader, 200, expectedContentType, bodyFragment);
     }
 
-    @Test
-    void jsonPathQuerySelectsAdditionalResponseRepresentationsFromAcceptHeader() {
-        Thingifier thingifier = taskThingifier();
-        createTask(thingifier, "Task");
-        ThingifierHttpApi api = new ThingifierHttpApi(thingifier);
-
-        for (Map.Entry<String, String> expected : expectedBodies().entrySet()) {
-            HttpApiRequest request =
-                    new HttpApiRequest("tasks")
-                            .addHeader(
-                                    "Content-Type", ThingifierHttpApi.JSONPATH_QUERY_CONTENT_TYPE)
-                            .addHeader("Accept", expected.getKey())
-                            .setBody("$.tasks[?(@.title == 'Task')]");
-            HttpApiResponse response = api.queryRequest(request);
-
-            Assertions.assertEquals(200, response.getStatusCode());
-            Assertions.assertEquals(expected.getKey(), response.getType());
-            Assertions.assertEquals(expected.getValue(), response.getBody());
-        }
+    @ParameterizedTest
+    @MethodSource("structuredXmlWildcardAcceptHeaders")
+    void getSelectsModelDerivedXmlFromStructuredXmlWildcardAcceptHeader(
+            final String acceptHeader,
+            final String expectedContentType,
+            final String bodyFragment) {
+        assertNegotiatedGet(
+                taskApiWithOneTask(), acceptHeader, 200, expectedContentType, bodyFragment);
     }
 
-    @Test
-    void structuredJsonQuerySelectsAdditionalResponseRepresentationsFromAcceptHeader() {
-        Thingifier thingifier = taskThingifier();
-        createTask(thingifier, "Task");
-        ThingifierHttpApi api = new ThingifierHttpApi(thingifier);
-
-        for (Map.Entry<String, String> expected : expectedBodies().entrySet()) {
-            HttpApiRequest request =
-                    new HttpApiRequest("tasks")
-                            .addHeader(
-                                    "Content-Type", ThingifierHttpApi.STRUCTURED_QUERY_CONTENT_TYPE)
-                            .addHeader("Accept", expected.getKey())
-                            .setBody("{\"filter\":{\"title\":\"Task\"}}");
-            HttpApiResponse response = api.queryRequest(request);
-
-            Assertions.assertEquals(200, response.getStatusCode());
-            Assertions.assertEquals(expected.getKey(), response.getType());
-            Assertions.assertEquals(expected.getValue(), response.getBody());
-        }
+    @ParameterizedTest
+    @MethodSource("typeWildcardAcceptHeaders")
+    void getSelectsRepresentationFromTypeWildcardAcceptHeader(
+            final String acceptHeader,
+            final String expectedContentType,
+            final String bodyFragment) {
+        assertNegotiatedGet(
+                taskApiWithOneTask(), acceptHeader, 200, expectedContentType, bodyFragment);
     }
 
-    private Map<String, String> expectedBodies() {
-        Map<String, String> expectedBodies = new LinkedHashMap<>();
-        expectedBodies.put("text/csv", "id,title\n1,Task");
-        expectedBodies.put("text/plain", "id=1, title=Task");
-        expectedBodies.put(
-                "text/html",
-                "<table><thead><tr><th>id</th><th>title</th></tr></thead>"
-                        + "<tbody><tr><td>1</td><td>Task</td></tr></tbody></table>");
-        expectedBodies.put("application/x-ndjson", "{\"id\":1,\"title\":\"Task\"}\n");
-        expectedBodies.put("application/jsonl", "{\"id\":1,\"title\":\"Task\"}\n");
-        expectedBodies.put("application/json-seq", "\u001E{\"id\":1,\"title\":\"Task\"}\n");
-        expectedBodies.put("text/tab-separated-values", "id\ttitle\n1\tTask");
-        expectedBodies.put("text/xml", "<tasks><task><id>1</id><title>Task</title></task></tasks>");
-        expectedBodies.put(
-                "application/vnd.example.task+xml",
-                "<tasks><task><id>1</id><title>Task</title></task></tasks>");
-        return expectedBodies;
+    @ParameterizedTest
+    @MethodSource("structuredJsonFallbackHeaders")
+    void getIgnoresUnsupportedStructuredJsonWhenJsonAlternativeExists(final String acceptHeader) {
+        assertNegotiatedGet(
+                taskApiWithOneTask(), acceptHeader, 200, "application/json", "\"tasks\"");
     }
 
-    private void assertIssue103AcceptHeaderQualityValueExamples(final ThingifierHttpApi api) {
+    @ParameterizedTest
+    @MethodSource("unsupportedStructuredJsonHeaders")
+    void getRejectsUnsupportedStructuredJsonAcceptHeaders(final String acceptHeader) {
         assertNegotiatedGet(
-                api,
-                "application/xml;q=1, application/json;q=0.5",
-                200,
-                "application/xml",
-                "<tasks>");
-        assertNegotiatedGet(
-                api,
-                "application/json;q=1, application/xml;q=0.5",
-                200,
-                "application/json",
-                "\"tasks\"");
-        assertNegotiatedGet(
-                api,
-                "application/xml;q=0.2, application/json;q=0.9",
-                200,
-                "application/json",
-                "\"tasks\"");
-        assertNegotiatedGet(
-                api,
-                "application/json;q=0, application/xml;q=1",
-                200,
-                "application/xml",
-                "<tasks>");
-        assertNegotiatedGet(
-                api,
-                "application/json;q=0, application/xml;q=0",
-                406,
-                "application/json",
-                "errorMessages");
-        assertNegotiatedGet(
-                api, "application/xml, application/json;q=0.5", 200, "application/xml", "<tasks>");
-        assertNegotiatedGet(
-                api, "*/*;q=0.8, application/xml;q=0.9", 200, "application/xml", "<tasks>");
-        assertNegotiatedGet(
-                api,
-                "application/gzip;q=1, application/json;q=0.5",
-                200,
-                "application/json",
-                "\"tasks\"");
+                taskApiWithOneTask(), acceptHeader, 406, "application/json", "errorMessages");
     }
 
-    private void assertXmlCompatibleAcceptHeaderQualityValueCombinations(
-            final ThingifierHttpApi api) {
+    @ParameterizedTest
+    @MethodSource("issue103HttpQualityValueExamples")
+    void issue103ExamplesNegotiateHttpResponsesByQualityValues(
+            final String acceptHeader,
+            final int expectedStatusCode,
+            final String expectedContentType,
+            final String bodyFragment) {
         assertNegotiatedGet(
-                api,
-                "application/json;q=0.5, "
-                        + "application/xml;q=0.6, "
-                        + "text/xml;q=0.8, "
-                        + "application/vnd.example.task+xml;q=0.9",
-                200,
-                "application/vnd.example.task+xml",
-                "<tasks>");
-        assertNegotiatedGet(
-                api,
-                "application/json;q=0.5, "
-                        + "application/xml;q=0.6, "
-                        + "text/xml;q=0.8, "
-                        + "application/*+xml;q=0.9",
-                200,
-                "application/task+xml",
-                "<tasks>");
-        assertNegotiatedGet(
-                api, "application/problem+xml;q=1, text/xml;q=0.4", 200, "text/xml", "<tasks>");
-        assertNegotiatedGet(
-                api,
-                "application/soap+xml;q=1, application/*+xml;q=0.4",
-                200,
-                "application/task+xml",
-                "<tasks>");
-        assertNegotiatedGet(
-                api,
-                "application/xml;q=0, application/*;q=0.8",
-                200,
-                "application/json",
-                "\"tasks\"");
-        assertNegotiatedGet(api, "text/xml;q=0, text/*;q=0.8", 200, "text/csv", "id,title");
-        assertNegotiatedGet(
-                api,
-                "application/task+xml;q=0, application/*+xml;q=0.8",
-                406,
-                "application/json",
-                "errorMessages");
-        assertNegotiatedGet(
-                api,
-                "application/*;q=0.8, application/xml;q=0.8",
-                200,
-                "application/xml",
-                "<tasks>");
-        assertNegotiatedGet(api, "text/*;q=0.8, text/xml;q=0.8", 200, "text/xml", "<tasks>");
-        assertNegotiatedGet(
-                api,
-                "application/*+xml;q=0.8, application/vnd.example.task+xml;q=0.8",
-                200,
-                "application/vnd.example.task+xml",
-                "<tasks>");
-        assertNegotiatedGet(
-                api, "text/xml;q=0.8, application/xml;q=0.8", 200, "text/xml", "<tasks>");
-        assertNegotiatedGet(
-                api, "application/xml;q=0.8, text/xml;q=0.8", 200, "application/xml", "<tasks>");
-        assertNegotiatedGet(
-                api,
-                "application/vnd.example.task+xml;q=0.8, text/xml;q=0.8",
-                200,
-                "application/vnd.example.task+xml",
-                "<tasks>");
+                taskApiWithOneTask(),
+                acceptHeader,
+                expectedStatusCode,
+                expectedContentType,
+                bodyFragment);
     }
 
-    private void assertUnsupportedXmlBasedMediaTypesAreNotNormalResourceXml(
-            final ThingifierHttpApi api) {
-        for (String mediaType :
-                java.util.List.of(
-                        "application/problem+xml",
-                        "application/soap+xml",
-                        "application/xhtml+xml",
-                        "image/svg+xml",
-                        "application/atom+xml",
-                        "application/rss+xml")) {
-            assertNegotiatedGet(api, mediaType, 406, "application/json", "errorMessages");
-        }
+    @ParameterizedTest
+    @MethodSource("xmlCompatibleQualityValueExamples")
+    void xmlCompatibleMediaTypesUseHighestSupportedQualityValue(
+            final String acceptHeader, final String expectedContentType) {
+        assertNegotiatedGet(
+                taskApiWithOneTask(), acceptHeader, 200, expectedContentType, "<tasks>");
+    }
+
+    @ParameterizedTest
+    @MethodSource("unsupportedHigherQualityXmlFallbackExamples")
+    void unsupportedHigherQualityXmlMediaRangesFallThroughToSupportedAlternatives(
+            final String acceptHeader, final String expectedContentType) {
+        assertNegotiatedGet(
+                taskApiWithOneTask(), acceptHeader, 200, expectedContentType, "<tasks>");
+    }
+
+    @ParameterizedTest
+    @MethodSource("qZeroWildcardFallbackExamples")
+    void qZeroExactMediaTypeCanFallBackToAllowedWildcardRepresentation(
+            final String acceptHeader,
+            final String expectedContentType,
+            final String bodyFragment) {
+        assertNegotiatedGet(
+                taskApiWithOneTask(), acceptHeader, 200, expectedContentType, bodyFragment);
+    }
+
+    @ParameterizedTest
+    @MethodSource("structuredXmlRejectedByQZeroExamples")
+    void qZeroExactStructuredXmlRejectsStructuredXmlWildcardFallback(final String acceptHeader) {
+        assertNegotiatedGet(
+                taskApiWithOneTask(), acceptHeader, 406, "application/json", "errorMessages");
+    }
+
+    @ParameterizedTest
+    @MethodSource("specificityTieBreakerExamples")
+    void specificityBeatsHeaderOrderWhenQualityValuesTie(
+            final String acceptHeader, final String expectedContentType) {
+        assertNegotiatedGet(
+                taskApiWithOneTask(), acceptHeader, 200, expectedContentType, "<tasks>");
+    }
+
+    @ParameterizedTest
+    @MethodSource("clientOrderTieBreakerExamples")
+    void clientOrderBreaksTiesWhenQualityAndSpecificityAreTheSame(
+            final String acceptHeader, final String expectedContentType) {
+        assertNegotiatedGet(
+                taskApiWithOneTask(), acceptHeader, 200, expectedContentType, "<tasks>");
+    }
+
+    @ParameterizedTest
+    @MethodSource("unsupportedXmlMediaTypes")
+    void unsupportedXmlBasedAcceptHeadersAreNotNormalResourceXml(final String mediaType) {
+        assertNegotiatedGet(
+                taskApiWithOneTask(), mediaType, 406, "application/json", "errorMessages");
+    }
+
+    @ParameterizedTest
+    @MethodSource("additionalRepresentationBodies")
+    void querySelectsAdditionalResponseRepresentationFromAcceptHeader(
+            final String acceptHeader, final String expectedBody) {
+        HttpApiRequest request =
+                new HttpApiRequest("tasks")
+                        .addHeader("Content-Type", ThingifierHttpApi.QUERY_CONTENT_TYPE)
+                        .addHeader("Accept", acceptHeader)
+                        .setBody("title=Task");
+
+        HttpApiResponse response = taskApiWithOneTask().queryRequest(request);
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(acceptHeader, response.getType());
+        Assertions.assertEquals(expectedBody, response.getBody());
+    }
+
+    @ParameterizedTest
+    @MethodSource("additionalRepresentationBodies")
+    void jsonPathQuerySelectsAdditionalResponseRepresentationFromAcceptHeader(
+            final String acceptHeader, final String expectedBody) {
+        HttpApiRequest request =
+                new HttpApiRequest("tasks")
+                        .addHeader("Content-Type", ThingifierHttpApi.JSONPATH_QUERY_CONTENT_TYPE)
+                        .addHeader("Accept", acceptHeader)
+                        .setBody("$.tasks[?(@.title == 'Task')]");
+
+        HttpApiResponse response = taskApiWithOneTask().queryRequest(request);
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(acceptHeader, response.getType());
+        Assertions.assertEquals(expectedBody, response.getBody());
+    }
+
+    @ParameterizedTest
+    @MethodSource("additionalRepresentationBodies")
+    void structuredJsonQuerySelectsAdditionalResponseRepresentationFromAcceptHeader(
+            final String acceptHeader, final String expectedBody) {
+        HttpApiRequest request =
+                new HttpApiRequest("tasks")
+                        .addHeader("Content-Type", ThingifierHttpApi.STRUCTURED_QUERY_CONTENT_TYPE)
+                        .addHeader("Accept", acceptHeader)
+                        .setBody("{\"filter\":{\"title\":\"Task\"}}");
+
+        HttpApiResponse response = taskApiWithOneTask().queryRequest(request);
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(acceptHeader, response.getType());
+        Assertions.assertEquals(expectedBody, response.getBody());
+    }
+
+    private static Stream<Arguments> additionalRepresentationBodies() {
+        return Stream.of(
+                Arguments.of("text/csv", "id,title\n1,Task"),
+                Arguments.of("text/plain", "id=1, title=Task"),
+                Arguments.of(
+                        "text/html",
+                        "<table><thead><tr><th>id</th><th>title</th></tr></thead>"
+                                + "<tbody><tr><td>1</td><td>Task</td></tr></tbody></table>"),
+                Arguments.of("application/x-ndjson", "{\"id\":1,\"title\":\"Task\"}\n"),
+                Arguments.of("application/jsonl", "{\"id\":1,\"title\":\"Task\"}\n"),
+                Arguments.of("application/json-seq", "\u001E{\"id\":1,\"title\":\"Task\"}\n"),
+                Arguments.of("text/tab-separated-values", "id\ttitle\n1\tTask"),
+                Arguments.of(
+                        "text/xml", "<tasks><task><id>1</id><title>Task</title></task></tasks>"),
+                Arguments.of(
+                        "application/vnd.example.task+xml",
+                        "<tasks><task><id>1</id><title>Task</title></task></tasks>"));
+    }
+
+    private static Stream<Arguments> defaultAndWildcardAcceptHeaders() {
+        return Stream.of(
+                Arguments.of((String) null), Arguments.of("*/*"), Arguments.of("application/*"));
+    }
+
+    private static Stream<Arguments> exactRepresentationAcceptHeaders() {
+        return Stream.of(
+                Arguments.of("application/json", "application/json", "\"tasks\""),
+                Arguments.of("application/xml", "application/xml", "<tasks>"),
+                Arguments.of("text/xml", "text/xml", "<tasks>"),
+                Arguments.of(
+                        "application/vnd.example.task+xml",
+                        "application/vnd.example.task+xml",
+                        "<tasks>"));
+    }
+
+    private static Stream<Arguments> structuredXmlWildcardAcceptHeaders() {
+        return Stream.of(Arguments.of("application/*+xml", "application/task+xml", "<tasks>"));
+    }
+
+    private static Stream<Arguments> typeWildcardAcceptHeaders() {
+        return Stream.of(Arguments.of("text/*", "text/csv", "id,title"));
+    }
+
+    private static Stream<Arguments> structuredJsonFallbackHeaders() {
+        return Stream.of(
+                Arguments.of("application/json, application/problem+json"),
+                Arguments.of("application/problem+json, application/json;q=0.5"));
+    }
+
+    private static Stream<Arguments> unsupportedStructuredJsonHeaders() {
+        return Stream.of(
+                Arguments.of("application/problem+json"), Arguments.of("application/*+json"));
+    }
+
+    private static Stream<Arguments> issue103HttpQualityValueExamples() {
+        return Stream.of(
+                Arguments.of(
+                        "application/xml;q=1, application/json;q=0.5",
+                        200,
+                        "application/xml",
+                        "<tasks>"),
+                Arguments.of(
+                        "application/json;q=1, application/xml;q=0.5",
+                        200,
+                        "application/json",
+                        "\"tasks\""),
+                Arguments.of(
+                        "application/xml;q=0.2, application/json;q=0.9",
+                        200,
+                        "application/json",
+                        "\"tasks\""),
+                Arguments.of(
+                        "application/json;q=0, application/xml;q=1",
+                        200,
+                        "application/xml",
+                        "<tasks>"),
+                Arguments.of(
+                        "application/json;q=0, application/xml;q=0",
+                        406,
+                        "application/json",
+                        "errorMessages"),
+                Arguments.of(
+                        "application/xml, application/json;q=0.5",
+                        200,
+                        "application/xml",
+                        "<tasks>"),
+                Arguments.of("*/*;q=0.8, application/xml;q=0.9", 200, "application/xml", "<tasks>"),
+                Arguments.of(
+                        "application/gzip;q=1, application/json;q=0.5",
+                        200,
+                        "application/json",
+                        "\"tasks\""));
+    }
+
+    private static Stream<Arguments> xmlCompatibleQualityValueExamples() {
+        return Stream.of(
+                Arguments.of(
+                        "application/json;q=0.5, "
+                                + "application/xml;q=0.6, "
+                                + "text/xml;q=0.8, "
+                                + "application/vnd.example.task+xml;q=0.9",
+                        "application/vnd.example.task+xml"),
+                Arguments.of(
+                        "application/json;q=0.5, "
+                                + "application/xml;q=0.6, "
+                                + "text/xml;q=0.8, "
+                                + "application/*+xml;q=0.9",
+                        "application/task+xml"));
+    }
+
+    private static Stream<Arguments> unsupportedHigherQualityXmlFallbackExamples() {
+        return Stream.of(
+                Arguments.of("application/problem+xml;q=1, text/xml;q=0.4", "text/xml"),
+                Arguments.of(
+                        "application/soap+xml;q=1, application/*+xml;q=0.4",
+                        "application/task+xml"));
+    }
+
+    private static Stream<Arguments> qZeroWildcardFallbackExamples() {
+        return Stream.of(
+                Arguments.of(
+                        "application/xml;q=0, application/*;q=0.8",
+                        "application/json",
+                        "\"tasks\""),
+                Arguments.of("text/xml;q=0, text/*;q=0.8", "text/csv", "id,title"));
+    }
+
+    private static Stream<Arguments> structuredXmlRejectedByQZeroExamples() {
+        return Stream.of(Arguments.of("application/task+xml;q=0, application/*+xml;q=0.8"));
+    }
+
+    private static Stream<Arguments> specificityTieBreakerExamples() {
+        return Stream.of(
+                Arguments.of("application/*;q=0.8, application/xml;q=0.8", "application/xml"),
+                Arguments.of("text/*;q=0.8, text/xml;q=0.8", "text/xml"),
+                Arguments.of(
+                        "application/*+xml;q=0.8, application/vnd.example.task+xml;q=0.8",
+                        "application/vnd.example.task+xml"));
+    }
+
+    private static Stream<Arguments> clientOrderTieBreakerExamples() {
+        return Stream.of(
+                Arguments.of("text/xml;q=0.8, application/xml;q=0.8", "text/xml"),
+                Arguments.of("application/xml;q=0.8, text/xml;q=0.8", "application/xml"),
+                Arguments.of(
+                        "application/vnd.example.task+xml;q=0.8, text/xml;q=0.8",
+                        "application/vnd.example.task+xml"),
+                Arguments.of("text/xml;q=0.8, application/vnd.example.task+xml;q=0.8", "text/xml"));
+    }
+
+    private static Stream<Arguments> unsupportedXmlMediaTypes() {
+        return Stream.of(
+                Arguments.of("application/problem+xml"),
+                Arguments.of("application/soap+xml"),
+                Arguments.of("application/xhtml+xml"),
+                Arguments.of("image/svg+xml"),
+                Arguments.of("application/atom+xml"),
+                Arguments.of("application/rss+xml"));
     }
 
     private void assertNegotiatedGet(
@@ -297,6 +382,12 @@ class ThingifierHttpApiAdditionalRepresentationsTest {
         Assertions.assertEquals(statusCode, response.getStatusCode(), acceptHeader);
         Assertions.assertEquals(contentType, response.getType(), acceptHeader);
         Assertions.assertTrue(response.getBody().contains(bodyFragment), response.getBody());
+    }
+
+    private ThingifierHttpApi taskApiWithOneTask() {
+        Thingifier thingifier = taskThingifier();
+        createTask(thingifier, "Task");
+        return new ThingifierHttpApi(thingifier);
     }
 
     private Thingifier taskThingifier() {

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/requests/ThingifierHttpApiAdditionalRepresentationsTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/requests/ThingifierHttpApiAdditionalRepresentationsTest.java
@@ -46,6 +46,19 @@ class ThingifierHttpApiAdditionalRepresentationsTest {
         assertNegotiatedGet(api, "text/*", 200, "text/csv", "id,title");
         assertNegotiatedGet(api, "application/json", 200, "application/json", "\"tasks\"");
         assertNegotiatedGet(api, "application/xml", 200, "application/xml", "<tasks>");
+        assertNegotiatedGet(api, "text/xml", 200, "text/xml", "<tasks>");
+        assertNegotiatedGet(
+                api,
+                "application/vnd.example.task+xml",
+                200,
+                "application/vnd.example.task+xml",
+                "<tasks>");
+        assertNegotiatedGet(
+                api,
+                "application/*+xml",
+                200,
+                "application/task+xml",
+                "<tasks>");
         assertNegotiatedGet(
                 api,
                 "application/json, application/problem+json",
@@ -64,6 +77,9 @@ class ThingifierHttpApiAdditionalRepresentationsTest {
                 api, "application/problem+json", 406, "application/json", "errorMessages");
         assertNegotiatedGet(api, "application/*+json", 406, "application/json", "errorMessages");
         assertNegotiatedGet(api, "application/json;q=0", 406, "application/json", "errorMessages");
+        assertIssue103AcceptHeaderQualityValueExamples(api);
+        assertXmlCompatibleAcceptHeaderQualityValueCombinations(api);
+        assertUnsupportedXmlBasedMediaTypesAreNotNormalResourceXml(api);
     }
 
     @Test
@@ -140,7 +156,164 @@ class ThingifierHttpApiAdditionalRepresentationsTest {
         expectedBodies.put("application/jsonl", "{\"id\":1,\"title\":\"Task\"}\n");
         expectedBodies.put("application/json-seq", "\u001E{\"id\":1,\"title\":\"Task\"}\n");
         expectedBodies.put("text/tab-separated-values", "id\ttitle\n1\tTask");
+        expectedBodies.put("text/xml", "<tasks><task><id>1</id><title>Task</title></task></tasks>");
+        expectedBodies.put(
+                "application/vnd.example.task+xml",
+                "<tasks><task><id>1</id><title>Task</title></task></tasks>");
         return expectedBodies;
+    }
+
+    private void assertIssue103AcceptHeaderQualityValueExamples(final ThingifierHttpApi api) {
+        assertNegotiatedGet(
+                api,
+                "application/xml;q=1, application/json;q=0.5",
+                200,
+                "application/xml",
+                "<tasks>");
+        assertNegotiatedGet(
+                api,
+                "application/json;q=1, application/xml;q=0.5",
+                200,
+                "application/json",
+                "\"tasks\"");
+        assertNegotiatedGet(
+                api,
+                "application/xml;q=0.2, application/json;q=0.9",
+                200,
+                "application/json",
+                "\"tasks\"");
+        assertNegotiatedGet(
+                api,
+                "application/json;q=0, application/xml;q=1",
+                200,
+                "application/xml",
+                "<tasks>");
+        assertNegotiatedGet(
+                api,
+                "application/json;q=0, application/xml;q=0",
+                406,
+                "application/json",
+                "errorMessages");
+        assertNegotiatedGet(
+                api,
+                "application/xml, application/json;q=0.5",
+                200,
+                "application/xml",
+                "<tasks>");
+        assertNegotiatedGet(
+                api,
+                "*/*;q=0.8, application/xml;q=0.9",
+                200,
+                "application/xml",
+                "<tasks>");
+        assertNegotiatedGet(
+                api,
+                "application/gzip;q=1, application/json;q=0.5",
+                200,
+                "application/json",
+                "\"tasks\"");
+    }
+
+    private void assertXmlCompatibleAcceptHeaderQualityValueCombinations(
+            final ThingifierHttpApi api) {
+        assertNegotiatedGet(
+                api,
+                "application/json;q=0.5, "
+                        + "application/xml;q=0.6, "
+                        + "text/xml;q=0.8, "
+                        + "application/vnd.example.task+xml;q=0.9",
+                200,
+                "application/vnd.example.task+xml",
+                "<tasks>");
+        assertNegotiatedGet(
+                api,
+                "application/json;q=0.5, "
+                        + "application/xml;q=0.6, "
+                        + "text/xml;q=0.8, "
+                        + "application/*+xml;q=0.9",
+                200,
+                "application/task+xml",
+                "<tasks>");
+        assertNegotiatedGet(
+                api,
+                "application/problem+xml;q=1, text/xml;q=0.4",
+                200,
+                "text/xml",
+                "<tasks>");
+        assertNegotiatedGet(
+                api,
+                "application/soap+xml;q=1, application/*+xml;q=0.4",
+                200,
+                "application/task+xml",
+                "<tasks>");
+        assertNegotiatedGet(
+                api,
+                "application/xml;q=0, application/*;q=0.8",
+                200,
+                "application/json",
+                "\"tasks\"");
+        assertNegotiatedGet(
+                api,
+                "text/xml;q=0, text/*;q=0.8",
+                200,
+                "text/csv",
+                "id,title");
+        assertNegotiatedGet(
+                api,
+                "application/task+xml;q=0, application/*+xml;q=0.8",
+                406,
+                "application/json",
+                "errorMessages");
+        assertNegotiatedGet(
+                api,
+                "application/*;q=0.8, application/xml;q=0.8",
+                200,
+                "application/xml",
+                "<tasks>");
+        assertNegotiatedGet(
+                api,
+                "text/*;q=0.8, text/xml;q=0.8",
+                200,
+                "text/xml",
+                "<tasks>");
+        assertNegotiatedGet(
+                api,
+                "application/*+xml;q=0.8, application/vnd.example.task+xml;q=0.8",
+                200,
+                "application/vnd.example.task+xml",
+                "<tasks>");
+        assertNegotiatedGet(
+                api,
+                "text/xml;q=0.8, application/xml;q=0.8",
+                200,
+                "text/xml",
+                "<tasks>");
+        assertNegotiatedGet(
+                api,
+                "application/xml;q=0.8, text/xml;q=0.8",
+                200,
+                "application/xml",
+                "<tasks>");
+        assertNegotiatedGet(
+                api,
+                "application/vnd.example.task+xml;q=0.8, text/xml;q=0.8",
+                200,
+                "application/vnd.example.task+xml",
+                "<tasks>");
+    }
+
+    private void assertUnsupportedXmlBasedMediaTypesAreNotNormalResourceXml(
+            final ThingifierHttpApi api) {
+        for (String mediaType :
+                java.util.List.of(
+                        "application/problem+xml",
+                        "application/soap+xml",
+                        "application/xhtml+xml",
+                        "image/svg+xml",
+                        "application/atom+xml",
+                        "application/rss+xml")) {
+            assertNegotiatedGet(api, mediaType, 406, "application/json", "errorMessages");
+        }
     }
 
     private void assertNegotiatedGet(

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/requests/ThingifierHttpApiAdditionalRepresentationsTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/requests/ThingifierHttpApiAdditionalRepresentationsTest.java
@@ -53,12 +53,7 @@ class ThingifierHttpApiAdditionalRepresentationsTest {
                 200,
                 "application/vnd.example.task+xml",
                 "<tasks>");
-        assertNegotiatedGet(
-                api,
-                "application/*+xml",
-                200,
-                "application/task+xml",
-                "<tasks>");
+        assertNegotiatedGet(api, "application/*+xml", 200, "application/task+xml", "<tasks>");
         assertNegotiatedGet(
                 api,
                 "application/json, application/problem+json",
@@ -195,17 +190,9 @@ class ThingifierHttpApiAdditionalRepresentationsTest {
                 "application/json",
                 "errorMessages");
         assertNegotiatedGet(
-                api,
-                "application/xml, application/json;q=0.5",
-                200,
-                "application/xml",
-                "<tasks>");
+                api, "application/xml, application/json;q=0.5", 200, "application/xml", "<tasks>");
         assertNegotiatedGet(
-                api,
-                "*/*;q=0.8, application/xml;q=0.9",
-                200,
-                "application/xml",
-                "<tasks>");
+                api, "*/*;q=0.8, application/xml;q=0.9", 200, "application/xml", "<tasks>");
         assertNegotiatedGet(
                 api,
                 "application/gzip;q=1, application/json;q=0.5",
@@ -235,11 +222,7 @@ class ThingifierHttpApiAdditionalRepresentationsTest {
                 "application/task+xml",
                 "<tasks>");
         assertNegotiatedGet(
-                api,
-                "application/problem+xml;q=1, text/xml;q=0.4",
-                200,
-                "text/xml",
-                "<tasks>");
+                api, "application/problem+xml;q=1, text/xml;q=0.4", 200, "text/xml", "<tasks>");
         assertNegotiatedGet(
                 api,
                 "application/soap+xml;q=1, application/*+xml;q=0.4",
@@ -252,12 +235,7 @@ class ThingifierHttpApiAdditionalRepresentationsTest {
                 200,
                 "application/json",
                 "\"tasks\"");
-        assertNegotiatedGet(
-                api,
-                "text/xml;q=0, text/*;q=0.8",
-                200,
-                "text/csv",
-                "id,title");
+        assertNegotiatedGet(api, "text/xml;q=0, text/*;q=0.8", 200, "text/csv", "id,title");
         assertNegotiatedGet(
                 api,
                 "application/task+xml;q=0, application/*+xml;q=0.8",
@@ -270,12 +248,7 @@ class ThingifierHttpApiAdditionalRepresentationsTest {
                 200,
                 "application/xml",
                 "<tasks>");
-        assertNegotiatedGet(
-                api,
-                "text/*;q=0.8, text/xml;q=0.8",
-                200,
-                "text/xml",
-                "<tasks>");
+        assertNegotiatedGet(api, "text/*;q=0.8, text/xml;q=0.8", 200, "text/xml", "<tasks>");
         assertNegotiatedGet(
                 api,
                 "application/*+xml;q=0.8, application/vnd.example.task+xml;q=0.8",
@@ -283,17 +256,9 @@ class ThingifierHttpApiAdditionalRepresentationsTest {
                 "application/vnd.example.task+xml",
                 "<tasks>");
         assertNegotiatedGet(
-                api,
-                "text/xml;q=0.8, application/xml;q=0.8",
-                200,
-                "text/xml",
-                "<tasks>");
+                api, "text/xml;q=0.8, application/xml;q=0.8", 200, "text/xml", "<tasks>");
         assertNegotiatedGet(
-                api,
-                "application/xml;q=0.8, text/xml;q=0.8",
-                200,
-                "application/xml",
-                "<tasks>");
+                api, "application/xml;q=0.8, text/xml;q=0.8", 200, "application/xml", "<tasks>");
         assertNegotiatedGet(
                 api,
                 "application/vnd.example.task+xml;q=0.8, text/xml;q=0.8",

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseTest.java
@@ -61,14 +61,12 @@ public class ApiResponseTest {
     public void errorFormatterUsesXmlCompatibleAcceptTypes() {
         Assertions.assertTrue(ApiResponseError.asAppropriate("text/xml", "oopsy").startsWith("<"));
         Assertions.assertTrue(
-                ApiResponseError.asAppropriate(
-                                "application/vnd.example.todo+xml", "oopsy")
+                ApiResponseError.asAppropriate("application/vnd.example.todo+xml", "oopsy")
                         .startsWith("{"));
         Assertions.assertTrue(
                 ApiResponseError.asAppropriate("application/*+xml", "oopsy").startsWith("{"));
         Assertions.assertTrue(
-                ApiResponseError.asAppropriate("application/problem+xml", "oopsy")
-                        .startsWith("{"));
+                ApiResponseError.asAppropriate("application/problem+xml", "oopsy").startsWith("{"));
     }
 
     @Test

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseTest.java
@@ -4,8 +4,12 @@ import static uk.co.compendiumdev.thingifier.core.domain.definitions.field.defin
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.core.EntityRelModel;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
@@ -43,30 +47,25 @@ public class ApiResponseTest {
         Assertions.assertTrue(response.getErrorMessages().contains("oopsy"));
     }
 
-    @Test
-    public void errorFormatterUsesAcceptQualityValuesForJsonAndXml() {
+    @ParameterizedTest
+    @MethodSource("acceptQualityValueErrorFormatExamples")
+    public void errorFormatterUsesAcceptQualityValuesForJsonAndXml(
+            final String acceptHeader, final String expectedPrefix) {
         Assertions.assertTrue(
-                ApiResponseError.asAppropriate("application/json;q=0, application/xml", "oopsy")
-                        .startsWith("<"));
-        Assertions.assertTrue(
-                ApiResponseError.asAppropriate(
-                                "application/xml;q=0.1, application/json;q=0.9", "oopsy")
-                        .startsWith("{"));
-        Assertions.assertTrue(
-                ApiResponseError.asAppropriate("application/problem+json", "oopsy")
-                        .startsWith("{"));
+                ApiResponseError.asAppropriate(acceptHeader, "oopsy").startsWith(expectedPrefix));
     }
 
     @Test
-    public void errorFormatterUsesXmlCompatibleAcceptTypes() {
+    public void errorFormatterUsesTextXmlAcceptType() {
         Assertions.assertTrue(ApiResponseError.asAppropriate("text/xml", "oopsy").startsWith("<"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("genericErrorAcceptHeadersThatFallBackToJson")
+    public void genericErrorFormatterUsesJsonWhenAcceptHeaderIsUnsupportedOrNeedsEntityContext(
+            final String acceptHeader) {
         Assertions.assertTrue(
-                ApiResponseError.asAppropriate("application/vnd.example.todo+xml", "oopsy")
-                        .startsWith("{"));
-        Assertions.assertTrue(
-                ApiResponseError.asAppropriate("application/*+xml", "oopsy").startsWith("{"));
-        Assertions.assertTrue(
-                ApiResponseError.asAppropriate("application/problem+xml", "oopsy").startsWith("{"));
+                ApiResponseError.asAppropriate(acceptHeader, "oopsy").startsWith("{"));
     }
 
     @Test
@@ -178,5 +177,19 @@ public class ApiResponseTest {
         Assertions.assertEquals(true, response.isCollection());
 
         Assertions.assertEquals(0, response.getReturnedInstanceCollection().size());
+    }
+
+    private static Stream<Arguments> acceptQualityValueErrorFormatExamples() {
+        return Stream.of(
+                Arguments.of("application/json;q=0, application/xml", "<"),
+                Arguments.of("application/xml;q=0.1, application/json;q=0.9", "{"));
+    }
+
+    private static Stream<String> genericErrorAcceptHeadersThatFallBackToJson() {
+        return Stream.of(
+                "application/problem+json",
+                "application/vnd.example.todo+xml",
+                "application/*+xml",
+                "application/problem+xml");
     }
 }

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseTest.java
@@ -58,6 +58,20 @@ public class ApiResponseTest {
     }
 
     @Test
+    public void errorFormatterUsesXmlCompatibleAcceptTypes() {
+        Assertions.assertTrue(ApiResponseError.asAppropriate("text/xml", "oopsy").startsWith("<"));
+        Assertions.assertTrue(
+                ApiResponseError.asAppropriate(
+                                "application/vnd.example.todo+xml", "oopsy")
+                        .startsWith("{"));
+        Assertions.assertTrue(
+                ApiResponseError.asAppropriate("application/*+xml", "oopsy").startsWith("{"));
+        Assertions.assertTrue(
+                ApiResponseError.asAppropriate("application/problem+xml", "oopsy")
+                        .startsWith("{"));
+    }
+
+    @Test
     public void responseErrors() {
 
         List<String> errors = new ArrayList();

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerEntityDescriptionTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerEntityDescriptionTest.java
@@ -88,6 +88,18 @@ class SwaggerizerEntityDescriptionTest {
                         .get("application/json")
                         .getSchema()
                         .get$ref());
+        Assertions.assertTrue(
+                relationshipCollection
+                        .getPost()
+                        .getRequestBody()
+                        .getContent()
+                        .containsKey("application/xml"));
+        Assertions.assertTrue(
+                relationshipCollection
+                        .getPost()
+                        .getRequestBody()
+                        .getContent()
+                        .containsKey("text/xml"));
 
         final PathItem singleTargetRelationship = openApi.getPaths().get("/todos/{id}/project");
         Assertions.assertNotNull(singleTargetRelationship);
@@ -127,6 +139,13 @@ class SwaggerizerEntityDescriptionTest {
         Assertions.assertEquals("array", xmlCollectionSchema.getType());
         Assertions.assertEquals("projects", xmlCollectionSchema.getXml().getName());
         Assertions.assertTrue(xmlCollectionSchema.getXml().getWrapped());
+        for (String xmlMediaType : List.of("text/xml")) {
+            final Schema<?> compatibleXmlCollectionSchema = content.get(xmlMediaType).getSchema();
+            Assertions.assertNull(compatibleXmlCollectionSchema.get$ref());
+            Assertions.assertEquals("array", compatibleXmlCollectionSchema.getType());
+            Assertions.assertEquals("projects", compatibleXmlCollectionSchema.getXml().getName());
+            Assertions.assertTrue(compatibleXmlCollectionSchema.getXml().getWrapped());
+        }
         for (String mediaType :
                 List.of(
                         "text/csv",

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerEntityDescriptionTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerEntityDescriptionTest.java
@@ -9,8 +9,12 @@ import io.swagger.v3.oas.models.parameters.Parameter;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.api.docgen.ThingifierApiDocumentationDefn;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.Cardinality;
@@ -38,13 +42,22 @@ class SwaggerizerEntityDescriptionTest {
     }
 
     @Test
-    void relationshipRoutesExposeEditablePathParametersAndPostBodies() {
+    void relationshipCollectionRouteExposesEditablePathParameter() {
         final OpenAPI openApi = new Swaggerizer(apiDefn(relationshipModel())).swagger();
 
         final PathItem relationshipCollection = openApi.getPaths().get("/projects/{id}/tasks");
+
         Assertions.assertNotNull(relationshipCollection);
         Assertions.assertEquals(Set.of("id"), pathParameterNames(relationshipCollection));
         Assertions.assertTrue(relationshipCollection.getParameters().get(0).getRequired());
+    }
+
+    @Test
+    void relationshipCollectionRouteGetUsesTodoJsonCollectionResponseSchema() {
+        final OpenAPI openApi = new Swaggerizer(apiDefn(relationshipModel())).swagger();
+
+        final PathItem relationshipCollection = openApi.getPaths().get("/projects/{id}/tasks");
+
         Assertions.assertNotNull(
                 relationshipCollection.getGet().getResponses().get("200").getContent());
         Assertions.assertEquals(
@@ -57,6 +70,14 @@ class SwaggerizerEntityDescriptionTest {
                         .get("application/json")
                         .getSchema()
                         .get$ref());
+    }
+
+    @Test
+    void relationshipCollectionRouteGetUsesTodoXmlCollectionResponseSchema() {
+        final OpenAPI openApi = new Swaggerizer(apiDefn(relationshipModel())).swagger();
+
+        final PathItem relationshipCollection = openApi.getPaths().get("/projects/{id}/tasks");
+
         Assertions.assertEquals(
                 "array",
                 relationshipCollection
@@ -78,6 +99,14 @@ class SwaggerizerEntityDescriptionTest {
                         .getSchema()
                         .getXml()
                         .getName());
+    }
+
+    @Test
+    void relationshipCollectionRoutePostUsesJsonRequestBodySchema() {
+        final OpenAPI openApi = new Swaggerizer(apiDefn(relationshipModel())).swagger();
+
+        final PathItem relationshipCollection = openApi.getPaths().get("/projects/{id}/tasks");
+
         Assertions.assertNotNull(relationshipCollection.getPost().getRequestBody());
         Assertions.assertEquals(
                 "#/components/schemas/todo",
@@ -88,20 +117,29 @@ class SwaggerizerEntityDescriptionTest {
                         .get("application/json")
                         .getSchema()
                         .get$ref());
+    }
+
+    @ParameterizedTest
+    @MethodSource("xmlRequestBodyMediaTypes")
+    void relationshipCollectionRoutePostAcceptsXmlRequestBody(final String mediaType) {
+        final OpenAPI openApi = new Swaggerizer(apiDefn(relationshipModel())).swagger();
+
+        final PathItem relationshipCollection = openApi.getPaths().get("/projects/{id}/tasks");
+
         Assertions.assertTrue(
                 relationshipCollection
                         .getPost()
                         .getRequestBody()
                         .getContent()
-                        .containsKey("application/xml"));
-        Assertions.assertTrue(
-                relationshipCollection
-                        .getPost()
-                        .getRequestBody()
-                        .getContent()
-                        .containsKey("text/xml"));
+                        .containsKey(mediaType));
+    }
+
+    @Test
+    void singleTargetRelationshipRouteGetUsesTargetSchema() {
+        final OpenAPI openApi = new Swaggerizer(apiDefn(relationshipModel())).swagger();
 
         final PathItem singleTargetRelationship = openApi.getPaths().get("/todos/{id}/project");
+
         Assertions.assertNotNull(singleTargetRelationship);
         Assertions.assertEquals(
                 "#/components/schemas/project",
@@ -113,9 +151,15 @@ class SwaggerizerEntityDescriptionTest {
                         .get("application/json")
                         .getSchema()
                         .get$ref());
+    }
+
+    @Test
+    void relationshipInstanceRouteRequiresSourceAndRelatedPathParameters() {
+        final OpenAPI openApi = new Swaggerizer(apiDefn(relationshipModel())).swagger();
 
         final PathItem relationshipInstance =
                 openApi.getPaths().get("/projects/{id}/tasks/{relatedId}");
+
         Assertions.assertNotNull(relationshipInstance);
         Assertions.assertEquals(
                 Set.of("id", "relatedId"), pathParameterNames(relationshipInstance));
@@ -125,7 +169,7 @@ class SwaggerizerEntityDescriptionTest {
     }
 
     @Test
-    void responseContentAdvertisesAdditionalRepresentations() {
+    void responseContentAdvertisesJsonComponentSchema() {
         final OpenAPI openApi = new Swaggerizer(apiDefn(relationshipModel())).swagger();
 
         final Content content =
@@ -134,45 +178,80 @@ class SwaggerizerEntityDescriptionTest {
         Assertions.assertEquals(
                 "#/components/schemas/projects",
                 content.get("application/json").getSchema().get$ref());
+    }
+
+    @Test
+    void responseContentAdvertisesApplicationXmlCollectionSchema() {
+        final OpenAPI openApi = new Swaggerizer(apiDefn(relationshipModel())).swagger();
+
+        final Content content =
+                openApi.getPaths().get("/projects").getGet().getResponses().get("200").getContent();
+
         final Schema<?> xmlCollectionSchema = content.get("application/xml").getSchema();
+
         Assertions.assertNull(xmlCollectionSchema.get$ref());
         Assertions.assertEquals("array", xmlCollectionSchema.getType());
         Assertions.assertEquals("projects", xmlCollectionSchema.getXml().getName());
         Assertions.assertTrue(xmlCollectionSchema.getXml().getWrapped());
-        for (String xmlMediaType : List.of("text/xml")) {
-            final Schema<?> compatibleXmlCollectionSchema = content.get(xmlMediaType).getSchema();
-            Assertions.assertNull(compatibleXmlCollectionSchema.get$ref());
-            Assertions.assertEquals("array", compatibleXmlCollectionSchema.getType());
-            Assertions.assertEquals("projects", compatibleXmlCollectionSchema.getXml().getName());
-            Assertions.assertTrue(compatibleXmlCollectionSchema.getXml().getWrapped());
-        }
-        for (String mediaType :
-                List.of(
-                        "text/csv",
-                        "text/plain",
-                        "text/html",
-                        "application/x-ndjson",
-                        "application/jsonl",
-                        "application/json-seq",
-                        "text/tab-separated-values")) {
-            Assertions.assertEquals("string", content.get(mediaType).getSchema().getType());
-        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("xmlCompatibleResponseMediaTypes")
+    void responseContentAdvertisesXmlCompatibleCollectionSchema(final String mediaType) {
+        final OpenAPI openApi = new Swaggerizer(apiDefn(relationshipModel())).swagger();
+
+        final Content content =
+                openApi.getPaths().get("/projects").getGet().getResponses().get("200").getContent();
+
+        final Schema<?> compatibleXmlCollectionSchema = content.get(mediaType).getSchema();
+
+        Assertions.assertNull(compatibleXmlCollectionSchema.get$ref());
+        Assertions.assertEquals("array", compatibleXmlCollectionSchema.getType());
+        Assertions.assertEquals("projects", compatibleXmlCollectionSchema.getXml().getName());
+        Assertions.assertTrue(compatibleXmlCollectionSchema.getXml().getWrapped());
+    }
+
+    @ParameterizedTest
+    @MethodSource("stringResponseMediaTypes")
+    void responseContentAdvertisesStringSchemaForTextAndStreamingRepresentations(
+            final String mediaType) {
+        final OpenAPI openApi = new Swaggerizer(apiDefn(relationshipModel())).swagger();
+
+        final Content content =
+                openApi.getPaths().get("/projects").getGet().getResponses().get("200").getContent();
+
+        Assertions.assertEquals("string", content.get(mediaType).getSchema().getType());
+    }
+
+    @ParameterizedTest
+    @MethodSource("filterableCollectionOperations")
+    void filterableCollectionOperationExposesSortByParameter(
+            final String path, final String operationKind) {
+        final OpenAPI openApi = new Swaggerizer(apiDefn(relationshipModel())).swagger();
+
+        assertSortByParameter(operationFor(openApi, path, operationKind));
+    }
+
+    @ParameterizedTest
+    @MethodSource("filterableCollectionOperations")
+    void filterableCollectionOperationExposesPagingParameters(
+            final String path, final String operationKind) {
+        final OpenAPI openApi = new Swaggerizer(apiDefn(relationshipModel())).swagger();
+
+        assertPagingParameters(operationFor(openApi, path, operationKind));
+    }
+
+    @ParameterizedTest
+    @MethodSource("queryOperationPaths")
+    void queryOperationExposesQueryContentTypes(final String path) {
+        final OpenAPI openApi = new Swaggerizer(apiDefn(relationshipModel())).swagger();
+
+        assertQueryContentTypes(queryOperation(openApi.getPaths().get(path)));
     }
 
     @Test
-    void filterableCollectionOperationsExposeSortByParameter() {
+    void singleTargetRelationshipDoesNotExposeSortByParameter() {
         final OpenAPI openApi = new Swaggerizer(apiDefn(relationshipModel())).swagger();
-
-        assertSortByParameter(openApi.getPaths().get("/projects").getGet());
-        assertPagingParameters(openApi.getPaths().get("/projects").getGet());
-        assertSortByParameter(queryOperation(openApi.getPaths().get("/projects")));
-        assertPagingParameters(queryOperation(openApi.getPaths().get("/projects")));
-        assertQueryContentTypes(queryOperation(openApi.getPaths().get("/projects")));
-        assertSortByParameter(openApi.getPaths().get("/projects/{id}/tasks").getGet());
-        assertPagingParameters(openApi.getPaths().get("/projects/{id}/tasks").getGet());
-        assertSortByParameter(queryOperation(openApi.getPaths().get("/projects/{id}/tasks")));
-        assertPagingParameters(queryOperation(openApi.getPaths().get("/projects/{id}/tasks")));
-        assertQueryContentTypes(queryOperation(openApi.getPaths().get("/projects/{id}/tasks")));
 
         Operation singleTargetRelationshipGet =
                 openApi.getPaths().get("/todos/{id}/project").getGet();
@@ -226,6 +305,45 @@ class SwaggerizerEntityDescriptionTest {
 
     private Operation queryOperation(final PathItem pathItem) {
         return (Operation) pathItem.getExtensions().get("x-query-operation");
+    }
+
+    private Operation operationFor(
+            final OpenAPI openApi, final String path, final String operationKind) {
+        if ("query".equals(operationKind)) {
+            return queryOperation(openApi.getPaths().get(path));
+        }
+        return openApi.getPaths().get(path).getGet();
+    }
+
+    private static Stream<String> xmlRequestBodyMediaTypes() {
+        return Stream.of("application/xml", "text/xml");
+    }
+
+    private static Stream<String> xmlCompatibleResponseMediaTypes() {
+        return Stream.of("text/xml");
+    }
+
+    private static Stream<String> stringResponseMediaTypes() {
+        return Stream.of(
+                "text/csv",
+                "text/plain",
+                "text/html",
+                "application/x-ndjson",
+                "application/jsonl",
+                "application/json-seq",
+                "text/tab-separated-values");
+    }
+
+    private static Stream<Arguments> filterableCollectionOperations() {
+        return Stream.of(
+                Arguments.of("/projects", "get"),
+                Arguments.of("/projects", "query"),
+                Arguments.of("/projects/{id}/tasks", "get"),
+                Arguments.of("/projects/{id}/tasks", "query"));
+    }
+
+    private static Stream<String> queryOperationPaths() {
+        return Stream.of("/projects", "/projects/{id}/tasks");
     }
 
     private void assertSortByParameter(final Operation operation) {

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerSchemaExampleTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerSchemaExampleTest.java
@@ -38,6 +38,7 @@ class SwaggerizerSchemaExampleTest {
                 itemsSchema.getAsJsonObject("properties").getAsJsonObject("items");
         final JsonObject itemSchema = itemsProperty.getAsJsonObject("items");
         final JsonObject xmlItemsSchema = responseSchemaFor(document, "/items", "application/xml");
+        final JsonObject textXmlItemsSchema = responseSchemaFor(document, "/items", "text/xml");
         final JsonObject xmlItemSchema = xmlItemsSchema.getAsJsonObject("items");
 
         Assertions.assertFalse(schemas.has("items_xml_collection"));
@@ -73,6 +74,9 @@ class SwaggerizerSchemaExampleTest {
         Assertions.assertEquals(
                 Set.of("id", "type", "isbn13", "price", "numberinstock"),
                 requiredPropertiesIn(xmlItemSchema, "XML item"));
+        Assertions.assertEquals("array", textXmlItemsSchema.get("type").getAsString());
+        Assertions.assertEquals(
+                "items", textXmlItemsSchema.getAsJsonObject("xml").get("name").getAsString());
     }
 
     @Test

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerSchemaExampleTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerSchemaExampleTest.java
@@ -17,31 +17,15 @@ import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.F
 class SwaggerizerSchemaExampleTest {
 
     @Test
-    void collectionResponseSchemasUseJsonWrapperAndXmlWrappedArray() {
-        final Thingifier thingifier = new Thingifier();
-        final EntityDefinition item = thingifier.defineThing("item", "items");
-        item.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT).withExample("21"));
-        item.addField(Field.is("type", FieldType.STRING).withExample("cd"));
-        item.addField(Field.is("isbn13", FieldType.STRING).withExample("123-4-56-789012-3"));
-        item.addField(Field.is("price", FieldType.FLOAT).withExample("97.99"));
-        item.addField(Field.is("numberinstock", FieldType.INTEGER).withExample("0"));
-
-        final ThingifierApiDocumentationDefn apiDefn =
-                new ThingifierApiDocumentationDefn().setThingifier(thingifier);
-
-        final JsonObject document =
-                JsonParser.parseString(new Swaggerizer(apiDefn).asJson()).getAsJsonObject();
+    void jsonCollectionResponseSchemaUsesWrapperObject() {
+        final JsonObject document = schemaExampleDocument();
         final JsonObject schemas =
                 document.getAsJsonObject("components").getAsJsonObject("schemas");
         final JsonObject itemsSchema = schemas.getAsJsonObject("items");
         final JsonObject itemsProperty =
                 itemsSchema.getAsJsonObject("properties").getAsJsonObject("items");
         final JsonObject itemSchema = itemsProperty.getAsJsonObject("items");
-        final JsonObject xmlItemsSchema = responseSchemaFor(document, "/items", "application/xml");
-        final JsonObject textXmlItemsSchema = responseSchemaFor(document, "/items", "text/xml");
-        final JsonObject xmlItemSchema = xmlItemsSchema.getAsJsonObject("items");
 
-        Assertions.assertFalse(schemas.has("items_xml_collection"));
         Assertions.assertEquals("object", itemsSchema.get("type").getAsString());
         Assertions.assertEquals("array", itemsProperty.get("type").getAsString());
         Assertions.assertEquals("object", itemSchema.get("type").getAsString());
@@ -62,6 +46,17 @@ class SwaggerizerSchemaExampleTest {
                         .getAsJsonObject("schema")
                         .get("$ref")
                         .getAsString());
+    }
+
+    @Test
+    void applicationXmlCollectionResponseSchemaUsesWrappedArray() {
+        final JsonObject document = schemaExampleDocument();
+        final JsonObject schemas =
+                document.getAsJsonObject("components").getAsJsonObject("schemas");
+        final JsonObject xmlItemsSchema = responseSchemaFor(document, "/items", "application/xml");
+        final JsonObject xmlItemSchema = xmlItemsSchema.getAsJsonObject("items");
+
+        Assertions.assertFalse(schemas.has("items_xml_collection"));
         Assertions.assertFalse(xmlItemsSchema.has("$ref"));
 
         Assertions.assertEquals("array", xmlItemsSchema.get("type").getAsString());
@@ -74,9 +69,19 @@ class SwaggerizerSchemaExampleTest {
         Assertions.assertEquals(
                 Set.of("id", "type", "isbn13", "price", "numberinstock"),
                 requiredPropertiesIn(xmlItemSchema, "XML item"));
+    }
+
+    @Test
+    void textXmlCollectionResponseSchemaUsesWrappedArray() {
+        final JsonObject document = schemaExampleDocument();
+        final JsonObject textXmlItemsSchema = responseSchemaFor(document, "/items", "text/xml");
+
+        Assertions.assertFalse(textXmlItemsSchema.has("$ref"));
         Assertions.assertEquals("array", textXmlItemsSchema.get("type").getAsString());
         Assertions.assertEquals(
                 "items", textXmlItemsSchema.getAsJsonObject("xml").get("name").getAsString());
+        Assertions.assertTrue(
+                textXmlItemsSchema.getAsJsonObject("xml").get("wrapped").getAsBoolean());
     }
 
     @Test
@@ -107,6 +112,21 @@ class SwaggerizerSchemaExampleTest {
         Assertions.assertFalse(itemXmlSchema.has("$ref"));
         Assertions.assertEquals(
                 "items", itemXmlSchema.getAsJsonObject("xml").get("name").getAsString());
+    }
+
+    private JsonObject schemaExampleDocument() {
+        final Thingifier thingifier = new Thingifier();
+        final EntityDefinition item = thingifier.defineThing("item", "items");
+        item.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT).withExample("21"));
+        item.addField(Field.is("type", FieldType.STRING).withExample("cd"));
+        item.addField(Field.is("isbn13", FieldType.STRING).withExample("123-4-56-789012-3"));
+        item.addField(Field.is("price", FieldType.FLOAT).withExample("97.99"));
+        item.addField(Field.is("numberinstock", FieldType.INTEGER).withExample("0"));
+
+        final ThingifierApiDocumentationDefn apiDefn =
+                new ThingifierApiDocumentationDefn().setThingifier(thingifier);
+
+        return JsonParser.parseString(new Swaggerizer(apiDefn).asJson()).getAsJsonObject();
     }
 
     private JsonObject responseSchemaFor(


### PR DESCRIPTION
## Summary
- Add XML-compatible Accept negotiation for `text/xml` and supported concrete `application/...+xml` media types.
- Keep unsupported XML-family types rejected rather than treating every `+xml` value as a normal resource representation.
- Refactor the amended Accept, Content-Type, HTTP API, XML request/response, and Swagger tests into smaller rule-focused or data-driven tests.

## Validation
- Focused Maven suite passed.
- `mvn spotless:check` passed.
- `mvn -pl thingifier -am test` passed.