### PR TITLE
Normalize OPTIONS documentation paths

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/ApiRoutingDefinitionDocGenerator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/ApiRoutingDefinitionDocGenerator.java
@@ -180,7 +180,7 @@ public class ApiRoutingDefinitionDocGenerator {
 
             // TODO: allow configurable 200 for options
             defn.addRouting(
-                    String.format("show all Options for endpoint of %s", pluralUrl),
+                    optionsDocumentationFor(pluralUrl),
                     RoutingVerb.OPTIONS,
                     pluralUrl,
                     RoutingStatus.returnValue(204, "the endpoint verb options"),
@@ -352,7 +352,7 @@ public class ApiRoutingDefinitionDocGenerator {
                                             "Could not find a specific %s", entityDefn.getName())));
 
             defn.addRouting(
-                            String.format("show all Options for endpoint of %s", aUrlWGuid),
+                            optionsDocumentationFor(aUrlWGuid),
                             RoutingVerb.OPTIONS,
                             aUrlWGuid,
                             RoutingStatus.returnValue(204),
@@ -519,7 +519,7 @@ public class ApiRoutingDefinitionDocGenerator {
                                         relationshipGetTargetDescription)));
 
         defn.addRouting(
-                String.format("show all Options for endpoint of %s", aUrl),
+                optionsDocumentationFor(aUrl),
                 RoutingVerb.OPTIONS,
                 aUrl,
                 RoutingStatus.returnValue(200),
@@ -605,7 +605,7 @@ public class ApiRoutingDefinitionDocGenerator {
                                 409, String.format("conflict when deleting the relationship")));
 
         defn.addRouting(
-                String.format("show all Options for endpoint of %s", aUrlDelete),
+                optionsDocumentationFor(aUrlDelete),
                 RoutingVerb.OPTIONS,
                 aUrlDelete,
                 RoutingStatus.returnValue(200),
@@ -636,6 +636,15 @@ public class ApiRoutingDefinitionDocGenerator {
             final RelationshipVectorDefinition relationship) {
         return relationship.getCardinality().hasMaximumLimit()
                 && relationship.getCardinality().maximumLimit() == 1;
+    }
+
+    private String optionsDocumentationFor(final String endpointPath) {
+        return String.format(
+                "show all Options for endpoint of %s", documentedEndpointPath(endpointPath));
+    }
+
+    private String documentedEndpointPath(final String endpointPath) {
+        return endpointPath.replaceAll("/{2,}", "/");
     }
 
     private String relationshipGetReturnPayload(final RelationshipVectorDefinition relationship) {

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/docgen/ApiRoutingDefinitionDocGeneratorTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/docgen/ApiRoutingDefinitionDocGeneratorTest.java
@@ -4,6 +4,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.Cardinality;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
@@ -122,6 +124,20 @@ public class ApiRoutingDefinitionDocGeneratorTest {
         Assertions.assertNotNull(route(definition, RoutingVerb.GET, "api/projects/:id/tasks"));
         Assertions.assertNotNull(
                 route(definition, RoutingVerb.DELETE, "api/projects/:id/tasks/:relatedId"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "/api/todos, show all Options for endpoint of /api/todos",
+        "/api/todos/:id, show all Options for endpoint of /api/todos/:id"
+    })
+    public void optionsDocumentationNormalisesDuplicateSlashesFromPathPrefix(
+            final String routeUrl, final String documentation) {
+        ApiRoutingDefinition definition =
+                new ApiRoutingDefinitionDocGenerator(model()).generate("//api");
+
+        Assertions.assertEquals(
+                documentation, route(definition, RoutingVerb.OPTIONS, routeUrl).getDocumentation());
     }
 
     private Thingifier model() {


### PR DESCRIPTION
## What changed

- Normalized generated OPTIONS documentation paths so prefix joins do not produce duplicate leading slashes like `//api/todos`.
- Added regression coverage for generating OpenAPI docs with a `//api` prefix.

## Why

APIChallenges consumes Thingifier-generated OpenAPI text, and clients were repeatedly seeing incorrect OPTIONS descriptions because the generated OpenAPI file contained the duplicated path text.

## Validation

- `mvn -pl thingifier -Dtest=ApiRoutingDefinitionDocGeneratorTest test`
- `mvn -pl thingifier -am install -DskipTests`
- Full Thingifier pre-commit verification: passed
- APIChallenges compatibility check against the local Thingifier snapshot: `mvn -pl challenger -Dtest=ApiChallengeRouteCompatibilityTest test`