### PR TITLE
Add scoped Thingifier hooks

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/hooks/HookScope.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/hooks/HookScope.java
@@ -1,0 +1,79 @@
+package uk.co.compendiumdev.thingifier.adapter.hooks;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
+import uk.co.compendiumdev.thingifier.api.spec.ApiRoutePathMatcher;
+
+public final class HookScope {
+
+    private final String pathPattern;
+    private final Set<RoutingVerb> verbs;
+
+    private HookScope(final String pathPattern, final Set<RoutingVerb> verbs) {
+        this.pathPattern = pathPattern;
+        this.verbs = verbs;
+    }
+
+    public static HookScope any() {
+        return new HookScope(null, Set.of());
+    }
+
+    public static HookScope endpoint(final String pathPattern) {
+        return new HookScope(pathPattern, Set.of());
+    }
+
+    public static HookScope verbs(final RoutingVerb... verbs) {
+        return new HookScope(null, verbsFrom(verbs));
+    }
+
+    public static HookScope endpointAndVerbs(final String pathPattern, final RoutingVerb... verbs) {
+        return new HookScope(pathPattern, verbsFrom(verbs));
+    }
+
+    public static HookScope endpointAndVerbs(
+            final String pathPattern, final Collection<RoutingVerb> verbs) {
+        return new HookScope(pathPattern, verbsFrom(verbs));
+    }
+
+    public boolean matches(
+            final String candidatePath, final RoutingVerb verb, final String apiPathPrefix) {
+        if (!verbs.isEmpty() && (verb == null || !verbs.contains(verb))) {
+            return false;
+        }
+
+        if (pathPattern == null || pathPattern.trim().isEmpty()) {
+            return true;
+        }
+
+        return ApiRoutePathMatcher.pathsMatch(pathPattern, candidatePath, apiPathPrefix);
+    }
+
+    private static Set<RoutingVerb> verbsFrom(final RoutingVerb... verbs) {
+        final EnumSet<RoutingVerb> selected = EnumSet.noneOf(RoutingVerb.class);
+        if (verbs != null) {
+            Collections.addAll(selected, verbs);
+        }
+        if (selected.isEmpty()) {
+            return Set.of();
+        }
+        return Collections.unmodifiableSet(EnumSet.copyOf(selected));
+    }
+
+    private static Set<RoutingVerb> verbsFrom(final Collection<RoutingVerb> verbs) {
+        final EnumSet<RoutingVerb> selected = EnumSet.noneOf(RoutingVerb.class);
+        if (verbs != null) {
+            for (RoutingVerb verb : verbs) {
+                if (verb != null) {
+                    selected.add(verb);
+                }
+            }
+        }
+        if (selected.isEmpty()) {
+            return Set.of();
+        }
+        return Collections.unmodifiableSet(EnumSet.copyOf(selected));
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/hooks/ScopedHook.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/hooks/ScopedHook.java
@@ -1,0 +1,32 @@
+package uk.co.compendiumdev.thingifier.adapter.hooks;
+
+import java.util.Objects;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
+
+public final class ScopedHook<T> {
+
+    private final HookScope scope;
+    private final T hook;
+
+    private ScopedHook(final HookScope scope, final T hook) {
+        this.scope = scope == null ? HookScope.any() : scope;
+        this.hook = Objects.requireNonNull(hook, "hook");
+    }
+
+    public static <T> ScopedHook<T> any(final T hook) {
+        return new ScopedHook<>(HookScope.any(), hook);
+    }
+
+    public static <T> ScopedHook<T> forScope(final HookScope scope, final T hook) {
+        return new ScopedHook<>(scope, hook);
+    }
+
+    public boolean matches(
+            final String candidatePath, final RoutingVerb verb, final String apiPathPrefix) {
+        return scope.matches(candidatePath, verb, apiPathPrefix);
+    }
+
+    public T hook() {
+        return hook;
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/messagehooks/HttpApiHookRegistry.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/messagehooks/HttpApiHookRegistry.java
@@ -1,0 +1,42 @@
+package uk.co.compendiumdev.thingifier.adapter.http.messagehooks;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import uk.co.compendiumdev.thingifier.adapter.hooks.HookScope;
+import uk.co.compendiumdev.thingifier.adapter.hooks.ScopedHook;
+
+public final class HttpApiHookRegistry {
+
+    private final List<ScopedHook<HttpApiRequestHook>> requestHooks;
+    private final List<ScopedHook<HttpApiResponseHook>> responseHooks;
+
+    public HttpApiHookRegistry() {
+        requestHooks = new ArrayList<>();
+        responseHooks = new ArrayList<>();
+    }
+
+    public void registerRequestHook(final HttpApiRequestHook hook) {
+        registerRequestHook(HookScope.any(), hook);
+    }
+
+    public void registerRequestHook(final HookScope scope, final HttpApiRequestHook hook) {
+        requestHooks.add(ScopedHook.forScope(scope, hook));
+    }
+
+    public void registerResponseHook(final HttpApiResponseHook hook) {
+        registerResponseHook(HookScope.any(), hook);
+    }
+
+    public void registerResponseHook(final HookScope scope, final HttpApiResponseHook hook) {
+        responseHooks.add(ScopedHook.forScope(scope, hook));
+    }
+
+    public List<ScopedHook<HttpApiRequestHook>> requestHooks() {
+        return Collections.unmodifiableList(requestHooks);
+    }
+
+    public List<ScopedHook<HttpApiResponseHook>> responseHooks() {
+        return Collections.unmodifiableList(responseHooks);
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/httpserver/ThingifierHttpApiRoutings.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/httpserver/ThingifierHttpApiRoutings.java
@@ -3,8 +3,12 @@ package uk.co.compendiumdev.thingifier.adapter.httpserver;
 import static uk.co.compendiumdev.thingifier.adapter.httpserver.ServerRoutes.*;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.adapter.hooks.HookScope;
+import uk.co.compendiumdev.thingifier.adapter.hooks.ScopedHook;
+import uk.co.compendiumdev.thingifier.adapter.http.messagehooks.HttpApiHookRegistry;
 import uk.co.compendiumdev.thingifier.adapter.http.messagehooks.HttpApiRequestHook;
 import uk.co.compendiumdev.thingifier.adapter.http.messagehooks.HttpApiResponseHook;
 import uk.co.compendiumdev.thingifier.adapter.httpserver.conversion.HttpServerRequestToInternalHttpRequest;
@@ -13,12 +17,14 @@ import uk.co.compendiumdev.thingifier.adapter.httpserver.conversion.InternalHttp
 import uk.co.compendiumdev.thingifier.adapter.httpserver.messagehooks.HttpRequestResponseHook;
 import uk.co.compendiumdev.thingifier.adapter.httpserver.messagehooks.InternalHttpRequestHook;
 import uk.co.compendiumdev.thingifier.adapter.httpserver.messagehooks.InternalHttpResponseHook;
+import uk.co.compendiumdev.thingifier.adapter.internalhttp.InternalHttpMethod;
 import uk.co.compendiumdev.thingifier.adapter.internalhttp.InternalHttpRequest;
 import uk.co.compendiumdev.thingifier.adapter.internalhttp.InternalHttpResponse;
 import uk.co.compendiumdev.thingifier.adapter.internalhttp.conversion.ThingifierHttpApiBridge;
 import uk.co.compendiumdev.thingifier.api.docgen.ApiRoutingDefinition;
 import uk.co.compendiumdev.thingifier.api.docgen.ApiRoutingDefinitionDocGenerator;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingDefinition;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.api.docgen.ThingifierApiDocumentationDefn;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierHttpApi;
 
@@ -29,10 +35,9 @@ public class ThingifierHttpApiRoutings {
     //    private String urlPath;
     private List<HttpRequestResponseHook> preHttpRequestHooks;
     private List<HttpRequestResponseHook> postHttpResponseHooks;
-    private List<InternalHttpRequestHook> preInternalHttpRequestHooks;
-    private List<InternalHttpResponseHook> postInternalHttpResponseHooks;
-    private List<HttpApiRequestHook> httpApiRequestHooks;
-    private final List<HttpApiResponseHook> httpApiResponseHooks;
+    private List<ScopedHook<InternalHttpRequestHook>> preInternalHttpRequestHooks;
+    private List<ScopedHook<InternalHttpResponseHook>> postInternalHttpResponseHooks;
+    private final HttpApiHookRegistry httpApiHooks;
 
     // todo : we should be able to configure the API routing for authorisation and support logging
 
@@ -49,11 +54,9 @@ public class ThingifierHttpApiRoutings {
         postInternalHttpResponseHooks = new ArrayList<>();
 
         // pre and post api request processing, using internal representations
-        httpApiRequestHooks = new ArrayList<>();
-        httpApiResponseHooks = new ArrayList<>();
+        httpApiHooks = new HttpApiHookRegistry();
 
-        ThingifierHttpApiBridge apiBridge =
-                new ThingifierHttpApiBridge(thingifier, httpApiRequestHooks, httpApiResponseHooks);
+        ThingifierHttpApiBridge apiBridge = new ThingifierHttpApiBridge(thingifier, httpApiHooks);
 
         before(
                 (request, response) -> {
@@ -82,9 +85,14 @@ public class ThingifierHttpApiRoutings {
                     InternalHttpRequest iRequest = internalRequestFrom(request);
                     // now run the HttpApiRequestHook hooks on this iRequest
                     if (preInternalHttpRequestHooks != null) {
-                        for (InternalHttpRequestHook hook : preInternalHttpRequestHooks) {
+                        for (ScopedHook<InternalHttpRequestHook> scopedHook :
+                                preInternalHttpRequestHooks) {
+                            if (!scopedHook.matches(
+                                    iRequest.getPath(), routingVerbFor(iRequest.getVerb()), "")) {
+                                continue;
+                            }
                             // todo: catch exceptions and `halt`
-                            InternalHttpResponse hookResponse = hook.run(iRequest);
+                            InternalHttpResponse hookResponse = scopedHook.hook().run(iRequest);
                             if (hookResponse != null) {
                                 InternalHttpResponseToHttpServer.convert(hookResponse, response);
                                 halt(hookResponse.getStatusCode(), hookResponse.getBody());
@@ -104,9 +112,14 @@ public class ThingifierHttpApiRoutings {
 
                     // now run the HttpApiRequestHook hooks on this iRequest
                     if (postInternalHttpResponseHooks != null) {
-                        for (InternalHttpResponseHook hook : postInternalHttpResponseHooks) {
+                        for (ScopedHook<InternalHttpResponseHook> scopedHook :
+                                postInternalHttpResponseHooks) {
+                            if (!scopedHook.matches(
+                                    iRequest.getPath(), routingVerbFor(iRequest.getVerb()), "")) {
+                                continue;
+                            }
                             // todo: catch exceptions and `halt`
-                            hook.run(iRequest, iResponse);
+                            scopedHook.hook().run(iRequest, iResponse);
                         }
                     }
 
@@ -346,7 +359,23 @@ public class ThingifierHttpApiRoutings {
     */
     public void registerHttpApiRequestHook(final HttpApiRequestHook hook) {
         // pre-request hooks run pre-every-api-request
-        httpApiRequestHooks.add(hook);
+        httpApiHooks.registerRequestHook(hook);
+    }
+
+    public void registerHttpApiRequestHook(final HookScope scope, final HttpApiRequestHook hook) {
+        httpApiHooks.registerRequestHook(scope, hook);
+    }
+
+    public void registerHttpApiRequestHook(
+            final String pathPattern, final HttpApiRequestHook hook) {
+        registerHttpApiRequestHook(HookScope.endpoint(pathPattern), hook);
+    }
+
+    public void registerHttpApiRequestHook(
+            final String pathPattern,
+            final Collection<RoutingVerb> verbs,
+            final HttpApiRequestHook hook) {
+        registerHttpApiRequestHook(HookScope.endpointAndVerbs(pathPattern, verbs), hook);
     }
 
     /*
@@ -355,17 +384,67 @@ public class ThingifierHttpApiRoutings {
     */
     public void registerHttpApiResponseHook(final HttpApiResponseHook hook) {
         // pre-request hooks run pre-every-api-request
-        httpApiResponseHooks.add(hook);
+        httpApiHooks.registerResponseHook(hook);
+    }
+
+    public void registerHttpApiResponseHook(final HookScope scope, final HttpApiResponseHook hook) {
+        httpApiHooks.registerResponseHook(scope, hook);
+    }
+
+    public void registerHttpApiResponseHook(
+            final String pathPattern, final HttpApiResponseHook hook) {
+        registerHttpApiResponseHook(HookScope.endpoint(pathPattern), hook);
+    }
+
+    public void registerHttpApiResponseHook(
+            final String pathPattern,
+            final Collection<RoutingVerb> verbs,
+            final HttpApiResponseHook hook) {
+        registerHttpApiResponseHook(HookScope.endpointAndVerbs(pathPattern, verbs), hook);
     }
 
     public void registerInternalHttpResponseHook(final InternalHttpResponseHook hook) {
         // pre-request hooks run post api processing on an internal http representation
-        postInternalHttpResponseHooks.add(hook);
+        postInternalHttpResponseHooks.add(ScopedHook.any(hook));
+    }
+
+    public void registerInternalHttpResponseHook(
+            final HookScope scope, final InternalHttpResponseHook hook) {
+        postInternalHttpResponseHooks.add(ScopedHook.forScope(scope, hook));
+    }
+
+    public void registerInternalHttpResponseHook(
+            final String pathPattern, final InternalHttpResponseHook hook) {
+        registerInternalHttpResponseHook(HookScope.endpoint(pathPattern), hook);
+    }
+
+    public void registerInternalHttpResponseHook(
+            final String pathPattern,
+            final Collection<RoutingVerb> verbs,
+            final InternalHttpResponseHook hook) {
+        registerInternalHttpResponseHook(HookScope.endpointAndVerbs(pathPattern, verbs), hook);
     }
 
     public void registerInternalHttpRequestHook(final InternalHttpRequestHook hook) {
         // pre-request hooks run pre api routing on an internal http representation
-        preInternalHttpRequestHooks.add(hook);
+        preInternalHttpRequestHooks.add(ScopedHook.any(hook));
+    }
+
+    public void registerInternalHttpRequestHook(
+            final HookScope scope, final InternalHttpRequestHook hook) {
+        preInternalHttpRequestHooks.add(ScopedHook.forScope(scope, hook));
+    }
+
+    public void registerInternalHttpRequestHook(
+            final String pathPattern, final InternalHttpRequestHook hook) {
+        registerInternalHttpRequestHook(HookScope.endpoint(pathPattern), hook);
+    }
+
+    public void registerInternalHttpRequestHook(
+            final String pathPattern,
+            final Collection<RoutingVerb> verbs,
+            final InternalHttpRequestHook hook) {
+        registerInternalHttpRequestHook(HookScope.endpointAndVerbs(pathPattern, verbs), hook);
     }
 
     private InternalHttpRequest internalRequestFrom(final HttpServerRequest request) {
@@ -396,6 +475,17 @@ public class ThingifierHttpApiRoutings {
             response.header(
                     ThingifierHttpApi.ACCEPT_QUERY_HEADER,
                     ThingifierHttpApi.SUPPORTED_QUERY_CONTENT_TYPES);
+        }
+    }
+
+    private RoutingVerb routingVerbFor(final InternalHttpMethod method) {
+        if (method == null) {
+            return null;
+        }
+        try {
+            return RoutingVerb.valueOf(method.name());
+        } catch (IllegalArgumentException ignored) {
+            return null;
         }
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/internalhttp/conversion/ThingifierHttpApiBridge.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/internalhttp/conversion/ThingifierHttpApiBridge.java
@@ -2,6 +2,7 @@ package uk.co.compendiumdev.thingifier.adapter.internalhttp.conversion;
 
 import java.util.List;
 import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.adapter.http.messagehooks.HttpApiHookRegistry;
 import uk.co.compendiumdev.thingifier.adapter.http.messagehooks.HttpApiRequestHook;
 import uk.co.compendiumdev.thingifier.adapter.http.messagehooks.HttpApiResponseHook;
 import uk.co.compendiumdev.thingifier.adapter.internalhttp.InternalHttpRequest;
@@ -28,6 +29,12 @@ public final class ThingifierHttpApiBridge {
         this.thingifier = aThingifier;
         this.thingifierHttpApi =
                 new ThingifierHttpApi(thingifier, apiRequestHooks, apiResponseHooks);
+    }
+
+    public ThingifierHttpApiBridge(
+            final Thingifier aThingifier, final HttpApiHookRegistry hookRegistry) {
+        this.thingifier = aThingifier;
+        this.thingifierHttpApi = new ThingifierHttpApi(thingifier, hookRegistry);
     }
 
     public InternalHttpResponse get(final InternalHttpRequest theRequest) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.adapter.hooks.ScopedHook;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.SchemaCatalog;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierSchemaCatalog;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.CollectionRoute;
@@ -17,6 +18,7 @@ import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.Relationshi
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.RelationshipInstanceRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRouteMapper;
+import uk.co.compendiumdev.thingifier.adapter.http.messagehooks.HttpApiHookRegistry;
 import uk.co.compendiumdev.thingifier.adapter.http.messagehooks.HttpApiRequestHook;
 import uk.co.compendiumdev.thingifier.adapter.http.messagehooks.HttpApiResponseHook;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
@@ -51,6 +53,7 @@ public final class ThingifierHttpApi {
     private final JsonThing jsonThing;
     private List<HttpApiRequestHook> apiRequestHooks;
     private List<HttpApiResponseHook> apiResponseHooks;
+    private final HttpApiHookRegistry apiHookRegistry;
 
     public enum HttpVerb {
         GET,
@@ -74,6 +77,7 @@ public final class ThingifierHttpApi {
             List<HttpApiRequestHook> apiRequestHooks,
             List<HttpApiResponseHook> apiResponseHooks) {
         this.thingifier = aThingifier;
+        this.apiHookRegistry = null;
 
         // request hooks are used to do initial processing and possibly prevent processing
         if (apiRequestHooks == null) {
@@ -89,6 +93,16 @@ public final class ThingifierHttpApi {
             this.apiResponseHooks = apiResponseHooks;
         }
 
+        jsonThing = new JsonThing(thingifier.apiConfig().jsonOutput());
+    }
+
+    public ThingifierHttpApi(
+            final Thingifier aThingifier, final HttpApiHookRegistry apiHookRegistry) {
+        this.thingifier = aThingifier;
+        this.apiRequestHooks = new ArrayList<>();
+        this.apiResponseHooks = new ArrayList<>();
+        this.apiHookRegistry =
+                apiHookRegistry == null ? new HttpApiHookRegistry() : apiHookRegistry;
         jsonThing = new JsonThing(thingifier.apiConfig().jsonOutput());
     }
 
@@ -111,7 +125,7 @@ public final class ThingifierHttpApi {
         }
 
         // any pre-request override processing
-        HttpApiResponse httpResponse = runTheHttpApiRequestHooksOn(request);
+        HttpApiResponse httpResponse = runTheHttpApiRequestHooksOn(request, effectiveVerb);
 
         // TODO: consider 'validation' hooks which can be used to override/augment validation
 
@@ -154,7 +168,7 @@ public final class ThingifierHttpApi {
         }
 
         // run any post processing response hooks
-        return runTheHttpApiResponseHooksOn(request, httpResponse);
+        return runTheHttpApiResponseHooksOn(request, httpResponse, effectiveVerb);
     }
 
     private boolean isDisabledByApiSpec(final HttpApiRequest request, final HttpVerb verb) {
@@ -575,7 +589,7 @@ public final class ThingifierHttpApi {
 
     public HttpApiResponse query(final HttpApiRequest request, final String query) {
 
-        HttpApiResponse httpResponse = runTheHttpApiRequestHooksOn(request);
+        HttpApiResponse httpResponse = runTheHttpApiRequestHooksOn(request, HttpVerb.GET);
 
         if (httpResponse == null) {
             ApiResponse apiResponse =
@@ -591,11 +605,29 @@ public final class ThingifierHttpApi {
                             xmlEntityNamesFor(request.getPath()));
         }
 
-        return runTheHttpApiResponseHooksOn(request, httpResponse);
+        return runTheHttpApiResponseHooksOn(request, httpResponse, HttpVerb.GET);
     }
 
     private HttpApiResponse runTheHttpApiResponseHooksOn(
-            final HttpApiRequest request, final HttpApiResponse response) {
+            final HttpApiRequest request, final HttpApiResponse response, final HttpVerb verb) {
+        if (apiHookRegistry != null) {
+            final RoutingVerb routingVerb = routingVerbFor(verb);
+            for (ScopedHook<HttpApiResponseHook> scopedHook : apiHookRegistry.responseHooks()) {
+                if (!scopedHook.matches(
+                        request.getPath(),
+                        routingVerb,
+                        thingifier.apiConfig().getApiEndPointPrefix())) {
+                    continue;
+                }
+                HttpApiResponse returnImmediately =
+                        scopedHook.hook().run(request, response, thingifier.apiConfig());
+                if (returnImmediately != null) {
+                    return returnImmediately;
+                }
+            }
+            return response;
+        }
+
         for (HttpApiResponseHook hook : apiResponseHooks) {
             HttpApiResponse returnImmediately = hook.run(request, response, thingifier.apiConfig());
             if (returnImmediately != null) {
@@ -605,7 +637,25 @@ public final class ThingifierHttpApi {
         return response;
     }
 
-    private HttpApiResponse runTheHttpApiRequestHooksOn(final HttpApiRequest request) {
+    private HttpApiResponse runTheHttpApiRequestHooksOn(
+            final HttpApiRequest request, final HttpVerb verb) {
+        if (apiHookRegistry != null) {
+            final RoutingVerb routingVerb = routingVerbFor(verb);
+            for (ScopedHook<HttpApiRequestHook> scopedHook : apiHookRegistry.requestHooks()) {
+                if (!scopedHook.matches(
+                        request.getPath(),
+                        routingVerb,
+                        thingifier.apiConfig().getApiEndPointPrefix())) {
+                    continue;
+                }
+                HttpApiResponse response = scopedHook.hook().run(request, thingifier.apiConfig());
+                if (response != null) {
+                    return response;
+                }
+            }
+            return null;
+        }
+
         for (HttpApiRequestHook hook : apiRequestHooks) {
             HttpApiResponse response = hook.run(request, thingifier.apiConfig());
             if (response != null) {
@@ -613,5 +663,16 @@ public final class ThingifierHttpApi {
             }
         }
         return null;
+    }
+
+    private RoutingVerb routingVerbFor(final HttpVerb verb) {
+        if (verb == null) {
+            return null;
+        }
+        try {
+            return RoutingVerb.valueOf(verb.name());
+        } catch (IllegalArgumentException ignored) {
+            return null;
+        }
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ApiRoutePathMatcher.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ApiRoutePathMatcher.java
@@ -1,0 +1,77 @@
+package uk.co.compendiumdev.thingifier.api.spec;
+
+import java.util.Arrays;
+import java.util.List;
+
+public final class ApiRoutePathMatcher {
+
+    private ApiRoutePathMatcher() {}
+
+    public static boolean pathsMatch(
+            final String rulePath, final String candidatePath, final String apiPathPrefix) {
+        final List<String> ruleSegments = segments(rulePath, apiPathPrefix);
+        final List<String> candidateSegments = segments(candidatePath, apiPathPrefix);
+        if (ruleSegments.size() != candidateSegments.size()) {
+            return false;
+        }
+        for (int index = 0; index < ruleSegments.size(); index++) {
+            final String ruleSegment = ruleSegments.get(index);
+            final String candidateSegment = candidateSegments.get(index);
+            if (isWildcard(ruleSegment) || isWildcard(candidateSegment)) {
+                continue;
+            }
+            if (!ruleSegment.equals(candidateSegment)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static List<String> segments(final String path, final String apiPathPrefix) {
+        final String normalized = removePrefix(normalize(path), normalize(apiPathPrefix));
+        if (normalized.isEmpty()) {
+            return List.of();
+        }
+        return Arrays.stream(normalized.split("/"))
+                .map(ApiRoutePathMatcher::normalizeParameterSegment)
+                .toList();
+    }
+
+    private static String normalize(final String path) {
+        String normalized = path == null ? "" : path.trim();
+        while (normalized.startsWith("/")) {
+            normalized = normalized.substring(1);
+        }
+        while (normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        return normalized;
+    }
+
+    private static String removePrefix(final String path, final String apiPathPrefix) {
+        if (apiPathPrefix == null || apiPathPrefix.isEmpty()) {
+            return path;
+        }
+        if (path.equals(apiPathPrefix)) {
+            return "";
+        }
+        if (path.startsWith(apiPathPrefix + "/")) {
+            return path.substring(apiPathPrefix.length() + 1);
+        }
+        return path;
+    }
+
+    private static String normalizeParameterSegment(final String segment) {
+        if (segment.startsWith(":")) {
+            return "*";
+        }
+        if (segment.startsWith("{") && segment.endsWith("}")) {
+            return "*";
+        }
+        return segment;
+    }
+
+    private static boolean isWildcard(final String segment) {
+        return "*".equals(segment);
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpec.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpec.java
@@ -1,7 +1,6 @@
 package uk.co.compendiumdev.thingifier.api.spec;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
@@ -126,7 +125,10 @@ public final class ThingifierApiSpec {
             final RoutingVerb verb, final String path, final String apiPathPrefix) {
         return routeRules.stream()
                 .filter(rule -> rule.verb() == verb)
-                .filter(rule -> pathsMatch(rule.pathPattern(), path, apiPathPrefix))
+                .filter(
+                        rule ->
+                                ApiRoutePathMatcher.pathsMatch(
+                                        rule.pathPattern(), path, apiPathPrefix))
                 .findFirst();
     }
 
@@ -141,7 +143,10 @@ public final class ThingifierApiSpec {
 
         return entityWritePolicyRules.stream()
                 .filter(rule -> rule.verb() == verb)
-                .filter(rule -> pathsMatch(rule.pathPattern(), path, apiPathPrefix))
+                .filter(
+                        rule ->
+                                ApiRoutePathMatcher.pathsMatch(
+                                        rule.pathPattern(), path, apiPathPrefix))
                 .map(EntityWritePolicyRule::operations)
                 .findFirst();
     }
@@ -156,7 +161,10 @@ public final class ThingifierApiSpec {
         }
 
         return entityPatchPolicyRules.stream()
-                .filter(rule -> pathsMatch(rule.pathPattern(), path, apiPathPrefix))
+                .filter(
+                        rule ->
+                                ApiRoutePathMatcher.pathsMatch(
+                                        rule.pathPattern(), path, apiPathPrefix))
                 .map(EntityPatchPolicyRule::updateStyles)
                 .findFirst();
     }
@@ -172,7 +180,10 @@ public final class ThingifierApiSpec {
 
         return relationshipWritePolicyRules.stream()
                 .filter(rule -> rule.verb() == verb)
-                .filter(rule -> pathsMatch(rule.pathPattern(), path, apiPathPrefix))
+                .filter(
+                        rule ->
+                                ApiRoutePathMatcher.pathsMatch(
+                                        rule.pathPattern(), path, apiPathPrefix))
                 .map(RelationshipWritePolicyRule::operations)
                 .findFirst();
     }
@@ -277,34 +288,6 @@ public final class ThingifierApiSpec {
         return Collections.unmodifiableSet(EnumSet.copyOf(selected));
     }
 
-    private boolean pathsMatch(
-            final String rulePath, final String candidatePath, final String apiPathPrefix) {
-        final List<String> ruleSegments = segments(rulePath, apiPathPrefix);
-        final List<String> candidateSegments = segments(candidatePath, apiPathPrefix);
-        if (ruleSegments.size() != candidateSegments.size()) {
-            return false;
-        }
-        for (int index = 0; index < ruleSegments.size(); index++) {
-            final String ruleSegment = ruleSegments.get(index);
-            final String candidateSegment = candidateSegments.get(index);
-            if (isWildcard(ruleSegment) || isWildcard(candidateSegment)) {
-                continue;
-            }
-            if (!ruleSegment.equals(candidateSegment)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private List<String> segments(final String path, final String apiPathPrefix) {
-        final String normalized = removePrefix(normalize(path), normalize(apiPathPrefix));
-        if (normalized.isEmpty()) {
-            return List.of();
-        }
-        return Arrays.stream(normalized.split("/")).map(this::normalizeParameterSegment).toList();
-    }
-
     private String normalize(final String path) {
         String normalized = path == null ? "" : path.trim();
         while (normalized.startsWith("/")) {
@@ -314,33 +297,6 @@ public final class ThingifierApiSpec {
             normalized = normalized.substring(0, normalized.length() - 1);
         }
         return normalized;
-    }
-
-    private String removePrefix(final String path, final String apiPathPrefix) {
-        if (apiPathPrefix == null || apiPathPrefix.isEmpty()) {
-            return path;
-        }
-        if (path.equals(apiPathPrefix)) {
-            return "";
-        }
-        if (path.startsWith(apiPathPrefix + "/")) {
-            return path.substring(apiPathPrefix.length() + 1);
-        }
-        return path;
-    }
-
-    private String normalizeParameterSegment(final String segment) {
-        if (segment.startsWith(":")) {
-            return "*";
-        }
-        if (segment.startsWith("{") && segment.endsWith("}")) {
-            return "*";
-        }
-        return segment;
-    }
-
-    private boolean isWildcard(final String segment) {
-        return "*".equals(segment);
     }
 
     private static final class EntityWritePolicyRule {

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/hooks/ThingifierHttpApiRequestHooksTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/hooks/ThingifierHttpApiRequestHooksTest.java
@@ -5,7 +5,10 @@ import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.adapter.hooks.HookScope;
+import uk.co.compendiumdev.thingifier.adapter.http.messagehooks.HttpApiHookRegistry;
 import uk.co.compendiumdev.thingifier.adapter.http.messagehooks.HttpApiRequestHook;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.api.ermodelconversion.JsonThing;
 import uk.co.compendiumdev.thingifier.api.http.HttpApiRequest;
 import uk.co.compendiumdev.thingifier.api.http.HttpApiResponse;
@@ -66,6 +69,128 @@ class ThingifierHttpApiRequestHooksTest {
         @Override
         public HttpApiResponse run(final HttpApiRequest request, ThingifierApiConfig config) {
             request.addHeader("X-BOB", "dobbs");
+            return null;
+        }
+    }
+
+    @Test
+    void globalRequestHookStillRunsForEveryApiRequest() {
+        CountingRequestHook hook = new CountingRequestHook();
+        HttpApiHookRegistry hooks = new HttpApiHookRegistry();
+        hooks.registerRequestHook(hook);
+
+        ThingifierHttpApi api = new ThingifierHttpApi(thingifier(), hooks);
+
+        api.get(new HttpApiRequest("/todos"));
+        api.post(new HttpApiRequest("/todos"));
+
+        Assertions.assertEquals(2, hook.callCount);
+    }
+
+    @Test
+    void endpointScopedRequestHookRunsOnlyForMatchingPaths() {
+        CountingRequestHook hook = new CountingRequestHook();
+        HttpApiHookRegistry hooks = new HttpApiHookRegistry();
+        hooks.registerRequestHook(HookScope.endpoint("/api/todos"), hook);
+
+        ThingifierHttpApi api = new ThingifierHttpApi(prefixedThingifier(), hooks);
+
+        api.get(new HttpApiRequest("/api/todos"));
+        api.get(new HttpApiRequest("/api/projects"));
+
+        Assertions.assertEquals(1, hook.callCount);
+    }
+
+    @Test
+    void verbScopedRequestHookRunsOnlyForMatchingVerbs() {
+        CountingRequestHook hook = new CountingRequestHook();
+        HttpApiHookRegistry hooks = new HttpApiHookRegistry();
+        hooks.registerRequestHook(HookScope.verbs(RoutingVerb.POST), hook);
+
+        ThingifierHttpApi api = new ThingifierHttpApi(thingifier(), hooks);
+
+        api.get(new HttpApiRequest("/todos"));
+        api.post(new HttpApiRequest("/todos"));
+
+        Assertions.assertEquals(1, hook.callCount);
+    }
+
+    @Test
+    void requestHookEndpointScopeMatchesCurlyBraceParameter() {
+        CountingRequestHook hook = new CountingRequestHook();
+        HttpApiHookRegistry hooks = new HttpApiHookRegistry();
+        hooks.registerRequestHook(HookScope.endpoint("todos/{id}"), hook);
+
+        ThingifierHttpApi api = new ThingifierHttpApi(thingifier(), hooks);
+
+        api.get(new HttpApiRequest("/todos/123"));
+
+        Assertions.assertEquals(1, hook.callCount);
+    }
+
+    @Test
+    void requestHookEndpointScopeMatchesColonParameter() {
+        CountingRequestHook hook = new CountingRequestHook();
+        HttpApiHookRegistry hooks = new HttpApiHookRegistry();
+        hooks.registerRequestHook(HookScope.endpoint("todos/:id"), hook);
+
+        ThingifierHttpApi api = new ThingifierHttpApi(thingifier(), hooks);
+
+        api.get(new HttpApiRequest("/todos/123"));
+
+        Assertions.assertEquals(1, hook.callCount);
+    }
+
+    @Test
+    void requestHookVerbScopeUsesEffectiveMethodOverrideVerb() {
+        CountingRequestHook hook = new CountingRequestHook();
+        HttpApiHookRegistry hooks = new HttpApiHookRegistry();
+        hooks.registerRequestHook(HookScope.verbs(RoutingVerb.DELETE), hook);
+
+        ThingifierHttpApi api = new ThingifierHttpApi(thingifier(), hooks);
+        HttpApiRequest request =
+                new HttpApiRequest("/todos/123")
+                        .setVerb(HttpApiRequest.VERB.POST)
+                        .addHeader("X-HTTP-Method-Override", "DELETE");
+
+        api.post(request);
+
+        Assertions.assertEquals(1, hook.callCount);
+    }
+
+    @Test
+    void nonMatchingRequestHookDoesNotShortCircuitRequest() {
+        HttpApiHookRegistry hooks = new HttpApiHookRegistry();
+        hooks.registerRequestHook(HookScope.endpoint("todos"), new Instant500Error());
+
+        ThingifierHttpApi api = new ThingifierHttpApi(thingifier(), hooks);
+
+        HttpApiResponse response = api.get(new HttpApiRequest("/projects"));
+
+        Assertions.assertNotEquals(500, response.getStatusCode());
+    }
+
+    private Thingifier thingifier() {
+        Thingifier thingifier = new Thingifier();
+        thingifier.apiConfig().setApiToEnforceAcceptHeaderForResponses(false);
+        thingifier.apiConfig().setApiToEnforceContentTypeForRequests(false);
+        thingifier.defineThing("todo", "todos");
+        return thingifier;
+    }
+
+    private Thingifier prefixedThingifier() {
+        Thingifier thingifier = thingifier();
+        thingifier.configureWithProfile(
+                thingifier.apiConfigProfiles().create("api", "API profile", "/api"));
+        return thingifier;
+    }
+
+    private static class CountingRequestHook implements HttpApiRequestHook {
+        private int callCount;
+
+        @Override
+        public HttpApiResponse run(final HttpApiRequest request, final ThingifierApiConfig config) {
+            callCount++;
             return null;
         }
     }

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/hooks/ThingifierHttpApiResponseHooksTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/hooks/ThingifierHttpApiResponseHooksTest.java
@@ -5,7 +5,10 @@ import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.adapter.hooks.HookScope;
+import uk.co.compendiumdev.thingifier.adapter.http.messagehooks.HttpApiHookRegistry;
 import uk.co.compendiumdev.thingifier.adapter.http.messagehooks.HttpApiResponseHook;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.api.ermodelconversion.JsonThing;
 import uk.co.compendiumdev.thingifier.api.http.HttpApiRequest;
 import uk.co.compendiumdev.thingifier.api.http.HttpApiResponse;
@@ -46,6 +49,131 @@ class ThingifierHttpApiResponseHooksTest {
                 return new HttpApiResponse(
                         null, ApiResponse.error(500, "bypassed all processing"), jsonThing, config);
             }
+            return null;
+        }
+    }
+
+    @Test
+    void globalResponseHookStillRunsForEveryApiRequest() {
+        CountingResponseHook hook = new CountingResponseHook();
+        HttpApiHookRegistry hooks = new HttpApiHookRegistry();
+        hooks.registerResponseHook(hook);
+
+        ThingifierHttpApi api = new ThingifierHttpApi(thingifier(), hooks);
+
+        api.get(new HttpApiRequest("/todos"));
+        api.post(new HttpApiRequest("/todos"));
+
+        Assertions.assertEquals(2, hook.callCount);
+    }
+
+    @Test
+    void endpointScopedResponseHookRunsOnlyForMatchingPaths() {
+        CountingResponseHook hook = new CountingResponseHook();
+        HttpApiHookRegistry hooks = new HttpApiHookRegistry();
+        hooks.registerResponseHook(HookScope.endpoint("/api/todos"), hook);
+
+        ThingifierHttpApi api = new ThingifierHttpApi(prefixedThingifier(), hooks);
+
+        api.get(new HttpApiRequest("/api/todos"));
+        api.get(new HttpApiRequest("/api/projects"));
+
+        Assertions.assertEquals(1, hook.callCount);
+    }
+
+    @Test
+    void verbScopedResponseHookRunsOnlyForMatchingVerbs() {
+        CountingResponseHook hook = new CountingResponseHook();
+        HttpApiHookRegistry hooks = new HttpApiHookRegistry();
+        hooks.registerResponseHook(HookScope.verbs(RoutingVerb.POST), hook);
+
+        ThingifierHttpApi api = new ThingifierHttpApi(thingifier(), hooks);
+
+        api.get(new HttpApiRequest("/todos"));
+        api.post(new HttpApiRequest("/todos"));
+
+        Assertions.assertEquals(1, hook.callCount);
+    }
+
+    @Test
+    void responseHookEndpointScopeMatchesCurlyBraceParameter() {
+        CountingResponseHook hook = new CountingResponseHook();
+        HttpApiHookRegistry hooks = new HttpApiHookRegistry();
+        hooks.registerResponseHook(HookScope.endpoint("todos/{id}"), hook);
+
+        ThingifierHttpApi api = new ThingifierHttpApi(thingifier(), hooks);
+
+        api.get(new HttpApiRequest("/todos/123"));
+
+        Assertions.assertEquals(1, hook.callCount);
+    }
+
+    @Test
+    void responseHookEndpointScopeMatchesColonParameter() {
+        CountingResponseHook hook = new CountingResponseHook();
+        HttpApiHookRegistry hooks = new HttpApiHookRegistry();
+        hooks.registerResponseHook(HookScope.endpoint("todos/:id"), hook);
+
+        ThingifierHttpApi api = new ThingifierHttpApi(thingifier(), hooks);
+
+        api.get(new HttpApiRequest("/todos/123"));
+
+        Assertions.assertEquals(1, hook.callCount);
+    }
+
+    @Test
+    void responseHookVerbScopeUsesEffectiveMethodOverrideVerb() {
+        CountingResponseHook hook = new CountingResponseHook();
+        HttpApiHookRegistry hooks = new HttpApiHookRegistry();
+        hooks.registerResponseHook(HookScope.verbs(RoutingVerb.DELETE), hook);
+
+        ThingifierHttpApi api = new ThingifierHttpApi(thingifier(), hooks);
+        HttpApiRequest request =
+                new HttpApiRequest("/todos/123")
+                        .setVerb(HttpApiRequest.VERB.POST)
+                        .addHeader("X-HTTP-Method-Override", "DELETE");
+
+        api.post(request);
+
+        Assertions.assertEquals(1, hook.callCount);
+    }
+
+    @Test
+    void nonMatchingResponseHookDoesNotShortCircuitResponse() {
+        HttpApiHookRegistry hooks = new HttpApiHookRegistry();
+        hooks.registerResponseHook(HookScope.endpoint("todos"), new And404Becomes500Error());
+
+        ThingifierHttpApi api = new ThingifierHttpApi(thingifier(), hooks);
+
+        HttpApiResponse response = api.get(new HttpApiRequest("/projects"));
+
+        Assertions.assertNotEquals(500, response.getStatusCode());
+    }
+
+    private Thingifier thingifier() {
+        Thingifier thingifier = new Thingifier();
+        thingifier.apiConfig().setApiToEnforceAcceptHeaderForResponses(false);
+        thingifier.apiConfig().setApiToEnforceContentTypeForRequests(false);
+        thingifier.defineThing("todo", "todos");
+        return thingifier;
+    }
+
+    private Thingifier prefixedThingifier() {
+        Thingifier thingifier = thingifier();
+        thingifier.configureWithProfile(
+                thingifier.apiConfigProfiles().create("api", "API profile", "/api"));
+        return thingifier;
+    }
+
+    private static class CountingResponseHook implements HttpApiResponseHook {
+        private int callCount;
+
+        @Override
+        public HttpApiResponse run(
+                final HttpApiRequest request,
+                final HttpApiResponse response,
+                final ThingifierApiConfig config) {
+            callCount++;
             return null;
         }
     }

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/hooks/ThingifierInternalHttpHooksTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/hooks/ThingifierInternalHttpHooksTest.java
@@ -1,0 +1,324 @@
+package uk.co.compendiumdev.thingifier.api.http.hooks;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.adapter.hooks.HookScope;
+import uk.co.compendiumdev.thingifier.adapter.httpserver.HttpRouteRegistry;
+import uk.co.compendiumdev.thingifier.adapter.httpserver.HttpServerRequest;
+import uk.co.compendiumdev.thingifier.adapter.httpserver.HttpServerResponse;
+import uk.co.compendiumdev.thingifier.adapter.httpserver.ThingifierHttpApiRoutings;
+import uk.co.compendiumdev.thingifier.adapter.httpserver.messagehooks.InternalHttpRequestHook;
+import uk.co.compendiumdev.thingifier.adapter.httpserver.messagehooks.InternalHttpResponseHook;
+import uk.co.compendiumdev.thingifier.adapter.internalhttp.InternalHttpRequest;
+import uk.co.compendiumdev.thingifier.adapter.internalhttp.InternalHttpResponse;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
+import uk.co.compendiumdev.thingifier.api.docgen.ThingifierApiDocumentationDefn;
+
+class ThingifierInternalHttpHooksTest {
+
+    @AfterEach
+    void clearRegistry() {
+        HttpRouteRegistry.clearCurrent();
+    }
+
+    @Test
+    void unscopedInternalRequestHookStillRuns() throws Exception {
+        HttpRouteRegistry registry = new HttpRouteRegistry();
+        ThingifierHttpApiRoutings routings = routingsOn(registry);
+        CountingInternalRequestHook hook = new CountingInternalRequestHook();
+        routings.registerInternalHttpRequestHook(hook);
+
+        registry.beforeHandlers().get(0).handle(request("GET", "/not-api"), new StubResponse());
+
+        Assertions.assertEquals(1, hook.callCount);
+    }
+
+    @Test
+    void scopedInternalRequestHookRequiresMatchingRoute() throws Exception {
+        HttpRouteRegistry registry = new HttpRouteRegistry();
+        ThingifierHttpApiRoutings routings = routingsOn(registry);
+        CountingInternalRequestHook hook = new CountingInternalRequestHook();
+        routings.registerInternalHttpRequestHook(
+                HookScope.endpointAndVerbs("/api/heartbeat", RoutingVerb.GET), hook);
+
+        registry.beforeHandlers()
+                .get(0)
+                .handle(request("GET", "/api/heartbeat"), new StubResponse());
+        registry.beforeHandlers()
+                .get(0)
+                .handle(request("POST", "/api/heartbeat"), new StubResponse());
+        registry.beforeHandlers()
+                .get(0)
+                .handle(request("GET", "/api/challenges"), new StubResponse());
+
+        Assertions.assertEquals(1, hook.callCount);
+    }
+
+    @Test
+    void scopedInternalResponseHookRequiresMatchingRoute() throws Exception {
+        HttpRouteRegistry registry = new HttpRouteRegistry();
+        ThingifierHttpApiRoutings routings = routingsOn(registry);
+        CountingInternalResponseHook hook = new CountingInternalResponseHook();
+        routings.registerInternalHttpResponseHook(
+                HookScope.endpointAndVerbs("/api/heartbeat", RoutingVerb.GET), hook);
+
+        registry.afterHandlers().get(0).handle(request("GET", "/api/heartbeat"), response(204));
+        registry.afterHandlers().get(0).handle(request("POST", "/api/heartbeat"), response(204));
+        registry.afterHandlers().get(0).handle(request("GET", "/api/challenges"), response(200));
+
+        Assertions.assertEquals(1, hook.callCount);
+    }
+
+    private ThingifierHttpApiRoutings routingsOn(final HttpRouteRegistry registry) {
+        HttpRouteRegistry.use(registry);
+        ThingifierApiDocumentationDefn apiDefn = new ThingifierApiDocumentationDefn();
+        apiDefn.setPathPrefix("/api");
+        return new ThingifierHttpApiRoutings(new Thingifier(), apiDefn);
+    }
+
+    private StubRequest request(final String method, final String path) {
+        return new StubRequest(method, path);
+    }
+
+    private StubResponse response(final int statusCode) {
+        StubResponse response = new StubResponse();
+        response.status(statusCode);
+        return response;
+    }
+
+    private static class CountingInternalRequestHook implements InternalHttpRequestHook {
+        private int callCount;
+
+        @Override
+        public InternalHttpResponse run(final InternalHttpRequest request) {
+            callCount++;
+            return null;
+        }
+    }
+
+    private static class CountingInternalResponseHook implements InternalHttpResponseHook {
+        private int callCount;
+
+        @Override
+        public void run(final InternalHttpRequest request, final InternalHttpResponse response) {
+            callCount++;
+        }
+    }
+
+    private static class StubRequest implements HttpServerRequest {
+        private final String method;
+        private final String path;
+        private final Map<String, Object> attributes;
+        private final Map<String, String> headers;
+
+        StubRequest(final String method, final String path) {
+            this.method = method;
+            this.path = path;
+            this.attributes = new HashMap<>();
+            this.headers = new LinkedHashMap<>();
+        }
+
+        @Override
+        public Object attribute(final String name) {
+            return attributes.get(name);
+        }
+
+        @Override
+        public void attribute(final String name, final Object value) {
+            attributes.put(name, value);
+        }
+
+        @Override
+        public String body() {
+            return "";
+        }
+
+        @Override
+        public String contentLength() {
+            return "0";
+        }
+
+        @Override
+        public String cookie(final String name) {
+            return "";
+        }
+
+        @Override
+        public String header(final String name) {
+            return headers.getOrDefault(name, "");
+        }
+
+        @Override
+        public Set<String> headerNames() {
+            return headers.keySet();
+        }
+
+        @Override
+        public String host() {
+            return "";
+        }
+
+        @Override
+        public String ip() {
+            return "";
+        }
+
+        @Override
+        public String method() {
+            return method;
+        }
+
+        @Override
+        public String path() {
+            return path;
+        }
+
+        @Override
+        public String pathInfo() {
+            return path;
+        }
+
+        @Override
+        public String protocol() {
+            return "";
+        }
+
+        @Override
+        public String queryParam(final String name) {
+            return "";
+        }
+
+        @Override
+        public Set<String> queryParamNames() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public List<String> queryParams(final String name) {
+            return List.of();
+        }
+
+        @Override
+        public Map<String, List<String>> queryParamMap() {
+            return Map.of();
+        }
+
+        @Override
+        public String queryString() {
+            return "";
+        }
+
+        @Override
+        public String scheme() {
+            return "";
+        }
+
+        @Override
+        public String splat() {
+            return "";
+        }
+
+        @Override
+        public String[] splatValues() {
+            return new String[0];
+        }
+
+        @Override
+        public String url() {
+            return path;
+        }
+
+        @Override
+        public Map<String, String> urlParams() {
+            return Map.of();
+        }
+    }
+
+    private static class StubResponse implements HttpServerResponse {
+        private int statusCode;
+        private String body;
+        private String type;
+        private final Map<String, String> headers;
+
+        StubResponse() {
+            statusCode = 200;
+            body = "";
+            type = "";
+            headers = new LinkedHashMap<>();
+        }
+
+        @Override
+        public String body() {
+            return body;
+        }
+
+        @Override
+        public void body(final String body) {
+            this.body = body;
+        }
+
+        @Override
+        public void forceBody(final String body) {
+            this.body = body;
+        }
+
+        @Override
+        public boolean containsHeader(final String name) {
+            return headers.containsKey(name);
+        }
+
+        @Override
+        public void header(final String name, final String value) {
+            headers.put(name, value);
+        }
+
+        @Override
+        public Map<String, String> headers() {
+            return headers;
+        }
+
+        @Override
+        public void redirect(final String location) {
+            headers.put("Location", location);
+        }
+
+        @Override
+        public void redirect(final String location, final int statusCode) {
+            status(statusCode);
+            redirect(location);
+        }
+
+        @Override
+        public int status() {
+            return statusCode;
+        }
+
+        @Override
+        public void status(final int statusCode) {
+            this.statusCode = statusCode;
+        }
+
+        @Override
+        public void suppressContentType() {
+            type = "";
+        }
+
+        @Override
+        public String type() {
+            return type;
+        }
+
+        @Override
+        public void type(final String contentType) {
+            type = contentType;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add scoped Thingifier hook registration for API and internal request/response hooks
- keep existing unscoped hook registration methods as global hooks
- share ordered hook registries between global and scoped hooks
- extract route-template path matching so `{id}` and `:id` wildcard segments behave consistently

## Validation
- `mvn -pl thingifier -Dtest=*HooksTest test`
- `mvn -pl thingifier test`
- `mvn -pl thingifier spotless:check checkstyle:check`
- `git diff --check`
- `mvn -pl thingifier -am install -DskipTests`