### PR TITLE
Expand relationship functionality

### DIFF
--- a/checkstyle-project-fqn.xml
+++ b/checkstyle-project-fqn.xml
@@ -144,6 +144,10 @@
         <property name="id" value="productionDeprecatedApi"/>
         <property name="files" value=".*[/\\]thingifier[/\\]src[/\\]main[/\\]java[/\\]uk[/\\]co[/\\]compendiumdev[/\\]thingifier[/\\]Thingifier\.java"/>
     </module>
+    <module name="SuppressionSingleFilter">
+        <property name="id" value="productionDeprecatedApi"/>
+        <property name="files" value=".*[/\\]thingifier[/\\]src[/\\]main[/\\]java[/\\]uk[/\\]co[/\\]compendiumdev[/\\]thingifier[/\\]api[/\\]spec[/\\]ThingifierApiRouteRule\.java"/>
+    </module>
     <module name="RegexpMultiline">
         <property name="id" value="commandDtosNoMutableDomain"/>
         <property name="format" value="(?s)package uk\.co\.compendiumdev\.thingifier\.application\.command;.*import uk\.co\.compendiumdev\.thingifier\.core\.domain\.(definitions\.EntityDefinition|instances\.(EntityInstance|EntityInstanceDraft));"/>

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/field/definition/Field.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/field/definition/Field.java
@@ -4,6 +4,7 @@ import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.DefinedFields;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.field.instance.FieldValue;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.validation.*;
 import uk.co.compendiumdev.thingifier.core.domain.randomdata.RandomString;
@@ -33,6 +34,7 @@ public final class Field {
     private int truncatedStringLength;
     private Function<String, String> transformToMakeUnique;
     private String description;
+    private FieldRelationshipReference relationshipReference;
 
     // todo: rather than all these fields, consider moving to more validation rules
     // to help keep the class to a more manageable size or create a FieldValidator class
@@ -74,6 +76,7 @@ public final class Field {
 
         description = "";
         transformToMakeUnique = (s) -> s;
+        relationshipReference = null;
     }
 
     public static Field is(String name, FieldType type) {
@@ -449,6 +452,45 @@ public final class Field {
 
     public String getDescription() {
         return description;
+    }
+
+    /**
+     * Declares that this field references another entity through a named relationship.
+     *
+     * <p>The field remains part of the source entity's data. During write processing, Thingifier
+     * resolves the supplied field value against {@code targetFieldName} on {@code targetEntity} and
+     * connects the source instance through {@code relationshipName}.
+     *
+     * @param targetEntity entity containing the referenced value
+     * @param targetFieldName field on the target entity to match
+     * @param relationshipName relationship from this field's owning entity to the target entity
+     * @return this field so definition code can be chained
+     */
+    public Field references(
+            final EntityDefinition targetEntity,
+            final String targetFieldName,
+            final String relationshipName) {
+        relationshipReference =
+                FieldRelationshipReference.to(targetEntity, targetFieldName, relationshipName);
+        return this;
+    }
+
+    /**
+     * Reports whether this field declares a relationship reference.
+     *
+     * @return true when writes to the field should also maintain a relationship
+     */
+    public boolean hasRelationshipReference() {
+        return relationshipReference != null;
+    }
+
+    /**
+     * Returns this field's relationship reference metadata.
+     *
+     * @return relationship reference metadata, or null when none is configured
+     */
+    public FieldRelationshipReference relationshipReference() {
+        return relationshipReference;
     }
 
     public Field withMinMaxValues(int minInt, int maxInt) {

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/field/definition/FieldRelationshipReference.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/field/definition/FieldRelationshipReference.java
@@ -1,0 +1,78 @@
+package uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition;
+
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+
+/**
+ * Describes how a normal field value points at another entity through a named relationship.
+ *
+ * <p>The source field remains a persisted field on its own entity. Thingifier uses this metadata to
+ * validate the referenced target exists and to maintain the configured relationship whenever the
+ * source field is supplied in a write request.
+ */
+public final class FieldRelationshipReference {
+
+    private final EntityDefinition targetEntity;
+    private final String targetFieldName;
+    private final String relationshipName;
+
+    private FieldRelationshipReference(
+            final EntityDefinition targetEntity,
+            final String targetFieldName,
+            final String relationshipName) {
+        this.targetEntity = targetEntity;
+        this.targetFieldName = requireText(targetFieldName, "targetFieldName");
+        this.relationshipName = requireText(relationshipName, "relationshipName");
+    }
+
+    /**
+     * Creates a field relationship reference.
+     *
+     * @param targetEntity entity containing the referenced value
+     * @param targetFieldName field on the target entity to match
+     * @param relationshipName relationship from the source entity to the target entity
+     * @return relationship reference metadata
+     */
+    public static FieldRelationshipReference to(
+            final EntityDefinition targetEntity,
+            final String targetFieldName,
+            final String relationshipName) {
+        if (targetEntity == null) {
+            throw new IllegalArgumentException("targetEntity is required");
+        }
+        return new FieldRelationshipReference(targetEntity, targetFieldName, relationshipName);
+    }
+
+    /**
+     * Returns the entity containing the referenced value.
+     *
+     * @return target entity definition
+     */
+    public EntityDefinition targetEntity() {
+        return targetEntity;
+    }
+
+    /**
+     * Returns the target field name used to resolve the relationship.
+     *
+     * @return target field name
+     */
+    public String targetFieldName() {
+        return targetFieldName;
+    }
+
+    /**
+     * Returns the relationship name to maintain from the source entity to the target entity.
+     *
+     * @return relationship name
+     */
+    public String relationshipName() {
+        return relationshipName;
+    }
+
+    private static String requireText(final String value, final String name) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(name + " is required");
+        }
+        return value;
+    }
+}

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/relationship/RelationshipDefinition.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/relationship/RelationshipDefinition.java
@@ -83,6 +83,32 @@ public class RelationshipDefinition {
         return fromTo;
     }
 
+    /**
+     * Configures the forward relationship vector to delete targets when disconnected.
+     *
+     * <p>This convenience method covers the common ownership case. Use {@link
+     * #getReversedRelationship()} when the reverse vector should have a different policy.
+     *
+     * @return this relationship definition so model configuration can be chained
+     */
+    public RelationshipDefinition deleteTargetWhenDisconnected() {
+        fromTo.deleteTargetWhenDisconnected();
+        return this;
+    }
+
+    /**
+     * Configures the forward relationship vector to delete targets when the source is deleted.
+     *
+     * <p>This convenience method covers the common ownership case. Use {@link
+     * #getReversedRelationship()} when the reverse vector should have a different policy.
+     *
+     * @return this relationship definition so model configuration can be chained
+     */
+    public RelationshipDefinition deleteTargetsWhenSourceDeleted() {
+        fromTo.deleteTargetsWhenSourceDeleted();
+        return this;
+    }
+
     /* given a vector in this relationship, return the other one */
     public RelationshipVectorDefinition otherVectorOf(
             final RelationshipVectorDefinition relationshipVector) {

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/relationship/RelationshipVectorDefinition.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/relationship/RelationshipVectorDefinition.java
@@ -23,6 +23,8 @@ public class RelationshipVectorDefinition {
     private EntityDefinition from;
     private EntityDefinition to;
     private RelationshipDefinition parentRelationship;
+    private boolean deleteTargetWhenDisconnected;
+    private boolean deleteTargetsWhenSourceDeleted;
 
     public RelationshipVectorDefinition(
             EntityDefinition from,
@@ -34,6 +36,8 @@ public class RelationshipVectorDefinition {
         this.to = to;
         this.cardinality = cardinality;
         this.optionality = OPTIONAL_RELATIONSHIP;
+        this.deleteTargetWhenDisconnected = false;
+        this.deleteTargetsWhenSourceDeleted = false;
 
         // assign to the from thingDefinition
         from.related().addRelationship(this);
@@ -70,5 +74,49 @@ public class RelationshipVectorDefinition {
 
     public void forRelationship(final RelationshipDefinition relationshipDefinition) {
         this.parentRelationship = relationshipDefinition;
+    }
+
+    /**
+     * Configures relationship instance deletion to delete the related target entity.
+     *
+     * <p>This models owned children such as cart items, where removing the relationship from the
+     * source should remove the target record rather than merely disconnecting it.
+     *
+     * @return this vector so relationship configuration can be chained
+     */
+    public RelationshipVectorDefinition deleteTargetWhenDisconnected() {
+        deleteTargetWhenDisconnected = true;
+        return this;
+    }
+
+    /**
+     * Configures source entity deletion to delete all currently related target entities.
+     *
+     * <p>This is an explicit cascade policy for generated and direct Thingifier deletes. It is
+     * independent of mandatory-relationship cleanup, which remains the store's responsibility.
+     *
+     * @return this vector so relationship configuration can be chained
+     */
+    public RelationshipVectorDefinition deleteTargetsWhenSourceDeleted() {
+        deleteTargetsWhenSourceDeleted = true;
+        return this;
+    }
+
+    /**
+     * Reports whether disconnecting this vector should delete the target entity.
+     *
+     * @return true when relationship-instance DELETE should also delete the target
+     */
+    public boolean shouldDeleteTargetWhenDisconnected() {
+        return deleteTargetWhenDisconnected;
+    }
+
+    /**
+     * Reports whether deleting the source should delete related targets for this vector.
+     *
+     * @return true when source entity DELETE should cascade to current targets
+     */
+    public boolean shouldDeleteTargetsWhenSourceDeleted() {
+        return deleteTargetsWhenSourceDeleted;
     }
 }

--- a/thingifier-yaml/src/main/java/uk/co/compendiumdev/thingifier/yaml/internal/YamlFieldDocument.java
+++ b/thingifier-yaml/src/main/java/uk/co/compendiumdev/thingifier/yaml/internal/YamlFieldDocument.java
@@ -18,6 +18,7 @@ public final class YamlFieldDocument {
     private final String maxValue;
     private final List<Object> validations;
     private final Map<String, YamlFieldDocument> fields;
+    private final YamlFieldReferenceDocument reference;
 
     private YamlFieldDocument(
             final String name,
@@ -31,7 +32,8 @@ public final class YamlFieldDocument {
             final String minValue,
             final String maxValue,
             final List<Object> validations,
-            final Map<String, YamlFieldDocument> fields) {
+            final Map<String, YamlFieldDocument> fields,
+            final YamlFieldReferenceDocument reference) {
         this.name = name;
         this.type = type;
         this.required = required;
@@ -44,6 +46,7 @@ public final class YamlFieldDocument {
         this.maxValue = maxValue;
         this.validations = validations;
         this.fields = fields;
+        this.reference = reference;
     }
 
     static YamlFieldDocument fromEntry(final String name, final Object source) {
@@ -60,7 +63,8 @@ public final class YamlFieldDocument {
                 YamlMapSupport.stringValue(map.get("min")),
                 YamlMapSupport.stringValue(map.get("max")),
                 YamlMapSupport.listValue(map.get("validations")),
-                fieldsFrom(map.get("fields")));
+                fieldsFrom(map.get("fields")),
+                YamlFieldReferenceDocument.fromObject(map.get("reference")));
     }
 
     public String name() {
@@ -109,6 +113,10 @@ public final class YamlFieldDocument {
 
     public Map<String, YamlFieldDocument> fields() {
         return fields;
+    }
+
+    public YamlFieldReferenceDocument reference() {
+        return reference;
     }
 
     private static Map<String, YamlFieldDocument> fieldsFrom(final Object source) {

--- a/thingifier-yaml/src/main/java/uk/co/compendiumdev/thingifier/yaml/internal/YamlFieldReferenceDocument.java
+++ b/thingifier-yaml/src/main/java/uk/co/compendiumdev/thingifier/yaml/internal/YamlFieldReferenceDocument.java
@@ -1,0 +1,42 @@
+package uk.co.compendiumdev.thingifier.yaml.internal;
+
+import java.util.Map;
+
+public final class YamlFieldReferenceDocument {
+
+    private final String targetEntityName;
+    private final String targetFieldName;
+    private final String relationshipName;
+
+    private YamlFieldReferenceDocument(
+            final String targetEntityName,
+            final String targetFieldName,
+            final String relationshipName) {
+        this.targetEntityName = targetEntityName;
+        this.targetFieldName = targetFieldName;
+        this.relationshipName = relationshipName;
+    }
+
+    static YamlFieldReferenceDocument fromObject(final Object source) {
+        if (source == null) {
+            return null;
+        }
+        final Map<String, Object> map = YamlMapSupport.asMap(source);
+        return new YamlFieldReferenceDocument(
+                YamlMapSupport.stringValue(map.get("entity")),
+                YamlMapSupport.stringValue(map.get("field")),
+                YamlMapSupport.stringValue(map.get("relationship")));
+    }
+
+    public String targetEntityName() {
+        return targetEntityName;
+    }
+
+    public String targetFieldName() {
+        return targetFieldName;
+    }
+
+    public String relationshipName() {
+        return relationshipName;
+    }
+}

--- a/thingifier-yaml/src/main/java/uk/co/compendiumdev/thingifier/yaml/internal/YamlRelationshipDocument.java
+++ b/thingifier-yaml/src/main/java/uk/co/compendiumdev/thingifier/yaml/internal/YamlRelationshipDocument.java
@@ -9,6 +9,8 @@ public final class YamlRelationshipDocument {
     private final String toEntityName;
     private final String cardinality;
     private final String optionality;
+    private final boolean deleteTargetWhenDisconnected;
+    private final boolean deleteTargetsWhenSourceDeleted;
     private final YamlRelationshipReverseDocument reverse;
 
     private YamlRelationshipDocument(
@@ -17,12 +19,16 @@ public final class YamlRelationshipDocument {
             final String toEntityName,
             final String cardinality,
             final String optionality,
+            final boolean deleteTargetWhenDisconnected,
+            final boolean deleteTargetsWhenSourceDeleted,
             final YamlRelationshipReverseDocument reverse) {
         this.fromEntityName = fromEntityName;
         this.name = name;
         this.toEntityName = toEntityName;
         this.cardinality = cardinality;
         this.optionality = optionality;
+        this.deleteTargetWhenDisconnected = deleteTargetWhenDisconnected;
+        this.deleteTargetsWhenSourceDeleted = deleteTargetsWhenSourceDeleted;
         this.reverse = reverse;
     }
 
@@ -34,6 +40,8 @@ public final class YamlRelationshipDocument {
                 YamlMapSupport.stringValue(map.get("to")),
                 YamlMapSupport.stringValue(map.get("cardinality")),
                 YamlMapSupport.stringValue(map.get("optionality")),
+                YamlMapSupport.booleanValue(map.get("deleteTargetWhenDisconnected")),
+                YamlMapSupport.booleanValue(map.get("deleteTargetsWhenSourceDeleted")),
                 reverseFrom(map.get("reverse")));
     }
 
@@ -55,6 +63,14 @@ public final class YamlRelationshipDocument {
 
     public String optionality() {
         return optionality;
+    }
+
+    public boolean deleteTargetWhenDisconnected() {
+        return deleteTargetWhenDisconnected;
+    }
+
+    public boolean deleteTargetsWhenSourceDeleted() {
+        return deleteTargetsWhenSourceDeleted;
     }
 
     public YamlRelationshipReverseDocument reverse() {

--- a/thingifier-yaml/src/main/java/uk/co/compendiumdev/thingifier/yaml/internal/YamlRelationshipReverseDocument.java
+++ b/thingifier-yaml/src/main/java/uk/co/compendiumdev/thingifier/yaml/internal/YamlRelationshipReverseDocument.java
@@ -7,12 +7,20 @@ public final class YamlRelationshipReverseDocument {
     private final String name;
     private final String cardinality;
     private final String optionality;
+    private final boolean deleteTargetWhenDisconnected;
+    private final boolean deleteTargetsWhenSourceDeleted;
 
     private YamlRelationshipReverseDocument(
-            final String name, final String cardinality, final String optionality) {
+            final String name,
+            final String cardinality,
+            final String optionality,
+            final boolean deleteTargetWhenDisconnected,
+            final boolean deleteTargetsWhenSourceDeleted) {
         this.name = name;
         this.cardinality = cardinality;
         this.optionality = optionality;
+        this.deleteTargetWhenDisconnected = deleteTargetWhenDisconnected;
+        this.deleteTargetsWhenSourceDeleted = deleteTargetsWhenSourceDeleted;
     }
 
     static YamlRelationshipReverseDocument fromObject(final Object source) {
@@ -20,7 +28,9 @@ public final class YamlRelationshipReverseDocument {
         return new YamlRelationshipReverseDocument(
                 YamlMapSupport.stringValue(map.get("name")),
                 YamlMapSupport.stringValue(map.get("cardinality")),
-                YamlMapSupport.stringValue(map.get("optionality")));
+                YamlMapSupport.stringValue(map.get("optionality")),
+                YamlMapSupport.booleanValue(map.get("deleteTargetWhenDisconnected")),
+                YamlMapSupport.booleanValue(map.get("deleteTargetsWhenSourceDeleted")));
     }
 
     public String name() {
@@ -33,5 +43,13 @@ public final class YamlRelationshipReverseDocument {
 
     public String optionality() {
         return optionality;
+    }
+
+    public boolean deleteTargetWhenDisconnected() {
+        return deleteTargetWhenDisconnected;
+    }
+
+    public boolean deleteTargetsWhenSourceDeleted() {
+        return deleteTargetsWhenSourceDeleted;
     }
 }

--- a/thingifier-yaml/src/main/java/uk/co/compendiumdev/thingifier/yaml/internal/YamlThingifierDocumentMapper.java
+++ b/thingifier-yaml/src/main/java/uk/co/compendiumdev/thingifier/yaml/internal/YamlThingifierDocumentMapper.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import uk.co.compendiumdev.thingifier.application.schema.FieldReferenceSpec;
 import uk.co.compendiumdev.thingifier.application.schema.definition.CardinalitySpec;
 import uk.co.compendiumdev.thingifier.application.schema.definition.EntityDefinitionSpec;
 import uk.co.compendiumdev.thingifier.application.schema.definition.FieldDefinitionSpec;
@@ -61,6 +62,12 @@ public final class YamlThingifierDocumentMapper {
                         .truncateTo(field.truncateTo())
                         .range(field.minValue(), field.maxValue())
                         .validationRules(validationRulesFor(field.validations()));
+        if (field.reference() != null) {
+            builder.reference(
+                    field.reference().targetEntityName(),
+                    field.reference().targetFieldName(),
+                    field.reference().relationshipName());
+        }
         for (YamlFieldDocument child : field.fields().values()) {
             builder.objectField(fieldSpecFor(child));
         }
@@ -96,6 +103,8 @@ public final class YamlThingifierDocumentMapper {
                 relationship.toEntityName(),
                 cardinalityFor(relationship.cardinality()),
                 relationship.optionality(),
+                relationship.deleteTargetWhenDisconnected(),
+                relationship.deleteTargetsWhenSourceDeleted(),
                 reverseSpecFor(relationship.reverse()));
     }
 
@@ -104,7 +113,11 @@ public final class YamlThingifierDocumentMapper {
             return null;
         }
         return new RelationshipVectorSpec(
-                reverse.name(), cardinalityFor(reverse.cardinality()), reverse.optionality());
+                reverse.name(),
+                cardinalityFor(reverse.cardinality()),
+                reverse.optionality(),
+                reverse.deleteTargetWhenDisconnected(),
+                reverse.deleteTargetsWhenSourceDeleted());
     }
 
     private CardinalitySpec cardinalityFor(final String text) {
@@ -168,9 +181,20 @@ public final class YamlThingifierDocumentMapper {
         if (!field.validationRules().isEmpty()) {
             map.put("validations", validationRulesListFor(field.validationRules()));
         }
+        if (field.hasRelationshipReference()) {
+            map.put("reference", referenceMapFor(field.relationshipReference()));
+        }
         if (!field.objectFields().isEmpty()) {
             map.put("fields", fieldsMapFor(field.objectFields()));
         }
+        return map;
+    }
+
+    private Map<String, Object> referenceMapFor(final FieldReferenceSpec reference) {
+        final Map<String, Object> map = new LinkedHashMap<>();
+        map.put("entity", reference.targetEntityName());
+        map.put("field", reference.targetFieldName());
+        map.put("relationship", reference.relationshipName());
         return map;
     }
 
@@ -203,6 +227,11 @@ public final class YamlThingifierDocumentMapper {
         map.put("to", relationship.toEntityName());
         map.put("cardinality", relationship.cardinality().canonicalName());
         putIfPresent(map, "optionality", relationship.optionality());
+        putIfTrue(map, "deleteTargetWhenDisconnected", relationship.deleteTargetWhenDisconnected());
+        putIfTrue(
+                map,
+                "deleteTargetsWhenSourceDeleted",
+                relationship.deleteTargetsWhenSourceDeleted());
         if (relationship.hasReverse()) {
             map.put("reverse", reverseMapFor(relationship.reverse()));
         }
@@ -214,6 +243,8 @@ public final class YamlThingifierDocumentMapper {
         map.put("name", reverse.name());
         map.put("cardinality", reverse.cardinality().canonicalName());
         putIfPresent(map, "optionality", reverse.optionality());
+        putIfTrue(map, "deleteTargetWhenDisconnected", reverse.deleteTargetWhenDisconnected());
+        putIfTrue(map, "deleteTargetsWhenSourceDeleted", reverse.deleteTargetsWhenSourceDeleted());
         return map;
     }
 

--- a/thingifier-yaml/src/test/java/uk/co/compendiumdev/thingifier/yaml/ThingifierYamlExporterTest.java
+++ b/thingifier-yaml/src/test/java/uk/co/compendiumdev/thingifier/yaml/ThingifierYamlExporterTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.application.schema.definition.ThingifierModelDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldRelationshipReference;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.relationship.RelationshipVectorDefinition;
 
 class ThingifierYamlExporterTest {
 
@@ -53,6 +55,34 @@ class ThingifierYamlExporterTest {
     }
 
     @Test
+    void loadExportLoadRoundTripPreservesRelationshipOwnershipPolicies() {
+        Thingifier first = new ThingifierYamlLoader().loadThingifier(relationshipMetadataYaml());
+
+        String yaml = new ThingifierYamlExporter().export(first);
+        Thingifier second = new ThingifierYamlLoader().loadThingifier(yaml);
+
+        RelationshipVectorDefinition relationship =
+                second.getDefinitionNamed("item")
+                        .getNamedRelationshipTo("product", second.getDefinitionNamed("product"));
+        Assertions.assertTrue(relationship.shouldDeleteTargetWhenDisconnected());
+        Assertions.assertTrue(relationship.shouldDeleteTargetsWhenSourceDeleted());
+    }
+
+    @Test
+    void loadExportLoadRoundTripPreservesFieldRelationshipReferences() {
+        Thingifier first = new ThingifierYamlLoader().loadThingifier(relationshipMetadataYaml());
+
+        String yaml = new ThingifierYamlExporter().export(first);
+        Thingifier second = new ThingifierYamlLoader().loadThingifier(yaml);
+
+        FieldRelationshipReference reference =
+                second.getDefinitionNamed("item").getField("productId").relationshipReference();
+        Assertions.assertEquals("product", reference.targetEntity().getName());
+        Assertions.assertEquals("id", reference.targetFieldName());
+        Assertions.assertEquals("product", reference.relationshipName());
+    }
+
+    @Test
     void exporterCanEmitYamlFromRuntimeThingifier() {
         Thingifier thingifier =
                 new ThingifierYamlLoader().loadThingifier(resource("field-types.yaml"));
@@ -69,5 +99,39 @@ class ThingifierYamlExporterTest {
         InputStream stream = getClass().getResourceAsStream("/models/" + resourceName);
         Assertions.assertNotNull(stream, resourceName);
         return stream;
+    }
+
+    private String relationshipMetadataYaml() {
+        return "formatVersion: 1\n"
+                + "model:\n"
+                + "  title: Relationships\n"
+                + "  description: Relationship metadata.\n"
+                + "entities:\n"
+                + "  product:\n"
+                + "    plural: products\n"
+                + "    primaryKey: id\n"
+                + "    fields:\n"
+                + "      id:\n"
+                + "        type: auto-increment\n"
+                + "  item:\n"
+                + "    plural: items\n"
+                + "    primaryKey: id\n"
+                + "    fields:\n"
+                + "      id:\n"
+                + "        type: auto-increment\n"
+                + "      productId:\n"
+                + "        type: integer\n"
+                + "        reference:\n"
+                + "          entity: product\n"
+                + "          field: id\n"
+                + "          relationship: product\n"
+                + "relationships:\n"
+                + "  - from: item\n"
+                + "    name: product\n"
+                + "    to: product\n"
+                + "    cardinality: one-to-one\n"
+                + "    optionality: optional\n"
+                + "    deleteTargetWhenDisconnected: true\n"
+                + "    deleteTargetsWhenSourceDeleted: true\n";
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/RelationshipBodyCommandParser.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/RelationshipBodyCommandParser.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import uk.co.compendiumdev.thingifier.application.command.RelationshipReference;
 import uk.co.compendiumdev.thingifier.application.schema.EntityTypeRef;
+import uk.co.compendiumdev.thingifier.application.schema.FieldReferenceSpec;
 import uk.co.compendiumdev.thingifier.application.schema.FieldSpec;
 import uk.co.compendiumdev.thingifier.application.schema.RelationshipSpec;
 import uk.co.compendiumdev.thingifier.application.schema.SchemaViewCatalog;
@@ -35,11 +36,34 @@ public final class RelationshipBodyCommandParser {
                     relationshipEntries.add(keyValue);
                     parseCompressedRelationship(entity, keyValue, report, references);
                 }
+            } else {
+                parseFieldRelationshipReference(entity, keyValue, report, references);
             }
         }
 
         report.setValid(report.getErrorMessages().isEmpty());
         return new RelationshipBodyCommands(relationshipEntries, references, report);
+    }
+
+    private void parseFieldRelationshipReference(
+            final EntityTypeRef entity,
+            final Map.Entry<String, String> keyValue,
+            final ValidationReport report,
+            final List<RelationshipReference> references) {
+        FieldSpec field = entity.fieldNamed(keyValue.getKey());
+        if (field == null || !field.hasRelationshipReference()) {
+            return;
+        }
+
+        FieldReferenceSpec reference = field.relationshipReference();
+        addReference(
+                RelationshipReference.fieldBinding(
+                        reference.relationshipName(),
+                        reference.targetEntityName(),
+                        reference.targetFieldName(),
+                        keyValue.getValue()),
+                report,
+                references);
     }
 
     private void parseCompressedRelationship(
@@ -65,8 +89,10 @@ public final class RelationshipBodyCommandParser {
             return;
         }
 
-        references.add(
-                RelationshipReference.compressed(relationshipName, fieldName, keyValue.getValue()));
+        addReference(
+                RelationshipReference.compressed(relationshipName, fieldName, keyValue.getValue()),
+                report,
+                references);
     }
 
     private void parseComplexRelationship(
@@ -95,13 +121,51 @@ public final class RelationshipBodyCommandParser {
             return;
         }
 
-        references.add(
+        addReference(
                 RelationshipReference.explicit(
                         relationshipName,
                         relationshipTo.name(),
                         relationshipToTerm,
                         relationshipField,
-                        keyValue.getValue()));
+                        keyValue.getValue()),
+                report,
+                references);
+    }
+
+    private void addReference(
+            final RelationshipReference candidate,
+            final ValidationReport report,
+            final List<RelationshipReference> references) {
+        for (RelationshipReference existing : references) {
+            if (!sameRelationship(existing, candidate)) {
+                continue;
+            }
+            if (sameReference(existing, candidate)) {
+                return;
+            }
+            report.addErrorMessage(
+                    String.format(
+                            "Conflicting relationship references supplied for %s",
+                            candidate.relationshipName()));
+            return;
+        }
+        references.add(candidate);
+    }
+
+    private boolean sameRelationship(
+            final RelationshipReference first, final RelationshipReference second) {
+        return first.relationshipName().equals(second.relationshipName());
+    }
+
+    private boolean sameReference(
+            final RelationshipReference first, final RelationshipReference second) {
+        if (first.hasExplicitTargetEntity()
+                && second.hasExplicitTargetEntity()
+                && !first.targetEntityName().equals(second.targetEntityName())) {
+            return false;
+        }
+        return first.referenceFieldName().equals(second.referenceFieldName())
+                && first.referenceValue().equals(second.referenceValue());
     }
 
     private boolean supportsReferenceField(

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/RelationshipWriteIntent.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/RelationshipWriteIntent.java
@@ -1,0 +1,39 @@
+package uk.co.compendiumdev.thingifier.adapter.http.apihandlers;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import uk.co.compendiumdev.thingifier.apiconfig.RelationshipWriteOperation;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.instance.NamedValue;
+
+final class RelationshipWriteIntent {
+
+    private final RelationshipWriteOperation operation;
+    private final List<NamedValue> childReferenceFields;
+
+    private RelationshipWriteIntent(
+            final RelationshipWriteOperation operation,
+            final List<NamedValue> childReferenceFields) {
+        this.operation = operation;
+        this.childReferenceFields =
+                Collections.unmodifiableList(new ArrayList<>(childReferenceFields));
+    }
+
+    static RelationshipWriteIntent of(
+            final RelationshipWriteOperation operation,
+            final List<NamedValue> childReferenceFields) {
+        return new RelationshipWriteIntent(operation, childReferenceFields);
+    }
+
+    static RelationshipWriteIntent none() {
+        return new RelationshipWriteIntent(null, List.of());
+    }
+
+    RelationshipWriteOperation operation() {
+        return operation;
+    }
+
+    List<NamedValue> childReferenceFields() {
+        return childReferenceFields;
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/RelationshipWriteIntentResolver.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/RelationshipWriteIntentResolver.java
@@ -1,0 +1,118 @@
+package uk.co.compendiumdev.thingifier.adapter.http.apihandlers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.RelationshipCollectionRoute;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.RelationshipInstanceRoute;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
+import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
+import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields;
+import uk.co.compendiumdev.thingifier.apiconfig.RelationshipWriteOperation;
+import uk.co.compendiumdev.thingifier.application.schema.RelationshipSpec;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.Field;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldType;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.instance.NamedValue;
+
+final class RelationshipWriteIntentResolver {
+
+    private final SchemaCatalog schema;
+
+    RelationshipWriteIntentResolver(final SchemaCatalog schema) {
+        this.schema = schema;
+    }
+
+    RelationshipWriteIntent intentFor(
+            final RoutingVerb verb,
+            final ThingRoute route,
+            final ApiBodyFields bodyFields,
+            final ThingifierRequestContext context,
+            final Set<RelationshipWriteOperation> allowedOperations) {
+        if (verb == RoutingVerb.DELETE && route instanceof RelationshipInstanceRoute) {
+            return RelationshipWriteIntent.of(RelationshipWriteOperation.DISCONNECT, List.of());
+        }
+
+        if (verb == RoutingVerb.POST && route instanceof RelationshipCollectionRoute) {
+            return postIntentFor(
+                    (RelationshipCollectionRoute) route, bodyFields, context, allowedOperations);
+        }
+
+        return RelationshipWriteIntent.none();
+    }
+
+    private RelationshipWriteIntent postIntentFor(
+            final RelationshipCollectionRoute route,
+            final ApiBodyFields bodyFields,
+            final ThingifierRequestContext context,
+            final Set<RelationshipWriteOperation> allowedOperations) {
+        List<NamedValue> childReferenceFields = childReferenceFields(route, bodyFields);
+        if (childReferenceFields.isEmpty()) {
+            return RelationshipWriteIntent.of(
+                    RelationshipWriteOperation.CREATE_AND_CONNECT, childReferenceFields);
+        }
+
+        if (allowedOperations != null
+                && allowedOperations.contains(RelationshipWriteOperation.UPDATE_CONNECTED)
+                && referencesConnectedChild(route, childReferenceFields, context)) {
+            return RelationshipWriteIntent.of(
+                    RelationshipWriteOperation.UPDATE_CONNECTED, childReferenceFields);
+        }
+
+        return RelationshipWriteIntent.of(
+                RelationshipWriteOperation.CONNECT_EXISTING, childReferenceFields);
+    }
+
+    private List<NamedValue> childReferenceFields(
+            final RelationshipCollectionRoute route, final ApiBodyFields bodyFields) {
+        EntityDefinition targetEntity = targetEntityFor(route);
+        if (targetEntity == null) {
+            return List.of();
+        }
+
+        List<NamedValue> references = new ArrayList<>();
+        for (Map.Entry<String, String> entry : bodyFields.asFlattenedStringMap()) {
+            Field field = targetEntity.getField(entry.getKey());
+            if (field != null
+                    && (field.getType() == FieldType.AUTO_GUID
+                            || field.getType() == FieldType.AUTO_INCREMENT)) {
+                references.add(new NamedValue(entry.getKey(), entry.getValue()));
+            }
+        }
+        return references;
+    }
+
+    private boolean referencesConnectedChild(
+            final RelationshipCollectionRoute route,
+            final List<NamedValue> childReferenceFields,
+            final ThingifierRequestContext context) {
+        if (context == null) {
+            return false;
+        }
+
+        EntityDefinition parentEntity =
+                schema.definitionWithSingularOrPluralNamed(route.parentEntity().name());
+        EntityDefinition targetEntity = targetEntityFor(route);
+        if (parentEntity == null || targetEntity == null) {
+            return false;
+        }
+
+        return context.hasRelatedEntityInstanceMatchingFields(
+                parentEntity,
+                route.parentIdentifier(),
+                targetEntity,
+                route.relationshipName(),
+                childReferenceFields);
+    }
+
+    private EntityDefinition targetEntityFor(final RelationshipCollectionRoute route) {
+        for (RelationshipSpec relationship : route.parentEntity().relationships()) {
+            if (relationship.name().equals(route.relationshipName())) {
+                return schema.definitionWithSingularOrPluralNamed(relationship.toEntityName());
+            }
+        }
+        return null;
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/RouteAuthPolicy.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/RouteAuthPolicy.java
@@ -1,0 +1,380 @@
+package uk.co.compendiumdev.thingifier.adapter.http.apihandlers;
+
+import java.util.Optional;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.CollectionRoute;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.InstanceRoute;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.RelationshipCollectionRoute;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.RelationshipInstanceRoute;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRouteMapper;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
+import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
+import uk.co.compendiumdev.thingifier.api.http.headers.headerparser.BearerAuthHeaderParser;
+import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
+import uk.co.compendiumdev.thingifier.api.security.ThingifierApiAuthenticationContext;
+import uk.co.compendiumdev.thingifier.api.security.ThingifierApiAuthenticationResult;
+import uk.co.compendiumdev.thingifier.api.security.ThingifierApiAuthenticator;
+import uk.co.compendiumdev.thingifier.api.security.ThingifierApiAuthorizationContext;
+import uk.co.compendiumdev.thingifier.api.security.ThingifierApiAuthorizationResult;
+import uk.co.compendiumdev.thingifier.api.security.ThingifierApiAuthorizer;
+import uk.co.compendiumdev.thingifier.api.security.ThingifierApiRouteAuthDetails;
+import uk.co.compendiumdev.thingifier.api.spec.ApiRoutePathMatcher;
+import uk.co.compendiumdev.thingifier.api.spec.ThingifierApiRouteRule;
+import uk.co.compendiumdev.thingifier.application.schema.EntityTypeRef;
+import uk.co.compendiumdev.thingifier.application.schema.RelationshipSpec;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+
+/**
+ * Enforces route-level authentication and authorization configured in the API spec.
+ *
+ * <p>The policy handles the generic HTTP bearer mechanics that belong in Thingifier and delegates
+ * application decisions to registered authenticators and authorizers. It returns an {@link
+ * ApiResponse} only when processing should stop.
+ */
+public final class RouteAuthPolicy {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String WWW_AUTHENTICATE_HEADER = "WWW-Authenticate";
+    private static final String BEARER_CHALLENGE = "Bearer";
+
+    private final ThingifierApiRuntime runtime;
+
+    /**
+     * Creates a route auth policy using the active Thingifier runtime.
+     *
+     * @param runtime runtime services used to resolve route rules, schema, and authenticators
+     */
+    public RouteAuthPolicy(final ThingifierApiRuntime runtime) {
+        this.runtime = runtime;
+    }
+
+    /**
+     * Rejects the request when route-level auth policy does not allow it to proceed.
+     *
+     * @param verb generated API verb
+     * @param path generated API path
+     * @param context active request context
+     * @return rejection response, or null when the route is unprotected or authorized
+     */
+    public ApiResponse rejectIfNotAuthorized(
+            final RoutingVerb verb, final String path, final ThingifierRequestContext context) {
+        final ThingRoute route = new ThingRouteMapper(runtime.schema()).map(path);
+        return rejectIfNotAuthorized(verb, path, context, route);
+    }
+
+    /**
+     * Rejects the request using a pre-mapped route.
+     *
+     * <p>HTTP routing already maps the route for lifecycle context creation, so this overload keeps
+     * auth enforcement from doing duplicate route work in that path.
+     *
+     * @param verb generated API verb
+     * @param path generated API path
+     * @param context active request context
+     * @param route mapped generated route
+     * @return rejection response, or null when the route is unprotected or authorized
+     */
+    public ApiResponse rejectIfNotAuthorized(
+            final RoutingVerb verb,
+            final String path,
+            final ThingifierRequestContext context,
+            final ThingRoute route) {
+        if (verb == null || context == null) {
+            return null;
+        }
+
+        final String apiPathPrefix = runtime.apiConfig().getApiEndPointPrefix();
+        final Optional<ThingifierApiRouteRule> matchingRule =
+                runtime.apiSpec().ruleFor(verb, path, apiPathPrefix);
+        if (matchingRule.isEmpty() || !requiresAuth(matchingRule.get())) {
+            return null;
+        }
+
+        final ThingifierApiRouteRule rule = matchingRule.get();
+        final String schemeName = rule.bearerAuthEnforcementSchemeName();
+        final Optional<ThingifierApiAuthenticator> authenticator =
+                runtime.apiSpec().authenticatorFor(schemeName);
+        if (authenticator.isEmpty()) {
+            return ApiResponse.error(
+                    500, "No authenticator configured for bearer auth scheme " + schemeName);
+        }
+
+        final BearerAuthHeaderParser bearer =
+                new BearerAuthHeaderParser(context.headers().get(AUTHORIZATION_HEADER));
+        if (!bearer.isValid()) {
+            return unauthorized();
+        }
+
+        final ThingifierApiAuthenticationContext authenticationContext =
+                new ThingifierApiAuthenticationContext(
+                        authDetails(schemeName, verb, path, context, route, rule),
+                        bearer.getToken());
+        final ThingifierApiAuthenticationResult authentication =
+                authenticator.get().authenticate(authenticationContext);
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return authenticationRejected(authentication);
+        }
+
+        context.setAuthenticatedPrincipal(schemeName, authentication.principal());
+        return rejectIfUnauthorizedByAuthorizer(rule, authenticationContext, authentication);
+    }
+
+    /**
+     * Reports whether a route rule has enforceable auth policy.
+     *
+     * @param rule matching route rule
+     * @return true when bearer auth should be enforced for this request
+     */
+    private boolean requiresAuth(final ThingifierApiRouteRule rule) {
+        return !rule.isDisabled() && !rule.isMethodNotAllowed() && rule.hasBearerAuthEnforcement();
+    }
+
+    /**
+     * Runs route authorizers after authentication succeeds.
+     *
+     * @param rule matching route rule
+     * @param authenticationContext context used by the authenticator
+     * @param authentication successful authentication result
+     * @return rejection response, or null when authorization succeeds
+     */
+    private ApiResponse rejectIfUnauthorizedByAuthorizer(
+            final ThingifierApiRouteRule rule,
+            final ThingifierApiAuthenticationContext authenticationContext,
+            final ThingifierApiAuthenticationResult authentication) {
+        for (ThingifierApiAuthorizer authorizer : rule.authorizers()) {
+            final ThingifierApiAuthorizationResult authorization =
+                    authorizer.authorize(
+                            new ThingifierApiAuthorizationContext(
+                                    authenticationContext, authentication.principal()));
+            if (authorization == null || !authorization.isAuthorized()) {
+                return authorizationRejected(authorization);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Creates the callback context details for the protected route.
+     *
+     * @param schemeName bearer scheme name
+     * @param verb generated API verb
+     * @param path generated API path
+     * @param context request context
+     * @param route mapped generated route
+     * @param rule matching route rule
+     * @return shared route auth details
+     */
+    private ThingifierApiRouteAuthDetails authDetails(
+            final String schemeName,
+            final RoutingVerb verb,
+            final String path,
+            final ThingifierRequestContext context,
+            final ThingRoute route,
+            final ThingifierApiRouteRule rule) {
+        return ThingifierApiRouteAuthDetails.builder()
+                .schemeName(schemeName)
+                .verb(verb)
+                .path(path)
+                .pathParameters(
+                        ApiRoutePathMatcher.pathParameters(
+                                rule.pathPattern(),
+                                path,
+                                runtime.apiConfig().getApiEndPointPrefix()))
+                .route(route)
+                .headers(context.headers())
+                .requestContext(context)
+                .targetEntity(targetEntity(route))
+                .targetIdentifier(targetIdentifier(route))
+                .parentEntity(parentEntity(route))
+                .parentIdentifier(parentIdentifier(route))
+                .relationshipName(relationshipName(route))
+                .childIdentifier(childIdentifier(route))
+                .build();
+    }
+
+    /**
+     * Converts an authentication failure into a response.
+     *
+     * @param authentication failed authentication result, possibly null
+     * @return rejection response with a bearer challenge for 401 responses
+     */
+    private ApiResponse authenticationRejected(
+            final ThingifierApiAuthenticationResult authentication) {
+        final ApiResponse response =
+                authentication == null || authentication.rejectionResponse() == null
+                        ? unauthorized()
+                        : authentication.rejectionResponse();
+        return challengeIfUnauthorized(response);
+    }
+
+    /**
+     * Converts an authorization failure into a response.
+     *
+     * @param authorization failed authorization result, possibly null
+     * @return rejection response
+     */
+    private ApiResponse authorizationRejected(
+            final ThingifierApiAuthorizationResult authorization) {
+        if (authorization == null || authorization.rejectionResponse() == null) {
+            return ApiResponse.error(403, "Forbidden");
+        }
+        return authorization.rejectionResponse();
+    }
+
+    /**
+     * Creates the standard bearer unauthorized response.
+     *
+     * @return 401 response with a WWW-Authenticate challenge
+     */
+    private ApiResponse unauthorized() {
+        return ApiResponse.error(401, "Unauthorized")
+                .setHeader(WWW_AUTHENTICATE_HEADER, BEARER_CHALLENGE);
+    }
+
+    /**
+     * Ensures authenticator-supplied 401 responses include the bearer challenge header.
+     *
+     * @param response response returned by an authenticator
+     * @return same response with the challenge header when appropriate
+     */
+    private ApiResponse challengeIfUnauthorized(final ApiResponse response) {
+        if (response.getStatusCode() == 401
+                && response.getHeaderValue(WWW_AUTHENTICATE_HEADER).isEmpty()) {
+            response.setHeader(WWW_AUTHENTICATE_HEADER, BEARER_CHALLENGE);
+        }
+        return response;
+    }
+
+    /**
+     * Resolves the target entity for entity and relationship routes.
+     *
+     * @param route mapped route
+     * @return target entity, or null when the route is unmatched
+     */
+    private EntityDefinition targetEntity(final ThingRoute route) {
+        if (route instanceof CollectionRoute) {
+            return entityNamed(((CollectionRoute) route).entity().name());
+        }
+        if (route instanceof InstanceRoute) {
+            return entityNamed(((InstanceRoute) route).entity().name());
+        }
+        if (route instanceof RelationshipCollectionRoute) {
+            final RelationshipCollectionRoute relationship = (RelationshipCollectionRoute) route;
+            return targetEntityForRelationship(
+                    relationship.parentEntity(), relationship.relationshipName());
+        }
+        if (route instanceof RelationshipInstanceRoute) {
+            final RelationshipInstanceRoute relationship = (RelationshipInstanceRoute) route;
+            return targetEntityForRelationship(
+                    relationship.parentEntity(), relationship.relationshipName());
+        }
+        return null;
+    }
+
+    /**
+     * Resolves the parent entity for relationship routes.
+     *
+     * @param route mapped route
+     * @return parent entity, or null for entity routes
+     */
+    private EntityDefinition parentEntity(final ThingRoute route) {
+        if (route instanceof RelationshipCollectionRoute) {
+            return entityNamed(((RelationshipCollectionRoute) route).parentEntity().name());
+        }
+        if (route instanceof RelationshipInstanceRoute) {
+            return entityNamed(((RelationshipInstanceRoute) route).parentEntity().name());
+        }
+        return null;
+    }
+
+    /**
+     * Resolves the target identifier for instance routes.
+     *
+     * @param route mapped route
+     * @return target identifier, or null for collection routes
+     */
+    private String targetIdentifier(final ThingRoute route) {
+        if (route instanceof InstanceRoute) {
+            return ((InstanceRoute) route).identifier();
+        }
+        if (route instanceof RelationshipInstanceRoute) {
+            return ((RelationshipInstanceRoute) route).childIdentifier();
+        }
+        return null;
+    }
+
+    /**
+     * Resolves the parent identifier for relationship routes.
+     *
+     * @param route mapped route
+     * @return parent identifier, or null for entity routes
+     */
+    private String parentIdentifier(final ThingRoute route) {
+        if (route instanceof RelationshipCollectionRoute) {
+            return ((RelationshipCollectionRoute) route).parentIdentifier();
+        }
+        if (route instanceof RelationshipInstanceRoute) {
+            return ((RelationshipInstanceRoute) route).parentIdentifier();
+        }
+        return null;
+    }
+
+    /**
+     * Resolves the relationship name for relationship routes.
+     *
+     * @param route mapped route
+     * @return relationship name, or null for entity routes
+     */
+    private String relationshipName(final ThingRoute route) {
+        if (route instanceof RelationshipCollectionRoute) {
+            return ((RelationshipCollectionRoute) route).relationshipName();
+        }
+        if (route instanceof RelationshipInstanceRoute) {
+            return ((RelationshipInstanceRoute) route).relationshipName();
+        }
+        return null;
+    }
+
+    /**
+     * Resolves the child identifier for relationship instance routes.
+     *
+     * @param route mapped route
+     * @return child identifier, or null when the route has no child
+     */
+    private String childIdentifier(final ThingRoute route) {
+        if (route instanceof RelationshipInstanceRoute) {
+            return ((RelationshipInstanceRoute) route).childIdentifier();
+        }
+        return null;
+    }
+
+    /**
+     * Resolves the target entity for a relationship route.
+     *
+     * @param parentEntity parent entity reference
+     * @param relationshipName relationship route name
+     * @return related entity, or null when the relationship cannot be resolved
+     */
+    private EntityDefinition targetEntityForRelationship(
+            final EntityTypeRef parentEntity, final String relationshipName) {
+        if (parentEntity == null) {
+            return null;
+        }
+        for (RelationshipSpec spec : parentEntity.relationships()) {
+            if (spec.name().equals(relationshipName)) {
+                return entityNamed(spec.toEntityName());
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Looks up an entity definition by singular or plural model name.
+     *
+     * @param entityName singular or plural entity name
+     * @return matching entity definition, or null
+     */
+    private EntityDefinition entityNamed(final String entityName) {
+        return runtime.schema().definitionWithSingularOrPluralNamed(entityName);
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/ThingCommandResultApiMapper.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/ThingCommandResultApiMapper.java
@@ -15,6 +15,7 @@ import uk.co.compendiumdev.thingifier.application.command.PatchThingDocumentComm
 import uk.co.compendiumdev.thingifier.application.command.RelateThingCommand;
 import uk.co.compendiumdev.thingifier.application.command.ReplaceThingCommand;
 import uk.co.compendiumdev.thingifier.application.command.ThingWriteCommand;
+import uk.co.compendiumdev.thingifier.application.command.UpdateConnectedRelationshipCommand;
 
 public final class ThingCommandResultApiMapper {
 
@@ -71,6 +72,10 @@ public final class ThingCommandResultApiMapper {
         }
 
         if (command instanceof AmendThingCommand || command instanceof PatchThingDocumentCommand) {
+            return ApiResponse.success().returnSingleInstance(result.getInstance());
+        }
+
+        if (command instanceof UpdateConnectedRelationshipCommand) {
             return ApiResponse.success().returnSingleInstance(result.getInstance());
         }
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/ThingWriteRequestMapper.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/ThingWriteRequestMapper.java
@@ -1,5 +1,6 @@
 package uk.co.compendiumdev.thingifier.adapter.http.apihandlers;
 
+import java.util.Set;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.commonerrorresponse.NoSuchEntity;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.CollectionRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.InstanceRoute;
@@ -7,12 +8,15 @@ import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.Relationshi
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.RelationshipInstanceRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.UnmatchedRoute;
+import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields;
 import uk.co.compendiumdev.thingifier.apiconfig.EntityWriteMethodConfig;
 import uk.co.compendiumdev.thingifier.apiconfig.PutIdentifierPolicy;
+import uk.co.compendiumdev.thingifier.apiconfig.RelationshipWriteOperation;
 import uk.co.compendiumdev.thingifier.application.command.DeleteThingCommand;
 import uk.co.compendiumdev.thingifier.application.command.DisconnectRelationshipCommand;
 import uk.co.compendiumdev.thingifier.application.command.RelateThingCommand;
+import uk.co.compendiumdev.thingifier.application.command.UpdateConnectedRelationshipCommand;
 import uk.co.compendiumdev.thingifier.application.schema.EntityTypeRef;
 import uk.co.compendiumdev.thingifier.application.schema.RelationshipSpec;
 import uk.co.compendiumdev.thingifier.application.schema.SchemaViewCatalog;
@@ -22,6 +26,9 @@ public final class ThingWriteRequestMapper {
     private final SchemaViewCatalog schema;
     private final ThingBodyCommandMapper bodyCommandMapper;
     private final EntityWriteMethodConfig entityWriteMethods;
+    private final Set<RelationshipWriteOperation> relationshipPostOperations;
+    private final ThingifierRequestContext context;
+    private final RelationshipWriteIntentResolver relationshipIntents;
 
     public ThingWriteRequestMapper(final SchemaViewCatalog schema) {
         this(schema, new EntityWriteMethodConfig());
@@ -33,6 +40,24 @@ public final class ThingWriteRequestMapper {
         this.bodyCommandMapper = new ThingBodyCommandMapper(schema);
         this.entityWriteMethods =
                 entityWriteMethods == null ? new EntityWriteMethodConfig() : entityWriteMethods;
+        this.relationshipPostOperations = Set.of();
+        this.context = null;
+        this.relationshipIntents = null;
+    }
+
+    public ThingWriteRequestMapper(
+            final SchemaCatalog schema,
+            final EntityWriteMethodConfig entityWriteMethods,
+            final Set<RelationshipWriteOperation> relationshipPostOperations,
+            final ThingifierRequestContext context) {
+        this.schema = schema;
+        this.bodyCommandMapper = new ThingBodyCommandMapper(schema);
+        this.entityWriteMethods =
+                entityWriteMethods == null ? new EntityWriteMethodConfig() : entityWriteMethods;
+        this.relationshipPostOperations =
+                relationshipPostOperations == null ? Set.of() : relationshipPostOperations;
+        this.context = context;
+        this.relationshipIntents = new RelationshipWriteIntentResolver(schema);
     }
 
     public ThingWriteRequestMapping mapPost(
@@ -299,6 +324,20 @@ public final class ThingWriteRequestMapper {
                                     relationships.validationReport().getCombinedErrorMessages())));
         }
 
+        RelationshipWriteIntent intent = relationshipIntentFor(route, bodyFields);
+        if (intent.operation() == RelationshipWriteOperation.UPDATE_CONNECTED) {
+            return ThingWriteRequestMapping.command(
+                    new UpdateConnectedRelationshipCommand(
+                            route.parentEntity().name(),
+                            route.parentIdentifier(),
+                            route.relationshipName(),
+                            bodyCommandMapper.fieldValuesExcludingRelationships(
+                                    bodyFields, relationships),
+                            bodyCommandMapper.bodyFieldValues(bodyFields),
+                            relationships.references()),
+                    ApiRouteDisplay.originalPath(route.originalPath()));
+        }
+
         return ThingWriteRequestMapping.command(
                 new RelateThingCommand(
                         route.parentEntity().name(),
@@ -318,5 +357,18 @@ public final class ThingWriteRequestMapper {
             }
         }
         return null;
+    }
+
+    private RelationshipWriteIntent relationshipIntentFor(
+            final RelationshipCollectionRoute route, final ApiBodyFields bodyFields) {
+        if (relationshipIntents == null) {
+            return RelationshipWriteIntent.none();
+        }
+        return relationshipIntents.intentFor(
+                uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb.POST,
+                route,
+                bodyFields,
+                context,
+                relationshipPostOperations);
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/ThingifierSchemaCatalog.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/ThingifierSchemaCatalog.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.application.schema.EntityTypeRef;
+import uk.co.compendiumdev.thingifier.application.schema.FieldReferenceSpec;
 import uk.co.compendiumdev.thingifier.application.schema.FieldSpec;
 import uk.co.compendiumdev.thingifier.application.schema.RelationshipSpec;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
@@ -57,7 +58,17 @@ public final class ThingifierSchemaCatalog implements SchemaCatalog {
         List<FieldSpec> fields = new ArrayList<>();
         for (String fieldName : definition.getFieldNames()) {
             Field field = definition.getField(fieldName);
-            fields.add(new FieldSpec(field.getName(), field.getType(), field.mustBeUnique()));
+            FieldReferenceSpec reference = null;
+            if (field.hasRelationshipReference()) {
+                reference =
+                        new FieldReferenceSpec(
+                                field.relationshipReference().targetEntity().getName(),
+                                field.relationshipReference().targetFieldName(),
+                                field.relationshipReference().relationshipName());
+            }
+            fields.add(
+                    new FieldSpec(
+                            field.getName(), field.getType(), field.mustBeUnique(), reference));
         }
         return fields;
     }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/WriteMethodPolicy.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/WriteMethodPolicy.java
@@ -41,6 +41,12 @@ public final class WriteMethodPolicy {
             return invalidConfig;
         }
 
+        ApiResponse configuredMethodNotAllowed =
+                rejectIfMethodNotAllowedByApiSpec(verb, route, bodyFields, context);
+        if (configuredMethodNotAllowed != null) {
+            return configuredMethodNotAllowed;
+        }
+
         if (route instanceof CollectionRoute || route instanceof InstanceRoute) {
             return rejectEntityWriteIfNotAllowed(verb, route, bodyFields, context);
         }
@@ -51,6 +57,17 @@ public final class WriteMethodPolicy {
         }
 
         return null;
+    }
+
+    private ApiResponse rejectIfMethodNotAllowedByApiSpec(
+            final RoutingVerb verb,
+            final ThingRoute route,
+            final ApiBodyFields bodyFields,
+            final ThingifierRequestContext context) {
+        if (!isMethodNotAllowedByApiSpec(verb, route)) {
+            return null;
+        }
+        return methodNotAllowed(allowHeaderFor(route, bodyFields, context));
     }
 
     private ApiResponse rejectEntityWriteIfNotAllowed(
@@ -290,32 +307,112 @@ public final class WriteMethodPolicy {
         List<String> allowed = new ArrayList<>();
         allowed.add("OPTIONS");
         if (route instanceof CollectionRoute) {
-            allowed.add("GET");
-            allowed.add("HEAD");
-            if (entityOperationsFor(RoutingVerb.POST, route)
-                    .contains(EntityWriteOperation.CREATE)) {
+            if (isMethodAllowedByApiSpec(RoutingVerb.GET, route)) {
+                allowed.add("GET");
+            }
+            if (isMethodAllowedByApiSpec(RoutingVerb.HEAD, route)) {
+                allowed.add("HEAD");
+            }
+            if (entityOperationsFor(RoutingVerb.POST, route).contains(EntityWriteOperation.CREATE)
+                    && isMethodAllowedByApiSpec(RoutingVerb.POST, route)) {
                 allowed.add("POST");
             }
             if (isEntityMethodAllowedFor(
                     RoutingVerb.PUT, route, bodyFields, context, blockedVerb, blockedOperation)) {
                 allowed.add("PUT");
             }
-            allowed.add("QUERY");
+            if (isMethodAllowedByApiSpec(RoutingVerb.QUERY, route)) {
+                allowed.add("QUERY");
+            }
         }
         if (route instanceof InstanceRoute) {
-            allowed.add("GET");
-            allowed.add("HEAD");
-            if (entityOperationsFor(RoutingVerb.POST, route)
-                    .contains(EntityWriteOperation.UPDATE)) {
+            if (isMethodAllowedByApiSpec(RoutingVerb.GET, route)) {
+                allowed.add("GET");
+            }
+            if (isMethodAllowedByApiSpec(RoutingVerb.HEAD, route)) {
+                allowed.add("HEAD");
+            }
+            if (entityOperationsFor(RoutingVerb.POST, route).contains(EntityWriteOperation.UPDATE)
+                    && isMethodAllowedByApiSpec(RoutingVerb.POST, route)) {
                 allowed.add("POST");
             }
             if (isEntityMethodAllowedFor(
                     RoutingVerb.PUT, route, bodyFields, context, blockedVerb, blockedOperation)) {
                 allowed.add("PUT");
             }
-            if (!entityPatchUpdateStylesFor(route).isEmpty()) {
+            if (!entityPatchUpdateStylesFor(route).isEmpty()
+                    && isMethodAllowedByApiSpec(RoutingVerb.PATCH, route)) {
                 allowed.add("PATCH");
             }
+            if (isMethodAllowedByApiSpec(RoutingVerb.DELETE, route)) {
+                allowed.add("DELETE");
+            }
+        }
+        return String.join(", ", allowed);
+    }
+
+    private String allowHeaderFor(
+            final ThingRoute route,
+            final ApiBodyFields bodyFields,
+            final ThingifierRequestContext context) {
+        List<String> allowed = new ArrayList<>();
+        allowed.add("OPTIONS");
+        if (route instanceof CollectionRoute) {
+            if (isMethodAllowedByApiSpec(RoutingVerb.GET, route)) {
+                allowed.add("GET");
+            }
+            if (isMethodAllowedByApiSpec(RoutingVerb.HEAD, route)) {
+                allowed.add("HEAD");
+            }
+            if (entityOperationsFor(RoutingVerb.POST, route).contains(EntityWriteOperation.CREATE)
+                    && isMethodAllowedByApiSpec(RoutingVerb.POST, route)) {
+                allowed.add("POST");
+            }
+            if (isEntityMethodAllowedFor(RoutingVerb.PUT, route, bodyFields, context, null, null)) {
+                allowed.add("PUT");
+            }
+            if (isMethodAllowedByApiSpec(RoutingVerb.QUERY, route)) {
+                allowed.add("QUERY");
+            }
+        }
+        if (route instanceof InstanceRoute) {
+            if (isMethodAllowedByApiSpec(RoutingVerb.GET, route)) {
+                allowed.add("GET");
+            }
+            if (isMethodAllowedByApiSpec(RoutingVerb.HEAD, route)) {
+                allowed.add("HEAD");
+            }
+            if (entityOperationsFor(RoutingVerb.POST, route).contains(EntityWriteOperation.UPDATE)
+                    && isMethodAllowedByApiSpec(RoutingVerb.POST, route)) {
+                allowed.add("POST");
+            }
+            if (isEntityMethodAllowedFor(RoutingVerb.PUT, route, bodyFields, context, null, null)) {
+                allowed.add("PUT");
+            }
+            if (!entityPatchUpdateStylesFor(route).isEmpty()
+                    && isMethodAllowedByApiSpec(RoutingVerb.PATCH, route)) {
+                allowed.add("PATCH");
+            }
+            if (isMethodAllowedByApiSpec(RoutingVerb.DELETE, route)) {
+                allowed.add("DELETE");
+            }
+        }
+        if (route instanceof RelationshipCollectionRoute) {
+            if (isMethodAllowedByApiSpec(RoutingVerb.GET, route)) {
+                allowed.add("GET");
+            }
+            if (isMethodAllowedByApiSpec(RoutingVerb.HEAD, route)) {
+                allowed.add("HEAD");
+            }
+            if (isRelationshipMethodAllowedFor(RoutingVerb.POST, route, null, null)) {
+                allowed.add("POST");
+            }
+            if (isMethodAllowedByApiSpec(RoutingVerb.QUERY, route)) {
+                allowed.add("QUERY");
+            }
+        }
+        if (route instanceof RelationshipInstanceRoute
+                && isRelationshipMethodAllowedFor(RoutingVerb.DELETE, route, null, null)) {
             allowed.add("DELETE");
         }
         return String.join(", ", allowed);
@@ -329,6 +426,9 @@ public final class WriteMethodPolicy {
             final RoutingVerb blockedVerb,
             final EntityWriteOperation blockedOperation) {
         if (verb == RoutingVerb.PUT && !canPutRouteUseIdentifier(route)) {
+            return false;
+        }
+        if (!isMethodAllowedByApiSpec(verb, route)) {
             return false;
         }
         EntityWriteOperation operation =
@@ -348,13 +448,19 @@ public final class WriteMethodPolicy {
         List<String> allowed = new ArrayList<>();
         allowed.add("OPTIONS");
         if (route instanceof RelationshipCollectionRoute) {
-            allowed.add("GET");
-            allowed.add("HEAD");
+            if (isMethodAllowedByApiSpec(RoutingVerb.GET, route)) {
+                allowed.add("GET");
+            }
+            if (isMethodAllowedByApiSpec(RoutingVerb.HEAD, route)) {
+                allowed.add("HEAD");
+            }
             if (isRelationshipMethodAllowedFor(
                     RoutingVerb.POST, route, blockedVerb, blockedOperation)) {
                 allowed.add("POST");
             }
-            allowed.add("QUERY");
+            if (isMethodAllowedByApiSpec(RoutingVerb.QUERY, route)) {
+                allowed.add("QUERY");
+            }
         }
         if (route instanceof RelationshipInstanceRoute) {
             if (isRelationshipMethodAllowedFor(
@@ -370,6 +476,9 @@ public final class WriteMethodPolicy {
             final ThingRoute route,
             final RoutingVerb blockedVerb,
             final RelationshipWriteOperation blockedOperation) {
+        if (!isMethodAllowedByApiSpec(verb, route)) {
+            return false;
+        }
         if (verb == RoutingVerb.POST && route instanceof RelationshipCollectionRoute) {
             return !relationshipOperationsFor(verb, route).isEmpty();
         }
@@ -379,5 +488,15 @@ public final class WriteMethodPolicy {
                         ? blockedOperation
                         : relationshipOperationFor(verb, route, ApiBodyFields.empty());
         return operation != null && relationshipOperationsFor(verb, route).contains(operation);
+    }
+
+    private boolean isMethodAllowedByApiSpec(final RoutingVerb verb, final ThingRoute route) {
+        return !isMethodNotAllowedByApiSpec(verb, route);
+    }
+
+    private boolean isMethodNotAllowedByApiSpec(final RoutingVerb verb, final ThingRoute route) {
+        return runtime.apiSpec()
+                .isMethodNotAllowed(
+                        verb, route.originalPath(), runtime.apiConfig().getApiEndPointPrefix());
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/WriteMethodPolicy.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/WriteMethodPolicy.java
@@ -18,10 +18,7 @@ import uk.co.compendiumdev.thingifier.apiconfig.EntityWriteOperation;
 import uk.co.compendiumdev.thingifier.apiconfig.PutIdentifierPolicy;
 import uk.co.compendiumdev.thingifier.apiconfig.RelationshipWriteOperation;
 import uk.co.compendiumdev.thingifier.application.schema.EntityTypeRef;
-import uk.co.compendiumdev.thingifier.application.schema.RelationshipSpec;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
-import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.Field;
-import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldType;
 
 /**
  * Enforces write-method policy for generated Thingifier routes.
@@ -74,7 +71,7 @@ public final class WriteMethodPolicy {
 
         if (route instanceof RelationshipCollectionRoute
                 || route instanceof RelationshipInstanceRoute) {
-            return rejectRelationshipWriteIfNotAllowed(verb, route, bodyFields);
+            return rejectRelationshipWriteIfNotAllowed(verb, route, bodyFields, context);
         }
 
         return null;
@@ -188,13 +185,17 @@ public final class WriteMethodPolicy {
      * @return rejection response, or null when the relationship write may continue
      */
     private ApiResponse rejectRelationshipWriteIfNotAllowed(
-            final RoutingVerb verb, final ThingRoute route, final ApiBodyFields bodyFields) {
-        RelationshipWriteOperation operation = relationshipOperationFor(verb, route, bodyFields);
+            final RoutingVerb verb,
+            final ThingRoute route,
+            final ApiBodyFields bodyFields,
+            final ThingifierRequestContext context) {
+        Set<RelationshipWriteOperation> allowed = relationshipOperationsFor(verb, route);
+        RelationshipWriteOperation operation =
+                relationshipOperationFor(verb, route, bodyFields, context, allowed);
         if (operation == null) {
             return null;
         }
 
-        Set<RelationshipWriteOperation> allowed = relationshipOperationsFor(verb, route);
         if (allowed.contains(operation)) {
             return null;
         }
@@ -353,61 +354,14 @@ public final class WriteMethodPolicy {
      * @return relationship operation, or null when the route does not map to one
      */
     private RelationshipWriteOperation relationshipOperationFor(
-            final RoutingVerb verb, final ThingRoute route, final ApiBodyFields bodyFields) {
-        if (verb == RoutingVerb.DELETE && route instanceof RelationshipInstanceRoute) {
-            return RelationshipWriteOperation.DISCONNECT;
-        }
-        if (verb == RoutingVerb.POST && route instanceof RelationshipCollectionRoute) {
-            return bodyReferencesExistingRelatedItem(
-                            (RelationshipCollectionRoute) route, bodyFields)
-                    ? RelationshipWriteOperation.CONNECT_EXISTING
-                    : RelationshipWriteOperation.CREATE_AND_CONNECT;
-        }
-        return null;
-    }
-
-    /**
-     * Reports whether a relationship POST body references an existing related item.
-     *
-     * <p>When the body contains an automatic identifier field for the target entity, the request is
-     * treated as connect-existing rather than create-and-connect.
-     *
-     * @param route mapped relationship collection route
-     * @param bodyFields parsed request body fields
-     * @return true when the body identifies an existing related item
-     */
-    private boolean bodyReferencesExistingRelatedItem(
-            final RelationshipCollectionRoute route, final ApiBodyFields bodyFields) {
-        EntityDefinition targetEntity = targetEntityFor(route);
-        if (targetEntity == null) {
-            return false;
-        }
-
-        for (java.util.Map.Entry<String, String> entry : bodyFields.asFlattenedStringMap()) {
-            Field field = targetEntity.getField(entry.getKey());
-            if (field != null
-                    && (field.getType() == FieldType.AUTO_GUID
-                            || field.getType() == FieldType.AUTO_INCREMENT)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Resolves the target entity of a relationship collection route.
-     *
-     * @param route mapped relationship collection route
-     * @return related target entity, or null when it cannot be resolved
-     */
-    private EntityDefinition targetEntityFor(final RelationshipCollectionRoute route) {
-        for (RelationshipSpec relationship : route.parentEntity().relationships()) {
-            if (relationship.name().equals(route.relationshipName())) {
-                return runtime.schema()
-                        .definitionWithSingularOrPluralNamed(relationship.toEntityName());
-            }
-        }
-        return null;
+            final RoutingVerb verb,
+            final ThingRoute route,
+            final ApiBodyFields bodyFields,
+            final ThingifierRequestContext context,
+            final Set<RelationshipWriteOperation> allowedOperations) {
+        return new RelationshipWriteIntentResolver(runtime.schema())
+                .intentFor(verb, route, bodyFields, context, allowedOperations)
+                .operation();
     }
 
     /**
@@ -445,7 +399,7 @@ public final class WriteMethodPolicy {
      * @param route mapped relationship route
      * @return allowed relationship operations
      */
-    private Set<RelationshipWriteOperation> relationshipOperationsFor(
+    public Set<RelationshipWriteOperation> relationshipOperationsFor(
             final RoutingVerb verb, final ThingRoute route) {
         return runtime.apiSpec()
                 .relationshipWriteOperationsFor(
@@ -687,7 +641,12 @@ public final class WriteMethodPolicy {
         RelationshipWriteOperation operation =
                 verb == blockedVerb
                         ? blockedOperation
-                        : relationshipOperationFor(verb, route, ApiBodyFields.empty());
+                        : relationshipOperationFor(
+                                verb,
+                                route,
+                                ApiBodyFields.empty(),
+                                null,
+                                relationshipOperationsFor(verb, route));
         return operation != null && relationshipOperationsFor(verb, route).contains(operation);
     }
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/WriteMethodPolicy.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/WriteMethodPolicy.java
@@ -23,14 +23,35 @@ import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.Field;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldType;
 
+/**
+ * Enforces write-method policy for generated Thingifier routes.
+ *
+ * <p>The policy combines global write-method configuration with API spec route overrides such as
+ * {@code methodNotAllowed}. It returns 405 responses before write commands are validated or applied
+ * when the generated route should not perform the requested operation.
+ */
 public final class WriteMethodPolicy {
 
     private final ThingifierApiRuntime runtime;
 
+    /**
+     * Creates a policy checker backed by runtime configuration and API spec rules.
+     *
+     * @param runtime runtime services for config, spec, schema, and store access
+     */
     public WriteMethodPolicy(final ThingifierApiRuntime runtime) {
         this.runtime = runtime;
     }
 
+    /**
+     * Rejects a write request when the generated route is not allowed to perform its operation.
+     *
+     * @param verb routing verb being processed
+     * @param route mapped generated route
+     * @param bodyFields parsed request body fields
+     * @param context request context used to inspect existing data when needed
+     * @return rejection response, or null when the write may continue
+     */
     public ApiResponse rejectIfNotAllowed(
             final RoutingVerb verb,
             final ThingRoute route,
@@ -59,6 +80,18 @@ public final class WriteMethodPolicy {
         return null;
     }
 
+    /**
+     * Rejects a route when the API spec declares the verb as method-not-allowed.
+     *
+     * <p>This check runs before operation-specific write policy because a route-level public API
+     * decision should win over generated create/update/connect semantics.
+     *
+     * @param verb routing verb being processed
+     * @param route mapped generated route
+     * @param bodyFields parsed request body fields
+     * @param context request context used for Allow header calculation
+     * @return rejection response, or null when the API spec allows the method
+     */
     private ApiResponse rejectIfMethodNotAllowedByApiSpec(
             final RoutingVerb verb,
             final ThingRoute route,
@@ -70,6 +103,15 @@ public final class WriteMethodPolicy {
         return methodNotAllowed(allowHeaderFor(route, bodyFields, context));
     }
 
+    /**
+     * Rejects entity writes whose concrete create/update operation is not allowed.
+     *
+     * @param verb routing verb being processed
+     * @param route mapped entity route
+     * @param bodyFields parsed request body fields
+     * @param context request context used to inspect existing data when needed
+     * @return rejection response, or null when the entity write may continue
+     */
     private ApiResponse rejectEntityWriteIfNotAllowed(
             final RoutingVerb verb,
             final ThingRoute route,
@@ -102,6 +144,14 @@ public final class WriteMethodPolicy {
         return methodNotAllowed(allowHeaderFor(route, bodyFields, context, verb, operation));
     }
 
+    /**
+     * Rejects PATCH requests when the route or API config does not accept the requested shape.
+     *
+     * @param route mapped entity route
+     * @param bodyFields parsed request body fields
+     * @param context request context used for Allow header calculation
+     * @return rejection response, or null when PATCH may continue
+     */
     private ApiResponse rejectEntityPatchIfNotAllowed(
             final ThingRoute route,
             final ApiBodyFields bodyFields,
@@ -129,6 +179,14 @@ public final class WriteMethodPolicy {
         return null;
     }
 
+    /**
+     * Rejects relationship writes whose connect/disconnect operation is not allowed.
+     *
+     * @param verb routing verb being processed
+     * @param route mapped relationship route
+     * @param bodyFields parsed request body fields
+     * @return rejection response, or null when the relationship write may continue
+     */
     private ApiResponse rejectRelationshipWriteIfNotAllowed(
             final RoutingVerb verb, final ThingRoute route, final ApiBodyFields bodyFields) {
         RelationshipWriteOperation operation = relationshipOperationFor(verb, route, bodyFields);
@@ -144,10 +202,21 @@ public final class WriteMethodPolicy {
         return methodNotAllowed(allowHeaderFor(route, verb, operation));
     }
 
+    /**
+     * Creates Thingifier's standard 405 response.
+     *
+     * @param allowHeader value to expose in the Allow header
+     * @return method-not-allowed API response
+     */
     private ApiResponse methodNotAllowed(final String allowHeader) {
         return ApiResponse.error(405, "Method Not Allowed").setHeader("Allow", allowHeader);
     }
 
+    /**
+     * Rejects requests when global API write-method configuration is invalid.
+     *
+     * @return server error response, or null when configuration is valid
+     */
     private ApiResponse rejectInvalidApiConfig() {
         ApiConfigValidationReport validation = runtime.apiConfig().validate();
         if (validation.isValid()) {
@@ -156,6 +225,15 @@ public final class WriteMethodPolicy {
         return ApiResponse.error(500, validation.errorMessages());
     }
 
+    /**
+     * Determines the entity operation represented by a generated write route.
+     *
+     * @param verb routing verb being processed
+     * @param route mapped entity route
+     * @param bodyFields parsed request body fields
+     * @param context request context used to check whether a PUT target already exists
+     * @return create/update operation, or null when the route does not map to one
+     */
     private EntityWriteOperation entityOperationFor(
             final RoutingVerb verb,
             final ThingRoute route,
@@ -181,6 +259,14 @@ public final class WriteMethodPolicy {
         return null;
     }
 
+    /**
+     * Reports whether an entity instance already exists for the supplied identifier.
+     *
+     * @param entityRef entity reference from the route
+     * @param identifier route or payload identifier
+     * @param context request context containing the active store
+     * @return true when the instance exists
+     */
     private boolean entityInstanceExists(
             final EntityTypeRef entityRef,
             final String identifier,
@@ -193,6 +279,12 @@ public final class WriteMethodPolicy {
         return context.hasEntityInstanceWithIdentifier(entity, identifier);
     }
 
+    /**
+     * Extracts the entity reference from a collection or instance route.
+     *
+     * @param route mapped entity route
+     * @return entity reference from the route
+     */
     private EntityTypeRef entityFor(final ThingRoute route) {
         if (route instanceof CollectionRoute) {
             return ((CollectionRoute) route).entity();
@@ -200,6 +292,13 @@ public final class WriteMethodPolicy {
         return ((InstanceRoute) route).entity();
     }
 
+    /**
+     * Resolves the identifier PUT would use for create-or-update decisions.
+     *
+     * @param route mapped entity route
+     * @param bodyFields parsed request body fields
+     * @return identifier from URI or payload, or null when none is available
+     */
     private String putIdentifierFor(final ThingRoute route, final ApiBodyFields bodyFields) {
         if (route instanceof InstanceRoute) {
             return ((InstanceRoute) route).identifier();
@@ -213,6 +312,12 @@ public final class WriteMethodPolicy {
         return null;
     }
 
+    /**
+     * Reports whether a PUT route can legally derive an identifier from its URI or payload.
+     *
+     * @param route mapped entity route
+     * @return true when PUT identifier policy permits this route shape
+     */
     private boolean canPutRouteUseIdentifier(final ThingRoute route) {
         if (route instanceof CollectionRoute) {
             CollectionRoute collection = (CollectionRoute) route;
@@ -229,10 +334,24 @@ public final class WriteMethodPolicy {
         return false;
     }
 
+    /**
+     * Reports whether an identifier has usable text.
+     *
+     * @param identifier candidate identifier
+     * @return true when the identifier is not blank
+     */
     private boolean hasIdentifier(final String identifier) {
         return identifier != null && !identifier.trim().isEmpty();
     }
 
+    /**
+     * Determines the relationship operation represented by a generated relationship route.
+     *
+     * @param verb routing verb being processed
+     * @param route mapped relationship route
+     * @param bodyFields parsed request body fields
+     * @return relationship operation, or null when the route does not map to one
+     */
     private RelationshipWriteOperation relationshipOperationFor(
             final RoutingVerb verb, final ThingRoute route, final ApiBodyFields bodyFields) {
         if (verb == RoutingVerb.DELETE && route instanceof RelationshipInstanceRoute) {
@@ -247,6 +366,16 @@ public final class WriteMethodPolicy {
         return null;
     }
 
+    /**
+     * Reports whether a relationship POST body references an existing related item.
+     *
+     * <p>When the body contains an automatic identifier field for the target entity, the request is
+     * treated as connect-existing rather than create-and-connect.
+     *
+     * @param route mapped relationship collection route
+     * @param bodyFields parsed request body fields
+     * @return true when the body identifies an existing related item
+     */
     private boolean bodyReferencesExistingRelatedItem(
             final RelationshipCollectionRoute route, final ApiBodyFields bodyFields) {
         EntityDefinition targetEntity = targetEntityFor(route);
@@ -265,6 +394,12 @@ public final class WriteMethodPolicy {
         return false;
     }
 
+    /**
+     * Resolves the target entity of a relationship collection route.
+     *
+     * @param route mapped relationship collection route
+     * @return related target entity, or null when it cannot be resolved
+     */
     private EntityDefinition targetEntityFor(final RelationshipCollectionRoute route) {
         for (RelationshipSpec relationship : route.parentEntity().relationships()) {
             if (relationship.name().equals(route.relationshipName())) {
@@ -275,6 +410,13 @@ public final class WriteMethodPolicy {
         return null;
     }
 
+    /**
+     * Resolves allowed entity operations from API spec or global write-method config.
+     *
+     * @param verb routing verb being processed
+     * @param route mapped entity route
+     * @return allowed entity operations
+     */
     private Set<EntityWriteOperation> entityOperationsFor(
             final RoutingVerb verb, final ThingRoute route) {
         return runtime.apiSpec()
@@ -283,6 +425,12 @@ public final class WriteMethodPolicy {
                 .orElse(runtime.apiConfig().writeMethods().entities().operationsFor(verb));
     }
 
+    /**
+     * Resolves allowed PATCH styles from API spec or global write-method config.
+     *
+     * @param route mapped entity route
+     * @return accepted PATCH update styles
+     */
     public Set<EntityPatchUpdateStyle> entityPatchUpdateStylesFor(final ThingRoute route) {
         return runtime.apiSpec()
                 .entityPatchUpdateStylesFor(
@@ -290,6 +438,13 @@ public final class WriteMethodPolicy {
                 .orElse(runtime.apiConfig().writeMethods().entities().patchUpdateStyles());
     }
 
+    /**
+     * Resolves allowed relationship operations from API spec or global write-method config.
+     *
+     * @param verb routing verb being processed
+     * @param route mapped relationship route
+     * @return allowed relationship operations
+     */
     private Set<RelationshipWriteOperation> relationshipOperationsFor(
             final RoutingVerb verb, final ThingRoute route) {
         return runtime.apiSpec()
@@ -298,6 +453,16 @@ public final class WriteMethodPolicy {
                 .orElse(runtime.apiConfig().writeMethods().relationships().operationsFor(verb));
     }
 
+    /**
+     * Builds an Allow header while excluding a rejected entity write operation.
+     *
+     * @param route mapped entity route
+     * @param bodyFields parsed request body fields
+     * @param context request context used for PUT create/update decisions
+     * @param blockedVerb verb currently being rejected
+     * @param blockedOperation operation currently being rejected
+     * @return comma-separated Allow header value
+     */
     private String allowHeaderFor(
             final ThingRoute route,
             final ApiBodyFields bodyFields,
@@ -351,6 +516,14 @@ public final class WriteMethodPolicy {
         return String.join(", ", allowed);
     }
 
+    /**
+     * Builds an Allow header from all methods currently permitted for a generated route.
+     *
+     * @param route mapped route
+     * @param bodyFields parsed request body fields
+     * @param context request context used for PUT create/update decisions
+     * @return comma-separated Allow header value
+     */
     private String allowHeaderFor(
             final ThingRoute route,
             final ApiBodyFields bodyFields,
@@ -418,6 +591,17 @@ public final class WriteMethodPolicy {
         return String.join(", ", allowed);
     }
 
+    /**
+     * Reports whether a specific entity method is allowed for the route and current data.
+     *
+     * @param verb routing verb to check
+     * @param route mapped entity route
+     * @param bodyFields parsed request body fields
+     * @param context request context used for PUT create/update decisions
+     * @param blockedVerb verb currently being rejected, or null
+     * @param blockedOperation operation currently being rejected, or null
+     * @return true when the method should appear in Allow
+     */
     private boolean isEntityMethodAllowedFor(
             final RoutingVerb verb,
             final ThingRoute route,
@@ -441,6 +625,14 @@ public final class WriteMethodPolicy {
         return operation != null && entityOperationsFor(verb, route).contains(operation);
     }
 
+    /**
+     * Builds an Allow header while excluding a rejected relationship write operation.
+     *
+     * @param route mapped relationship route
+     * @param blockedVerb verb currently being rejected
+     * @param blockedOperation operation currently being rejected
+     * @return comma-separated Allow header value
+     */
     private String allowHeaderFor(
             final ThingRoute route,
             final RoutingVerb blockedVerb,
@@ -471,6 +663,15 @@ public final class WriteMethodPolicy {
         return String.join(", ", allowed);
     }
 
+    /**
+     * Reports whether a specific relationship method is allowed for the route.
+     *
+     * @param verb routing verb to check
+     * @param route mapped relationship route
+     * @param blockedVerb verb currently being rejected, or null
+     * @param blockedOperation operation currently being rejected, or null
+     * @return true when the method should appear in Allow
+     */
     private boolean isRelationshipMethodAllowedFor(
             final RoutingVerb verb,
             final ThingRoute route,
@@ -490,10 +691,24 @@ public final class WriteMethodPolicy {
         return operation != null && relationshipOperationsFor(verb, route).contains(operation);
     }
 
+    /**
+     * Reports whether API spec allows a generated method to be advertised.
+     *
+     * @param verb routing verb to check
+     * @param route mapped route
+     * @return true when the method is not configured as method-not-allowed
+     */
     private boolean isMethodAllowedByApiSpec(final RoutingVerb verb, final ThingRoute route) {
         return !isMethodNotAllowedByApiSpec(verb, route);
     }
 
+    /**
+     * Reports whether API spec marks a generated method as 405 Method Not Allowed.
+     *
+     * @param verb routing verb to check
+     * @param route mapped route
+     * @return true when API spec marks the method unavailable
+     */
     private boolean isMethodNotAllowedByApiSpec(final RoutingVerb verb, final ThingRoute route) {
         return runtime.apiSpec()
                 .isMethodNotAllowed(

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/AfterActionContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/AfterActionContext.java
@@ -1,0 +1,3 @@
+package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
+
+public interface AfterActionContext extends ThingifierApiLifecycleContextView {}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/AfterActionContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/AfterActionContext.java
@@ -1,3 +1,9 @@
 package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
 
+/**
+ * Context view exposed after Thingifier has executed a read query or write command.
+ *
+ * <p>Hooks at this phase can inspect command/query results and replace the final {@code
+ * ApiResponse} before legacy HTTP response hooks and content rendering run.
+ */
 public interface AfterActionContext extends ThingifierApiLifecycleContextView {}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/AfterActionHook.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/AfterActionHook.java
@@ -1,6 +1,17 @@
 package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
 
+/**
+ * Hook invoked after the read or write action has produced its result and response.
+ *
+ * <p>This phase is intended for response shaping, result inspection, or explicit result replacement
+ * after Thingifier has done the core work.
+ */
 public interface AfterActionHook {
 
+    /**
+     * Runs the hook against the after-action context.
+     *
+     * @param context lifecycle context for the current request
+     */
     void run(AfterActionContext context);
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/AfterActionHook.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/AfterActionHook.java
@@ -1,0 +1,6 @@
+package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
+
+public interface AfterActionHook {
+
+    void run(AfterActionContext context);
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/AfterValidationContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/AfterValidationContext.java
@@ -1,3 +1,9 @@
 package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
 
+/**
+ * Context view exposed after Thingifier has validated a mapped read query or write command.
+ *
+ * <p>Hooks at this phase can inspect, replace, reject, or clear validation results before the
+ * action phase decides whether the command or query should execute.
+ */
 public interface AfterValidationContext extends ThingifierApiLifecycleContextView {}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/AfterValidationContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/AfterValidationContext.java
@@ -1,0 +1,3 @@
+package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
+
+public interface AfterValidationContext extends ThingifierApiLifecycleContextView {}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/AfterValidationHook.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/AfterValidationHook.java
@@ -1,6 +1,17 @@
 package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
 
+/**
+ * Hook invoked after Thingifier validation and before action execution.
+ *
+ * <p>This phase lets callers convert validation outcomes into custom behavior, reject otherwise
+ * valid work, or clear a recoverable validation failure before action execution.
+ */
 public interface AfterValidationHook {
 
+    /**
+     * Runs the hook against the after-validation context.
+     *
+     * @param context lifecycle context for the current request
+     */
     void run(AfterValidationContext context);
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/AfterValidationHook.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/AfterValidationHook.java
@@ -1,0 +1,6 @@
+package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
+
+public interface AfterValidationHook {
+
+    void run(AfterValidationContext context);
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/BeforeActionContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/BeforeActionContext.java
@@ -1,3 +1,9 @@
 package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
 
+/**
+ * Context view exposed immediately before Thingifier executes a read query or write command.
+ *
+ * <p>Hooks at this phase are the last chance to replace the command or query before persistence or
+ * repository read behavior occurs.
+ */
 public interface BeforeActionContext extends ThingifierApiLifecycleContextView {}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/BeforeActionContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/BeforeActionContext.java
@@ -1,0 +1,3 @@
+package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
+
+public interface BeforeActionContext extends ThingifierApiLifecycleContextView {}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/BeforeActionHook.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/BeforeActionHook.java
@@ -1,6 +1,17 @@
 package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
 
+/**
+ * Hook invoked after validation and immediately before the read or write action.
+ *
+ * <p>This phase is intended for last-mile command or query replacement when validation has already
+ * accepted the work that will be executed.
+ */
 public interface BeforeActionHook {
 
+    /**
+     * Runs the hook against the before-action context.
+     *
+     * @param context lifecycle context for the current request
+     */
     void run(BeforeActionContext context);
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/BeforeActionHook.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/BeforeActionHook.java
@@ -1,0 +1,6 @@
+package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
+
+public interface BeforeActionHook {
+
+    void run(BeforeActionContext context);
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/BeforeValidationContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/BeforeValidationContext.java
@@ -1,3 +1,9 @@
 package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
 
+/**
+ * Context view exposed after a read query or write command has been mapped and before validation.
+ *
+ * <p>Hooks at this phase are intended for explicit input shaping, such as replacing a mapped write
+ * command so Thingifier validation evaluates the amended command.
+ */
 public interface BeforeValidationContext extends ThingifierApiLifecycleContextView {}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/BeforeValidationContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/BeforeValidationContext.java
@@ -1,0 +1,3 @@
+package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
+
+public interface BeforeValidationContext extends ThingifierApiLifecycleContextView {}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/BeforeValidationHook.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/BeforeValidationHook.java
@@ -1,0 +1,6 @@
+package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
+
+public interface BeforeValidationHook {
+
+    void run(BeforeValidationContext context);
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/BeforeValidationHook.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/BeforeValidationHook.java
@@ -1,6 +1,17 @@
 package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
 
+/**
+ * Hook invoked after request mapping and before Thingifier validation.
+ *
+ * <p>This is the right phase to replace a mapped command or query when validation should evaluate
+ * the replacement rather than the original request.
+ */
 public interface BeforeValidationHook {
 
+    /**
+     * Runs the hook against the before-validation context.
+     *
+     * @param context lifecycle context for the current request
+     */
     void run(BeforeValidationContext context);
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/BodyParsedContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/BodyParsedContext.java
@@ -1,0 +1,3 @@
+package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
+
+public interface BodyParsedContext extends ThingifierApiLifecycleContextView {}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/BodyParsedContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/BodyParsedContext.java
@@ -1,3 +1,9 @@
 package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
 
+/**
+ * Context view exposed after request body and query data have been parsed.
+ *
+ * <p>Hooks at this phase can replace parsed body fields, raw body text, query parameters, or query
+ * body format before Thingifier maps the request into a read query or write command.
+ */
 public interface BodyParsedContext extends ThingifierApiLifecycleContextView {}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/BodyParsedHook.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/BodyParsedHook.java
@@ -1,6 +1,17 @@
 package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
 
+/**
+ * Hook invoked after request body and query data are parsed.
+ *
+ * <p>This phase is designed for explicit request data changes before the request is mapped into a
+ * Thingifier read query or write command.
+ */
 public interface BodyParsedHook {
 
+    /**
+     * Runs the hook against the parsed-body context.
+     *
+     * @param context lifecycle context for the current request
+     */
     void run(BodyParsedContext context);
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/BodyParsedHook.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/BodyParsedHook.java
@@ -1,0 +1,6 @@
+package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
+
+public interface BodyParsedHook {
+
+    void run(BodyParsedContext context);
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/RouteMatchedContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/RouteMatchedContext.java
@@ -1,3 +1,9 @@
 package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
 
+/**
+ * Context view exposed after a dynamic Thingifier API route has been matched.
+ *
+ * <p>At this phase hooks can inspect route, path, headers, query parameters, and target entity
+ * information before request syntax and entity-view checks continue.
+ */
 public interface RouteMatchedContext extends ThingifierApiLifecycleContextView {}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/RouteMatchedContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/RouteMatchedContext.java
@@ -1,0 +1,3 @@
+package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
+
+public interface RouteMatchedContext extends ThingifierApiLifecycleContextView {}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/RouteMatchedHook.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/RouteMatchedHook.java
@@ -1,0 +1,6 @@
+package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
+
+public interface RouteMatchedHook {
+
+    void run(RouteMatchedContext context);
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/RouteMatchedHook.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/RouteMatchedHook.java
@@ -1,6 +1,17 @@
 package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
 
+/**
+ * Hook invoked once a dynamic Thingifier API request has been matched to a route.
+ *
+ * <p>This phase is useful for route-aware policy decisions that should happen before body parsing
+ * or validation, including early short-circuit responses.
+ */
 public interface RouteMatchedHook {
 
+    /**
+     * Runs the hook against the route-matched context.
+     *
+     * @param context lifecycle context for the current request
+     */
     void run(RouteMatchedContext context);
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/ThingifierApiLifecycleContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/ThingifierApiLifecycleContext.java
@@ -24,6 +24,13 @@ import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
 import uk.co.compendiumdev.thingifier.core.query.RepositoryQueryResult;
 import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
 
+/**
+ * Mutable operation context shared by all lifecycle hook phases for one Thingifier API request.
+ *
+ * <p>The class precomputes stable route details and tracks explicit replacements made by hooks. The
+ * replacement flags allow handlers to decide whether request data should be remapped or whether a
+ * hook intentionally supplied a final command, query, result, or response.
+ */
 public final class ThingifierApiLifecycleContext
         implements RouteMatchedContext,
                 BodyParsedContext,
@@ -65,6 +72,16 @@ public final class ThingifierApiLifecycleContext
     private boolean apiResponseReplaced;
     private boolean shortCircuit;
 
+    /**
+     * Creates a lifecycle context for one matched Thingifier API route.
+     *
+     * @param runtime runtime services for schema, API spec, stores, commands, and queries
+     * @param request HTTP API request being processed
+     * @param effectiveVerb verb after method override handling
+     * @param routingVerb generated routing verb equivalent
+     * @param route matched generated route
+     * @param apiPathPrefix configured API prefix used by scoped hook matching
+     */
     public ThingifierApiLifecycleContext(
             final ThingifierApiRuntime runtime,
             final HttpApiRequest request,
@@ -95,14 +112,29 @@ public final class ThingifierApiLifecycleContext
         return effectiveVerb;
     }
 
+    /**
+     * Returns the generated routing verb equivalent for scoped hook matching.
+     *
+     * @return routing verb, or null when no generated route verb applies
+     */
     public RoutingVerb routingVerb() {
         return routingVerb;
     }
 
+    /**
+     * Returns runtime services backing this lifecycle request.
+     *
+     * @return Thingifier API runtime
+     */
     public ThingifierApiRuntime runtime() {
         return runtime;
     }
 
+    /**
+     * Returns the underlying HTTP API request.
+     *
+     * @return request being processed
+     */
     public HttpApiRequest request() {
         return request;
     }
@@ -112,6 +144,11 @@ public final class ThingifierApiLifecycleContext
         return request.getPath();
     }
 
+    /**
+     * Returns the API path prefix used when matching scoped hooks and API spec rules.
+     *
+     * @return configured API prefix, or an empty string
+     */
     public String apiPathPrefix() {
         return apiPathPrefix;
     }
@@ -302,6 +339,14 @@ public final class ThingifierApiLifecycleContext
         return shortCircuit;
     }
 
+    /**
+     * Applies parsed request data after syntax and entity-view checks.
+     *
+     * <p>Values already replaced by earlier hooks are preserved so explicit hook mutations are not
+     * overwritten by normal parsing.
+     *
+     * @param envelope parsed request envelope
+     */
     public void applyParsedEnvelope(final ApiRequestEnvelope envelope) {
         if (envelope == null) {
             return;
@@ -316,6 +361,11 @@ public final class ThingifierApiLifecycleContext
         queryBodyFormat = envelope.queryBodyFormat();
     }
 
+    /**
+     * Converts the current lifecycle request state back into a handler envelope.
+     *
+     * @return request envelope reflecting hook mutations
+     */
     public ApiRequestEnvelope toEnvelope() {
         return ApiRequestEnvelope.fromParsed(
                 effectiveVerb,
@@ -327,49 +377,114 @@ public final class ThingifierApiLifecycleContext
                 queryBodyFormat);
     }
 
+    /**
+     * Stores the write command produced by normal request mapping.
+     *
+     * <p>This differs from {@link #replaceWriteCommand(ThingWriteCommand)} because it records the
+     * mapped baseline, not a hook replacement.
+     *
+     * @param command mapped write command
+     */
     public void useMappedWriteCommand(final ThingWriteCommand command) {
         this.writeCommand = command;
         this.writeCommandReplaced = false;
     }
 
+    /**
+     * Reports whether a hook explicitly replaced the write command.
+     *
+     * @return true when the mapped write command was replaced
+     */
     public boolean writeCommandWasReplaced() {
         return writeCommandReplaced;
     }
 
+    /**
+     * Stores the read query produced by normal request mapping.
+     *
+     * <p>This differs from {@link #replaceReadQuery(ThingReadQuery)} because it records the mapped
+     * baseline, not a hook replacement.
+     *
+     * @param query mapped read query
+     */
     public void useMappedReadQuery(final ThingReadQuery query) {
         this.readQuery = query;
         this.readQueryReplaced = false;
     }
 
+    /**
+     * Reports whether a hook explicitly replaced the read query.
+     *
+     * @return true when the mapped read query was replaced
+     */
     public boolean readQueryWasReplaced() {
         return readQueryReplaced;
     }
 
+    /**
+     * Reports whether query parameters were explicitly replaced.
+     *
+     * @return true when a hook replaced query parameters
+     */
     public boolean queryParamsWereReplaced() {
         return queryParamsReplaced;
     }
 
+    /**
+     * Reports whether parsed body fields were explicitly replaced.
+     *
+     * @return true when a hook replaced body fields
+     */
     public boolean bodyFieldsWereReplaced() {
         return bodyFieldsReplaced;
     }
 
+    /**
+     * Reports whether the raw body was explicitly replaced.
+     *
+     * @return true when a hook replaced raw body text
+     */
     public boolean rawBodyWasReplaced() {
         return rawBodyReplaced;
     }
 
+    /**
+     * Reports whether the QUERY body format was explicitly replaced.
+     *
+     * @return true when a hook replaced query body format
+     */
     public boolean queryBodyFormatWasReplaced() {
         return queryBodyFormatReplaced;
     }
 
+    /**
+     * Stores the API response produced by normal request processing.
+     *
+     * <p>This differs from {@link #replaceApiResponse(ApiResponse)} because it records the mapped
+     * baseline, not a hook replacement.
+     *
+     * @param response generated API response
+     */
     public void useApiResponse(final ApiResponse response) {
         this.apiResponse = response;
         this.apiResponseReplaced = false;
     }
 
+    /**
+     * Reports whether a hook explicitly replaced the API response.
+     *
+     * @return true when a hook replaced the API response
+     */
     public boolean apiResponseWasReplaced() {
         return apiResponseReplaced;
     }
 
+    /**
+     * Resolves the target entity for entity and relationship routes.
+     *
+     * @param route matched generated route
+     * @return target entity, or null when the route is not entity-backed
+     */
     private EntityDefinition resolveTargetEntity(final ThingRoute route) {
         if (route instanceof CollectionRoute) {
             return entityNamed(((CollectionRoute) route).entity().name());
@@ -390,6 +505,12 @@ public final class ThingifierApiLifecycleContext
         return null;
     }
 
+    /**
+     * Resolves the parent entity for relationship routes.
+     *
+     * @param route matched generated route
+     * @return parent entity, or null for non-relationship routes
+     */
     private EntityDefinition resolveParentEntity(final ThingRoute route) {
         if (route instanceof RelationshipCollectionRoute) {
             return entityNamed(((RelationshipCollectionRoute) route).parentEntity().name());
@@ -400,6 +521,12 @@ public final class ThingifierApiLifecycleContext
         return null;
     }
 
+    /**
+     * Resolves the target identifier for instance routes.
+     *
+     * @param route matched generated route
+     * @return target identifier, or null for collection routes
+     */
     private String resolveTargetIdentifier(final ThingRoute route) {
         if (route instanceof InstanceRoute) {
             return ((InstanceRoute) route).identifier();
@@ -410,6 +537,12 @@ public final class ThingifierApiLifecycleContext
         return null;
     }
 
+    /**
+     * Resolves the parent identifier for relationship routes.
+     *
+     * @param route matched generated route
+     * @return parent identifier, or null for non-relationship routes
+     */
     private String resolveParentIdentifier(final ThingRoute route) {
         if (route instanceof RelationshipCollectionRoute) {
             return ((RelationshipCollectionRoute) route).parentIdentifier();
@@ -420,6 +553,12 @@ public final class ThingifierApiLifecycleContext
         return null;
     }
 
+    /**
+     * Resolves the relationship name for relationship routes.
+     *
+     * @param route matched generated route
+     * @return relationship name, or null for entity routes
+     */
     private String resolveRelationshipName(final ThingRoute route) {
         if (route instanceof RelationshipCollectionRoute) {
             return ((RelationshipCollectionRoute) route).relationshipName();
@@ -430,6 +569,12 @@ public final class ThingifierApiLifecycleContext
         return null;
     }
 
+    /**
+     * Resolves the child identifier for relationship instance routes.
+     *
+     * @param route matched generated route
+     * @return child identifier, or null when the route does not identify a child
+     */
     private String resolveChildIdentifier(final ThingRoute route) {
         if (route instanceof RelationshipInstanceRoute) {
             return ((RelationshipInstanceRoute) route).childIdentifier();
@@ -437,6 +582,13 @@ public final class ThingifierApiLifecycleContext
         return null;
     }
 
+    /**
+     * Resolves the related entity targeted by a relationship route.
+     *
+     * @param parentEntity parent entity reference from the route
+     * @param relationshipName relationship route name
+     * @return related target entity, or null when the relationship cannot be resolved
+     */
     private EntityDefinition targetEntityForRelationship(
             final EntityTypeRef parentEntity, final String relationshipName) {
         if (parentEntity == null) {
@@ -450,10 +602,22 @@ public final class ThingifierApiLifecycleContext
         return null;
     }
 
+    /**
+     * Looks up an entity definition by singular or plural model name.
+     *
+     * @param entityName singular or plural entity name
+     * @return matching entity definition, or null
+     */
     private EntityDefinition entityNamed(final String entityName) {
         return runtime.schema().definitionWithSingularOrPluralNamed(entityName);
     }
 
+    /**
+     * Copies query parameters so hook callers cannot mutate internal state by retaining references.
+     *
+     * @param original source query parameters
+     * @return independent query parameter copy
+     */
     private QueryFilterParams copyQueryParams(final QueryFilterParams original) {
         QueryFilterParams copy = new QueryFilterParams();
         copy.addAll(original);

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/ThingifierApiLifecycleContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/ThingifierApiLifecycleContext.java
@@ -1,0 +1,462 @@
+package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
+
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierApiRuntime;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.CollectionRoute;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.InstanceRoute;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.RelationshipCollectionRoute;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.RelationshipInstanceRoute;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
+import uk.co.compendiumdev.thingifier.api.http.ApiRequestEnvelope;
+import uk.co.compendiumdev.thingifier.api.http.HttpApiRequest;
+import uk.co.compendiumdev.thingifier.api.http.ThingifierHttpApi;
+import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
+import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields;
+import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
+import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
+import uk.co.compendiumdev.thingifier.application.ThingCommandResult;
+import uk.co.compendiumdev.thingifier.application.command.ThingWriteCommand;
+import uk.co.compendiumdev.thingifier.application.query.ThingReadQuery;
+import uk.co.compendiumdev.thingifier.application.schema.EntityTypeRef;
+import uk.co.compendiumdev.thingifier.application.schema.RelationshipSpec;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
+import uk.co.compendiumdev.thingifier.core.query.RepositoryQueryResult;
+import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
+
+public final class ThingifierApiLifecycleContext
+        implements RouteMatchedContext,
+                BodyParsedContext,
+                BeforeValidationContext,
+                AfterValidationContext,
+                BeforeActionContext,
+                AfterActionContext {
+
+    private final ThingifierApiRuntime runtime;
+    private final HttpApiRequest request;
+    private final ThingifierHttpApi.HttpVerb effectiveVerb;
+    private final RoutingVerb routingVerb;
+    private final ThingRoute route;
+    private final String apiPathPrefix;
+    private final EntityDefinition targetEntity;
+    private final EntityDefinition parentEntity;
+    private final String targetIdentifier;
+    private final String parentIdentifier;
+    private final String relationshipName;
+    private final String childIdentifier;
+
+    private QueryFilterParams queryParams;
+    private boolean queryParamsReplaced;
+    private String rawBody;
+    private boolean rawBodyReplaced;
+    private ApiBodyFields bodyFields;
+    private boolean bodyFieldsReplaced;
+    private ApiRequestEnvelope.QueryBodyFormat queryBodyFormat;
+    private boolean queryBodyFormatReplaced;
+    private ThingifierRequestContext requestContext;
+    private ThingWriteCommand writeCommand;
+    private boolean writeCommandReplaced;
+    private ThingReadQuery readQuery;
+    private boolean readQueryReplaced;
+    private ThingCommandResult validationResult;
+    private ThingCommandResult writeCommandResult;
+    private RepositoryQueryResult readQueryResult;
+    private ApiResponse apiResponse;
+    private boolean apiResponseReplaced;
+    private boolean shortCircuit;
+
+    public ThingifierApiLifecycleContext(
+            final ThingifierApiRuntime runtime,
+            final HttpApiRequest request,
+            final ThingifierHttpApi.HttpVerb effectiveVerb,
+            final RoutingVerb routingVerb,
+            final ThingRoute route,
+            final String apiPathPrefix) {
+        this.runtime = runtime;
+        this.request = request;
+        this.effectiveVerb = effectiveVerb;
+        this.routingVerb = routingVerb;
+        this.route = route;
+        this.apiPathPrefix = apiPathPrefix == null ? "" : apiPathPrefix;
+        this.queryParams = copyQueryParams(request.getFilterableQueryParams());
+        this.rawBody = request.getBody();
+        this.bodyFields = ApiBodyFields.empty();
+        this.queryBodyFormat = ApiRequestEnvelope.QueryBodyFormat.URL_ENCODED;
+        this.targetEntity = resolveTargetEntity(route);
+        this.parentEntity = resolveParentEntity(route);
+        this.targetIdentifier = resolveTargetIdentifier(route);
+        this.parentIdentifier = resolveParentIdentifier(route);
+        this.relationshipName = resolveRelationshipName(route);
+        this.childIdentifier = resolveChildIdentifier(route);
+    }
+
+    @Override
+    public ThingifierHttpApi.HttpVerb effectiveVerb() {
+        return effectiveVerb;
+    }
+
+    public RoutingVerb routingVerb() {
+        return routingVerb;
+    }
+
+    public ThingifierApiRuntime runtime() {
+        return runtime;
+    }
+
+    public HttpApiRequest request() {
+        return request;
+    }
+
+    @Override
+    public String path() {
+        return request.getPath();
+    }
+
+    public String apiPathPrefix() {
+        return apiPathPrefix;
+    }
+
+    @Override
+    public ThingRoute route() {
+        return route;
+    }
+
+    @Override
+    public EntityDefinition targetEntity() {
+        return targetEntity;
+    }
+
+    @Override
+    public String targetIdentifier() {
+        return targetIdentifier;
+    }
+
+    @Override
+    public EntityDefinition parentEntity() {
+        return parentEntity;
+    }
+
+    @Override
+    public String parentIdentifier() {
+        return parentIdentifier;
+    }
+
+    @Override
+    public String relationshipName() {
+        return relationshipName;
+    }
+
+    @Override
+    public String childIdentifier() {
+        return childIdentifier;
+    }
+
+    @Override
+    public HttpHeadersBlock headers() {
+        return request.getHeaders();
+    }
+
+    @Override
+    public void setHeader(final String name, final String value) {
+        request.addHeader(name, value);
+        requestContext = null;
+    }
+
+    @Override
+    public QueryFilterParams queryParams() {
+        return copyQueryParams(queryParams);
+    }
+
+    @Override
+    public void replaceQueryParams(final QueryFilterParams queryParams) {
+        this.queryParams = copyQueryParams(queryParams);
+        this.queryParamsReplaced = true;
+    }
+
+    @Override
+    public String rawBody() {
+        return rawBody;
+    }
+
+    @Override
+    public void replaceRawBody(final String rawBody) {
+        this.rawBody = rawBody == null ? "" : rawBody;
+        this.rawBodyReplaced = true;
+        request.setBody(this.rawBody);
+    }
+
+    @Override
+    public ApiBodyFields bodyFields() {
+        return bodyFields;
+    }
+
+    @Override
+    public void replaceBodyFields(final ApiBodyFields bodyFields) {
+        this.bodyFields = bodyFields == null ? ApiBodyFields.empty() : bodyFields;
+        this.bodyFieldsReplaced = true;
+    }
+
+    @Override
+    public ApiRequestEnvelope.QueryBodyFormat queryBodyFormat() {
+        return queryBodyFormat;
+    }
+
+    @Override
+    public void replaceQueryBodyFormat(final ApiRequestEnvelope.QueryBodyFormat queryBodyFormat) {
+        if (queryBodyFormat != null) {
+            this.queryBodyFormat = queryBodyFormat;
+            this.queryBodyFormatReplaced = true;
+        }
+    }
+
+    @Override
+    public ThingifierRequestContext requestContext() {
+        if (requestContext == null) {
+            requestContext = runtime.contextFrom(request.getHeaders());
+        }
+        return requestContext;
+    }
+
+    @Override
+    public ThingStore store() {
+        return requestContext().store();
+    }
+
+    @Override
+    public ThingWriteCommand writeCommand() {
+        return writeCommand;
+    }
+
+    @Override
+    public void replaceWriteCommand(final ThingWriteCommand command) {
+        this.writeCommand = command;
+        this.writeCommandReplaced = true;
+    }
+
+    @Override
+    public ThingReadQuery readQuery() {
+        return readQuery;
+    }
+
+    @Override
+    public void replaceReadQuery(final ThingReadQuery query) {
+        this.readQuery = query;
+        this.readQueryReplaced = true;
+    }
+
+    @Override
+    public ThingCommandResult validationResult() {
+        return validationResult;
+    }
+
+    @Override
+    public void replaceValidationResult(final ThingCommandResult result) {
+        this.validationResult = result;
+    }
+
+    @Override
+    public void clearValidationResult() {
+        validationResult = null;
+    }
+
+    @Override
+    public ThingCommandResult writeCommandResult() {
+        return writeCommandResult;
+    }
+
+    @Override
+    public void replaceWriteCommandResult(final ThingCommandResult result) {
+        this.writeCommandResult = result;
+    }
+
+    @Override
+    public RepositoryQueryResult readQueryResult() {
+        return readQueryResult;
+    }
+
+    @Override
+    public void replaceReadQueryResult(final RepositoryQueryResult result) {
+        this.readQueryResult = result;
+    }
+
+    @Override
+    public ApiResponse apiResponse() {
+        return apiResponse;
+    }
+
+    @Override
+    public void replaceApiResponse(final ApiResponse response) {
+        this.apiResponse = response;
+        this.apiResponseReplaced = true;
+    }
+
+    @Override
+    public void shortCircuitWith(final ApiResponse response) {
+        this.apiResponse = response;
+        this.apiResponseReplaced = true;
+        this.shortCircuit = true;
+    }
+
+    @Override
+    public boolean shouldShortCircuit() {
+        return shortCircuit;
+    }
+
+    public void applyParsedEnvelope(final ApiRequestEnvelope envelope) {
+        if (envelope == null) {
+            return;
+        }
+        if (!queryParamsReplaced) {
+            queryParams = copyQueryParams(envelope.queryParams());
+        }
+        if (!bodyFieldsReplaced) {
+            bodyFields = envelope.bodyFields();
+        }
+        rawBody = envelope.body();
+        queryBodyFormat = envelope.queryBodyFormat();
+    }
+
+    public ApiRequestEnvelope toEnvelope() {
+        return ApiRequestEnvelope.fromParsed(
+                effectiveVerb,
+                path(),
+                queryParams(),
+                headers(),
+                bodyFields,
+                rawBody,
+                queryBodyFormat);
+    }
+
+    public void useMappedWriteCommand(final ThingWriteCommand command) {
+        this.writeCommand = command;
+        this.writeCommandReplaced = false;
+    }
+
+    public boolean writeCommandWasReplaced() {
+        return writeCommandReplaced;
+    }
+
+    public void useMappedReadQuery(final ThingReadQuery query) {
+        this.readQuery = query;
+        this.readQueryReplaced = false;
+    }
+
+    public boolean readQueryWasReplaced() {
+        return readQueryReplaced;
+    }
+
+    public boolean queryParamsWereReplaced() {
+        return queryParamsReplaced;
+    }
+
+    public boolean bodyFieldsWereReplaced() {
+        return bodyFieldsReplaced;
+    }
+
+    public boolean rawBodyWasReplaced() {
+        return rawBodyReplaced;
+    }
+
+    public boolean queryBodyFormatWasReplaced() {
+        return queryBodyFormatReplaced;
+    }
+
+    public void useApiResponse(final ApiResponse response) {
+        this.apiResponse = response;
+        this.apiResponseReplaced = false;
+    }
+
+    public boolean apiResponseWasReplaced() {
+        return apiResponseReplaced;
+    }
+
+    private EntityDefinition resolveTargetEntity(final ThingRoute route) {
+        if (route instanceof CollectionRoute) {
+            return entityNamed(((CollectionRoute) route).entity().name());
+        }
+        if (route instanceof InstanceRoute) {
+            return entityNamed(((InstanceRoute) route).entity().name());
+        }
+        if (route instanceof RelationshipCollectionRoute) {
+            RelationshipCollectionRoute relationship = (RelationshipCollectionRoute) route;
+            return targetEntityForRelationship(
+                    relationship.parentEntity(), relationship.relationshipName());
+        }
+        if (route instanceof RelationshipInstanceRoute) {
+            RelationshipInstanceRoute relationship = (RelationshipInstanceRoute) route;
+            return targetEntityForRelationship(
+                    relationship.parentEntity(), relationship.relationshipName());
+        }
+        return null;
+    }
+
+    private EntityDefinition resolveParentEntity(final ThingRoute route) {
+        if (route instanceof RelationshipCollectionRoute) {
+            return entityNamed(((RelationshipCollectionRoute) route).parentEntity().name());
+        }
+        if (route instanceof RelationshipInstanceRoute) {
+            return entityNamed(((RelationshipInstanceRoute) route).parentEntity().name());
+        }
+        return null;
+    }
+
+    private String resolveTargetIdentifier(final ThingRoute route) {
+        if (route instanceof InstanceRoute) {
+            return ((InstanceRoute) route).identifier();
+        }
+        if (route instanceof RelationshipInstanceRoute) {
+            return ((RelationshipInstanceRoute) route).childIdentifier();
+        }
+        return null;
+    }
+
+    private String resolveParentIdentifier(final ThingRoute route) {
+        if (route instanceof RelationshipCollectionRoute) {
+            return ((RelationshipCollectionRoute) route).parentIdentifier();
+        }
+        if (route instanceof RelationshipInstanceRoute) {
+            return ((RelationshipInstanceRoute) route).parentIdentifier();
+        }
+        return null;
+    }
+
+    private String resolveRelationshipName(final ThingRoute route) {
+        if (route instanceof RelationshipCollectionRoute) {
+            return ((RelationshipCollectionRoute) route).relationshipName();
+        }
+        if (route instanceof RelationshipInstanceRoute) {
+            return ((RelationshipInstanceRoute) route).relationshipName();
+        }
+        return null;
+    }
+
+    private String resolveChildIdentifier(final ThingRoute route) {
+        if (route instanceof RelationshipInstanceRoute) {
+            return ((RelationshipInstanceRoute) route).childIdentifier();
+        }
+        return null;
+    }
+
+    private EntityDefinition targetEntityForRelationship(
+            final EntityTypeRef parentEntity, final String relationshipName) {
+        if (parentEntity == null) {
+            return null;
+        }
+        for (RelationshipSpec spec : parentEntity.relationships()) {
+            if (spec.name().equals(relationshipName)) {
+                return entityNamed(spec.toEntityName());
+            }
+        }
+        return null;
+    }
+
+    private EntityDefinition entityNamed(final String entityName) {
+        return runtime.schema().definitionWithSingularOrPluralNamed(entityName);
+    }
+
+    private QueryFilterParams copyQueryParams(final QueryFilterParams original) {
+        QueryFilterParams copy = new QueryFilterParams();
+        copy.addAll(original);
+        return copy;
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/ThingifierApiLifecycleContextView.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/ThingifierApiLifecycleContextView.java
@@ -15,77 +15,261 @@ import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
 import uk.co.compendiumdev.thingifier.core.query.RepositoryQueryResult;
 import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
 
+/**
+ * Shared context contract exposed to all Thingifier API lifecycle hook phases.
+ *
+ * <p>The context exposes route, request, mapped command/query, validation, result, and response
+ * information as it becomes available. Mutations are explicit methods so hook code documents when
+ * it intentionally changes the request, command, query, result, or response.
+ */
 public interface ThingifierApiLifecycleContextView {
 
+    /**
+     * Returns the effective HTTP verb after method override handling.
+     *
+     * @return effective HTTP API verb
+     */
     ThingifierHttpApi.HttpVerb effectiveVerb();
 
+    /**
+     * Returns the normalized request path used for Thingifier routing.
+     *
+     * @return request path without the configured API prefix
+     */
     String path();
 
+    /**
+     * Returns the mapped Thingifier route.
+     *
+     * @return matched route abstraction
+     */
     ThingRoute route();
 
+    /**
+     * Returns the entity targeted by the request or returned relationship.
+     *
+     * @return target entity definition, or null when no entity route matched
+     */
     EntityDefinition targetEntity();
 
+    /**
+     * Returns the target instance identifier for instance routes.
+     *
+     * @return instance identifier, or null for collection routes
+     */
     String targetIdentifier();
 
+    /**
+     * Returns the parent entity for relationship routes.
+     *
+     * @return parent entity definition, or null for non-relationship routes
+     */
     EntityDefinition parentEntity();
 
+    /**
+     * Returns the parent instance identifier for relationship routes.
+     *
+     * @return parent identifier, or null for non-relationship routes
+     */
     String parentIdentifier();
 
+    /**
+     * Returns the relationship route name.
+     *
+     * @return relationship name, or null for entity routes
+     */
     String relationshipName();
 
+    /**
+     * Returns the child identifier for relationship instance routes.
+     *
+     * @return child identifier, or null when the route is not a relationship instance route
+     */
     String childIdentifier();
 
+    /**
+     * Returns the request headers.
+     *
+     * @return mutable header block used by the request
+     */
     HttpHeadersBlock headers();
 
+    /**
+     * Sets or replaces a request header for the rest of lifecycle processing.
+     *
+     * @param name header name
+     * @param value header value
+     */
     void setHeader(String name, String value);
 
+    /**
+     * Returns a copy of the current query parameters.
+     *
+     * @return query filter parameters
+     */
     QueryFilterParams queryParams();
 
+    /**
+     * Replaces the query parameters used by later mapping or action phases.
+     *
+     * @param queryParams replacement query parameters
+     */
     void replaceQueryParams(QueryFilterParams queryParams);
 
+    /**
+     * Returns the current raw request body.
+     *
+     * @return raw body text, never null
+     */
     String rawBody();
 
+    /**
+     * Replaces the raw body used by later phases.
+     *
+     * @param rawBody replacement raw body text
+     */
     void replaceRawBody(String rawBody);
 
+    /**
+     * Returns the currently parsed body fields.
+     *
+     * @return parsed body fields, or an empty field set before parsing
+     */
     ApiBodyFields bodyFields();
 
+    /**
+     * Replaces the parsed body fields used by write command mapping.
+     *
+     * @param bodyFields replacement parsed body fields
+     */
     void replaceBodyFields(ApiBodyFields bodyFields);
 
+    /**
+     * Returns the selected QUERY body format.
+     *
+     * @return query body format
+     */
     ApiRequestEnvelope.QueryBodyFormat queryBodyFormat();
 
+    /**
+     * Replaces the QUERY body format used by query remapping.
+     *
+     * @param queryBodyFormat replacement query body format
+     */
     void replaceQueryBodyFormat(ApiRequestEnvelope.QueryBodyFormat queryBodyFormat);
 
+    /**
+     * Returns the request context for the active store/session.
+     *
+     * @return request context
+     */
     ThingifierRequestContext requestContext();
 
+    /**
+     * Returns the active Thingifier store for the request.
+     *
+     * @return active store
+     */
     ThingStore store();
 
+    /**
+     * Returns the mapped write command when the request is a write operation.
+     *
+     * @return mapped write command, or null before mapping or for read operations
+     */
     ThingWriteCommand writeCommand();
 
+    /**
+     * Replaces the mapped write command to be validated or executed.
+     *
+     * @param command replacement write command
+     */
     void replaceWriteCommand(ThingWriteCommand command);
 
+    /**
+     * Returns the mapped read query when the request is a read operation.
+     *
+     * @return mapped read query, or null before mapping or for write operations
+     */
     ThingReadQuery readQuery();
 
+    /**
+     * Replaces the mapped read query to be executed.
+     *
+     * @param query replacement read query
+     */
     void replaceReadQuery(ThingReadQuery query);
 
+    /**
+     * Returns the Thingifier validation result.
+     *
+     * @return validation result, or null before validation
+     */
     ThingCommandResult validationResult();
 
+    /**
+     * Replaces the validation result used by later phases.
+     *
+     * @param result replacement validation result
+     */
     void replaceValidationResult(ThingCommandResult result);
 
+    /** Clears the validation result so later processing can proceed. */
     void clearValidationResult();
 
+    /**
+     * Returns the write command result after action execution.
+     *
+     * @return write result, or null before action execution or for read operations
+     */
     ThingCommandResult writeCommandResult();
 
+    /**
+     * Replaces the write command result seen by later response mapping.
+     *
+     * @param result replacement write result
+     */
     void replaceWriteCommandResult(ThingCommandResult result);
 
+    /**
+     * Returns the read query result after action execution.
+     *
+     * @return query result, or null before action execution or for write operations
+     */
     RepositoryQueryResult readQueryResult();
 
+    /**
+     * Replaces the read query result seen by later response mapping.
+     *
+     * @param result replacement query result
+     */
     void replaceReadQueryResult(RepositoryQueryResult result);
 
+    /**
+     * Returns the current API response.
+     *
+     * @return API response, or null before one has been created
+     */
     ApiResponse apiResponse();
 
+    /**
+     * Replaces the API response without stopping lifecycle processing.
+     *
+     * @param response replacement response
+     */
     void replaceApiResponse(ApiResponse response);
 
+    /**
+     * Replaces the API response and stops remaining lifecycle processing for this request.
+     *
+     * @param response response to return immediately
+     */
     void shortCircuitWith(ApiResponse response);
 
+    /**
+     * Reports whether lifecycle processing should stop and return the current response.
+     *
+     * @return true when a hook has short-circuited the request
+     */
     boolean shouldShortCircuit();
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/ThingifierApiLifecycleContextView.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/ThingifierApiLifecycleContextView.java
@@ -1,0 +1,91 @@
+package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
+
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
+import uk.co.compendiumdev.thingifier.api.http.ApiRequestEnvelope;
+import uk.co.compendiumdev.thingifier.api.http.ThingifierHttpApi;
+import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
+import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields;
+import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
+import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
+import uk.co.compendiumdev.thingifier.application.ThingCommandResult;
+import uk.co.compendiumdev.thingifier.application.command.ThingWriteCommand;
+import uk.co.compendiumdev.thingifier.application.query.ThingReadQuery;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
+import uk.co.compendiumdev.thingifier.core.query.RepositoryQueryResult;
+import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
+
+public interface ThingifierApiLifecycleContextView {
+
+    ThingifierHttpApi.HttpVerb effectiveVerb();
+
+    String path();
+
+    ThingRoute route();
+
+    EntityDefinition targetEntity();
+
+    String targetIdentifier();
+
+    EntityDefinition parentEntity();
+
+    String parentIdentifier();
+
+    String relationshipName();
+
+    String childIdentifier();
+
+    HttpHeadersBlock headers();
+
+    void setHeader(String name, String value);
+
+    QueryFilterParams queryParams();
+
+    void replaceQueryParams(QueryFilterParams queryParams);
+
+    String rawBody();
+
+    void replaceRawBody(String rawBody);
+
+    ApiBodyFields bodyFields();
+
+    void replaceBodyFields(ApiBodyFields bodyFields);
+
+    ApiRequestEnvelope.QueryBodyFormat queryBodyFormat();
+
+    void replaceQueryBodyFormat(ApiRequestEnvelope.QueryBodyFormat queryBodyFormat);
+
+    ThingifierRequestContext requestContext();
+
+    ThingStore store();
+
+    ThingWriteCommand writeCommand();
+
+    void replaceWriteCommand(ThingWriteCommand command);
+
+    ThingReadQuery readQuery();
+
+    void replaceReadQuery(ThingReadQuery query);
+
+    ThingCommandResult validationResult();
+
+    void replaceValidationResult(ThingCommandResult result);
+
+    void clearValidationResult();
+
+    ThingCommandResult writeCommandResult();
+
+    void replaceWriteCommandResult(ThingCommandResult result);
+
+    RepositoryQueryResult readQueryResult();
+
+    void replaceReadQueryResult(RepositoryQueryResult result);
+
+    ApiResponse apiResponse();
+
+    void replaceApiResponse(ApiResponse response);
+
+    void shortCircuitWith(ApiResponse response);
+
+    boolean shouldShortCircuit();
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/ThingifierApiLifecycleHookRegistry.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/ThingifierApiLifecycleHookRegistry.java
@@ -1,0 +1,239 @@
+package uk.co.compendiumdev.thingifier.adapter.http.lifecycle;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import uk.co.compendiumdev.thingifier.adapter.hooks.HookScope;
+import uk.co.compendiumdev.thingifier.adapter.hooks.ScopedHook;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
+
+public final class ThingifierApiLifecycleHookRegistry {
+
+    private final List<ScopedHook<RouteMatchedHook>> routeMatchedHooks;
+    private final List<ScopedHook<BodyParsedHook>> bodyParsedHooks;
+    private final List<ScopedHook<BeforeValidationHook>> beforeValidationHooks;
+    private final List<ScopedHook<AfterValidationHook>> afterValidationHooks;
+    private final List<ScopedHook<BeforeActionHook>> beforeActionHooks;
+    private final List<ScopedHook<AfterActionHook>> afterActionHooks;
+
+    public ThingifierApiLifecycleHookRegistry() {
+        routeMatchedHooks = new ArrayList<>();
+        bodyParsedHooks = new ArrayList<>();
+        beforeValidationHooks = new ArrayList<>();
+        afterValidationHooks = new ArrayList<>();
+        beforeActionHooks = new ArrayList<>();
+        afterActionHooks = new ArrayList<>();
+    }
+
+    public void registerRouteMatchedHook(final RouteMatchedHook hook) {
+        registerRouteMatchedHook(HookScope.any(), hook);
+    }
+
+    public void registerRouteMatchedHook(final HookScope scope, final RouteMatchedHook hook) {
+        routeMatchedHooks.add(ScopedHook.forScope(scope, hook));
+    }
+
+    public void registerRouteMatchedHook(final String pathPattern, final RouteMatchedHook hook) {
+        registerRouteMatchedHook(HookScope.endpoint(pathPattern), hook);
+    }
+
+    public void registerRouteMatchedHook(
+            final String pathPattern,
+            final Collection<RoutingVerb> verbs,
+            final RouteMatchedHook hook) {
+        registerRouteMatchedHook(HookScope.endpointAndVerbs(pathPattern, verbs), hook);
+    }
+
+    public void registerBodyParsedHook(final BodyParsedHook hook) {
+        registerBodyParsedHook(HookScope.any(), hook);
+    }
+
+    public void registerBodyParsedHook(final HookScope scope, final BodyParsedHook hook) {
+        bodyParsedHooks.add(ScopedHook.forScope(scope, hook));
+    }
+
+    public void registerBodyParsedHook(final String pathPattern, final BodyParsedHook hook) {
+        registerBodyParsedHook(HookScope.endpoint(pathPattern), hook);
+    }
+
+    public void registerBodyParsedHook(
+            final String pathPattern,
+            final Collection<RoutingVerb> verbs,
+            final BodyParsedHook hook) {
+        registerBodyParsedHook(HookScope.endpointAndVerbs(pathPattern, verbs), hook);
+    }
+
+    public void registerBeforeValidationHook(final BeforeValidationHook hook) {
+        registerBeforeValidationHook(HookScope.any(), hook);
+    }
+
+    public void registerBeforeValidationHook(
+            final HookScope scope, final BeforeValidationHook hook) {
+        beforeValidationHooks.add(ScopedHook.forScope(scope, hook));
+    }
+
+    public void registerBeforeValidationHook(
+            final String pathPattern, final BeforeValidationHook hook) {
+        registerBeforeValidationHook(HookScope.endpoint(pathPattern), hook);
+    }
+
+    public void registerBeforeValidationHook(
+            final String pathPattern,
+            final Collection<RoutingVerb> verbs,
+            final BeforeValidationHook hook) {
+        registerBeforeValidationHook(HookScope.endpointAndVerbs(pathPattern, verbs), hook);
+    }
+
+    public void registerAfterValidationHook(final AfterValidationHook hook) {
+        registerAfterValidationHook(HookScope.any(), hook);
+    }
+
+    public void registerAfterValidationHook(final HookScope scope, final AfterValidationHook hook) {
+        afterValidationHooks.add(ScopedHook.forScope(scope, hook));
+    }
+
+    public void registerAfterValidationHook(
+            final String pathPattern, final AfterValidationHook hook) {
+        registerAfterValidationHook(HookScope.endpoint(pathPattern), hook);
+    }
+
+    public void registerAfterValidationHook(
+            final String pathPattern,
+            final Collection<RoutingVerb> verbs,
+            final AfterValidationHook hook) {
+        registerAfterValidationHook(HookScope.endpointAndVerbs(pathPattern, verbs), hook);
+    }
+
+    public void registerBeforeActionHook(final BeforeActionHook hook) {
+        registerBeforeActionHook(HookScope.any(), hook);
+    }
+
+    public void registerBeforeActionHook(final HookScope scope, final BeforeActionHook hook) {
+        beforeActionHooks.add(ScopedHook.forScope(scope, hook));
+    }
+
+    public void registerBeforeActionHook(final String pathPattern, final BeforeActionHook hook) {
+        registerBeforeActionHook(HookScope.endpoint(pathPattern), hook);
+    }
+
+    public void registerBeforeActionHook(
+            final String pathPattern,
+            final Collection<RoutingVerb> verbs,
+            final BeforeActionHook hook) {
+        registerBeforeActionHook(HookScope.endpointAndVerbs(pathPattern, verbs), hook);
+    }
+
+    public void registerAfterActionHook(final AfterActionHook hook) {
+        registerAfterActionHook(HookScope.any(), hook);
+    }
+
+    public void registerAfterActionHook(final HookScope scope, final AfterActionHook hook) {
+        afterActionHooks.add(ScopedHook.forScope(scope, hook));
+    }
+
+    public void registerAfterActionHook(final String pathPattern, final AfterActionHook hook) {
+        registerAfterActionHook(HookScope.endpoint(pathPattern), hook);
+    }
+
+    public void registerAfterActionHook(
+            final String pathPattern,
+            final Collection<RoutingVerb> verbs,
+            final AfterActionHook hook) {
+        registerAfterActionHook(HookScope.endpointAndVerbs(pathPattern, verbs), hook);
+    }
+
+    public List<ScopedHook<RouteMatchedHook>> routeMatchedHooks() {
+        return Collections.unmodifiableList(routeMatchedHooks);
+    }
+
+    public List<ScopedHook<BodyParsedHook>> bodyParsedHooks() {
+        return Collections.unmodifiableList(bodyParsedHooks);
+    }
+
+    public List<ScopedHook<BeforeValidationHook>> beforeValidationHooks() {
+        return Collections.unmodifiableList(beforeValidationHooks);
+    }
+
+    public List<ScopedHook<AfterValidationHook>> afterValidationHooks() {
+        return Collections.unmodifiableList(afterValidationHooks);
+    }
+
+    public List<ScopedHook<BeforeActionHook>> beforeActionHooks() {
+        return Collections.unmodifiableList(beforeActionHooks);
+    }
+
+    public List<ScopedHook<AfterActionHook>> afterActionHooks() {
+        return Collections.unmodifiableList(afterActionHooks);
+    }
+
+    public void runRouteMatchedHooks(final ThingifierApiLifecycleContext context) {
+        for (ScopedHook<RouteMatchedHook> hook : routeMatchedHooks) {
+            if (matches(hook, context)) {
+                hook.hook().run(context);
+                if (context.shouldShortCircuit()) {
+                    return;
+                }
+            }
+        }
+    }
+
+    public void runBodyParsedHooks(final ThingifierApiLifecycleContext context) {
+        for (ScopedHook<BodyParsedHook> hook : bodyParsedHooks) {
+            if (matches(hook, context)) {
+                hook.hook().run(context);
+                if (context.shouldShortCircuit()) {
+                    return;
+                }
+            }
+        }
+    }
+
+    public void runBeforeValidationHooks(final ThingifierApiLifecycleContext context) {
+        for (ScopedHook<BeforeValidationHook> hook : beforeValidationHooks) {
+            if (matches(hook, context)) {
+                hook.hook().run(context);
+                if (context.shouldShortCircuit()) {
+                    return;
+                }
+            }
+        }
+    }
+
+    public void runAfterValidationHooks(final ThingifierApiLifecycleContext context) {
+        for (ScopedHook<AfterValidationHook> hook : afterValidationHooks) {
+            if (matches(hook, context)) {
+                hook.hook().run(context);
+                if (context.shouldShortCircuit()) {
+                    return;
+                }
+            }
+        }
+    }
+
+    public void runBeforeActionHooks(final ThingifierApiLifecycleContext context) {
+        for (ScopedHook<BeforeActionHook> hook : beforeActionHooks) {
+            if (matches(hook, context)) {
+                hook.hook().run(context);
+                if (context.shouldShortCircuit()) {
+                    return;
+                }
+            }
+        }
+    }
+
+    public void runAfterActionHooks(final ThingifierApiLifecycleContext context) {
+        for (ScopedHook<AfterActionHook> hook : afterActionHooks) {
+            if (matches(hook, context)) {
+                hook.hook().run(context);
+                if (context.shouldShortCircuit()) {
+                    return;
+                }
+            }
+        }
+    }
+
+    private boolean matches(final ScopedHook<?> hook, final ThingifierApiLifecycleContext context) {
+        return hook.matches(context.path(), context.routingVerb(), context.apiPathPrefix());
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/ThingifierApiLifecycleHookRegistry.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/ThingifierApiLifecycleHookRegistry.java
@@ -8,6 +8,12 @@ import uk.co.compendiumdev.thingifier.adapter.hooks.HookScope;
 import uk.co.compendiumdev.thingifier.adapter.hooks.ScopedHook;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 
+/**
+ * Registry for Thingifier API lifecycle hooks.
+ *
+ * <p>The registry stores hooks by lifecycle phase and optional scope. Runtime handlers call the run
+ * methods in phase order and stop a phase as soon as a hook short-circuits the request.
+ */
 public final class ThingifierApiLifecycleHookRegistry {
 
     private final List<ScopedHook<RouteMatchedHook>> routeMatchedHooks;
@@ -17,6 +23,7 @@ public final class ThingifierApiLifecycleHookRegistry {
     private final List<ScopedHook<BeforeActionHook>> beforeActionHooks;
     private final List<ScopedHook<AfterActionHook>> afterActionHooks;
 
+    /** Creates an empty lifecycle hook registry. */
     public ThingifierApiLifecycleHookRegistry() {
         routeMatchedHooks = new ArrayList<>();
         bodyParsedHooks = new ArrayList<>();
@@ -26,18 +33,42 @@ public final class ThingifierApiLifecycleHookRegistry {
         afterActionHooks = new ArrayList<>();
     }
 
+    /**
+     * Registers a route-matched hook for all Thingifier API routes.
+     *
+     * @param hook hook to run
+     */
     public void registerRouteMatchedHook(final RouteMatchedHook hook) {
         registerRouteMatchedHook(HookScope.any(), hook);
     }
 
+    /**
+     * Registers a route-matched hook with an explicit scope.
+     *
+     * @param scope route and verb scope
+     * @param hook hook to run
+     */
     public void registerRouteMatchedHook(final HookScope scope, final RouteMatchedHook hook) {
         routeMatchedHooks.add(ScopedHook.forScope(scope, hook));
     }
 
+    /**
+     * Registers a route-matched hook for one path pattern.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param hook hook to run
+     */
     public void registerRouteMatchedHook(final String pathPattern, final RouteMatchedHook hook) {
         registerRouteMatchedHook(HookScope.endpoint(pathPattern), hook);
     }
 
+    /**
+     * Registers a route-matched hook for one path pattern and selected verbs.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param verbs verbs that should run the hook
+     * @param hook hook to run
+     */
     public void registerRouteMatchedHook(
             final String pathPattern,
             final Collection<RoutingVerb> verbs,
@@ -45,18 +76,42 @@ public final class ThingifierApiLifecycleHookRegistry {
         registerRouteMatchedHook(HookScope.endpointAndVerbs(pathPattern, verbs), hook);
     }
 
+    /**
+     * Registers a body-parsed hook for all Thingifier API routes.
+     *
+     * @param hook hook to run
+     */
     public void registerBodyParsedHook(final BodyParsedHook hook) {
         registerBodyParsedHook(HookScope.any(), hook);
     }
 
+    /**
+     * Registers a body-parsed hook with an explicit scope.
+     *
+     * @param scope route and verb scope
+     * @param hook hook to run
+     */
     public void registerBodyParsedHook(final HookScope scope, final BodyParsedHook hook) {
         bodyParsedHooks.add(ScopedHook.forScope(scope, hook));
     }
 
+    /**
+     * Registers a body-parsed hook for one path pattern.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param hook hook to run
+     */
     public void registerBodyParsedHook(final String pathPattern, final BodyParsedHook hook) {
         registerBodyParsedHook(HookScope.endpoint(pathPattern), hook);
     }
 
+    /**
+     * Registers a body-parsed hook for one path pattern and selected verbs.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param verbs verbs that should run the hook
+     * @param hook hook to run
+     */
     public void registerBodyParsedHook(
             final String pathPattern,
             final Collection<RoutingVerb> verbs,
@@ -64,20 +119,44 @@ public final class ThingifierApiLifecycleHookRegistry {
         registerBodyParsedHook(HookScope.endpointAndVerbs(pathPattern, verbs), hook);
     }
 
+    /**
+     * Registers a before-validation hook for all Thingifier API routes.
+     *
+     * @param hook hook to run
+     */
     public void registerBeforeValidationHook(final BeforeValidationHook hook) {
         registerBeforeValidationHook(HookScope.any(), hook);
     }
 
+    /**
+     * Registers a before-validation hook with an explicit scope.
+     *
+     * @param scope route and verb scope
+     * @param hook hook to run
+     */
     public void registerBeforeValidationHook(
             final HookScope scope, final BeforeValidationHook hook) {
         beforeValidationHooks.add(ScopedHook.forScope(scope, hook));
     }
 
+    /**
+     * Registers a before-validation hook for one path pattern.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param hook hook to run
+     */
     public void registerBeforeValidationHook(
             final String pathPattern, final BeforeValidationHook hook) {
         registerBeforeValidationHook(HookScope.endpoint(pathPattern), hook);
     }
 
+    /**
+     * Registers a before-validation hook for one path pattern and selected verbs.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param verbs verbs that should run the hook
+     * @param hook hook to run
+     */
     public void registerBeforeValidationHook(
             final String pathPattern,
             final Collection<RoutingVerb> verbs,
@@ -85,19 +164,43 @@ public final class ThingifierApiLifecycleHookRegistry {
         registerBeforeValidationHook(HookScope.endpointAndVerbs(pathPattern, verbs), hook);
     }
 
+    /**
+     * Registers an after-validation hook for all Thingifier API routes.
+     *
+     * @param hook hook to run
+     */
     public void registerAfterValidationHook(final AfterValidationHook hook) {
         registerAfterValidationHook(HookScope.any(), hook);
     }
 
+    /**
+     * Registers an after-validation hook with an explicit scope.
+     *
+     * @param scope route and verb scope
+     * @param hook hook to run
+     */
     public void registerAfterValidationHook(final HookScope scope, final AfterValidationHook hook) {
         afterValidationHooks.add(ScopedHook.forScope(scope, hook));
     }
 
+    /**
+     * Registers an after-validation hook for one path pattern.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param hook hook to run
+     */
     public void registerAfterValidationHook(
             final String pathPattern, final AfterValidationHook hook) {
         registerAfterValidationHook(HookScope.endpoint(pathPattern), hook);
     }
 
+    /**
+     * Registers an after-validation hook for one path pattern and selected verbs.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param verbs verbs that should run the hook
+     * @param hook hook to run
+     */
     public void registerAfterValidationHook(
             final String pathPattern,
             final Collection<RoutingVerb> verbs,
@@ -105,18 +208,42 @@ public final class ThingifierApiLifecycleHookRegistry {
         registerAfterValidationHook(HookScope.endpointAndVerbs(pathPattern, verbs), hook);
     }
 
+    /**
+     * Registers a before-action hook for all Thingifier API routes.
+     *
+     * @param hook hook to run
+     */
     public void registerBeforeActionHook(final BeforeActionHook hook) {
         registerBeforeActionHook(HookScope.any(), hook);
     }
 
+    /**
+     * Registers a before-action hook with an explicit scope.
+     *
+     * @param scope route and verb scope
+     * @param hook hook to run
+     */
     public void registerBeforeActionHook(final HookScope scope, final BeforeActionHook hook) {
         beforeActionHooks.add(ScopedHook.forScope(scope, hook));
     }
 
+    /**
+     * Registers a before-action hook for one path pattern.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param hook hook to run
+     */
     public void registerBeforeActionHook(final String pathPattern, final BeforeActionHook hook) {
         registerBeforeActionHook(HookScope.endpoint(pathPattern), hook);
     }
 
+    /**
+     * Registers a before-action hook for one path pattern and selected verbs.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param verbs verbs that should run the hook
+     * @param hook hook to run
+     */
     public void registerBeforeActionHook(
             final String pathPattern,
             final Collection<RoutingVerb> verbs,
@@ -124,18 +251,42 @@ public final class ThingifierApiLifecycleHookRegistry {
         registerBeforeActionHook(HookScope.endpointAndVerbs(pathPattern, verbs), hook);
     }
 
+    /**
+     * Registers an after-action hook for all Thingifier API routes.
+     *
+     * @param hook hook to run
+     */
     public void registerAfterActionHook(final AfterActionHook hook) {
         registerAfterActionHook(HookScope.any(), hook);
     }
 
+    /**
+     * Registers an after-action hook with an explicit scope.
+     *
+     * @param scope route and verb scope
+     * @param hook hook to run
+     */
     public void registerAfterActionHook(final HookScope scope, final AfterActionHook hook) {
         afterActionHooks.add(ScopedHook.forScope(scope, hook));
     }
 
+    /**
+     * Registers an after-action hook for one path pattern.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param hook hook to run
+     */
     public void registerAfterActionHook(final String pathPattern, final AfterActionHook hook) {
         registerAfterActionHook(HookScope.endpoint(pathPattern), hook);
     }
 
+    /**
+     * Registers an after-action hook for one path pattern and selected verbs.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param verbs verbs that should run the hook
+     * @param hook hook to run
+     */
     public void registerAfterActionHook(
             final String pathPattern,
             final Collection<RoutingVerb> verbs,
@@ -143,30 +294,65 @@ public final class ThingifierApiLifecycleHookRegistry {
         registerAfterActionHook(HookScope.endpointAndVerbs(pathPattern, verbs), hook);
     }
 
+    /**
+     * Returns route-matched hooks in registration order.
+     *
+     * @return immutable view of registered hooks
+     */
     public List<ScopedHook<RouteMatchedHook>> routeMatchedHooks() {
         return Collections.unmodifiableList(routeMatchedHooks);
     }
 
+    /**
+     * Returns body-parsed hooks in registration order.
+     *
+     * @return immutable view of registered hooks
+     */
     public List<ScopedHook<BodyParsedHook>> bodyParsedHooks() {
         return Collections.unmodifiableList(bodyParsedHooks);
     }
 
+    /**
+     * Returns before-validation hooks in registration order.
+     *
+     * @return immutable view of registered hooks
+     */
     public List<ScopedHook<BeforeValidationHook>> beforeValidationHooks() {
         return Collections.unmodifiableList(beforeValidationHooks);
     }
 
+    /**
+     * Returns after-validation hooks in registration order.
+     *
+     * @return immutable view of registered hooks
+     */
     public List<ScopedHook<AfterValidationHook>> afterValidationHooks() {
         return Collections.unmodifiableList(afterValidationHooks);
     }
 
+    /**
+     * Returns before-action hooks in registration order.
+     *
+     * @return immutable view of registered hooks
+     */
     public List<ScopedHook<BeforeActionHook>> beforeActionHooks() {
         return Collections.unmodifiableList(beforeActionHooks);
     }
 
+    /**
+     * Returns after-action hooks in registration order.
+     *
+     * @return immutable view of registered hooks
+     */
     public List<ScopedHook<AfterActionHook>> afterActionHooks() {
         return Collections.unmodifiableList(afterActionHooks);
     }
 
+    /**
+     * Runs matching route-matched hooks until they complete or short-circuit.
+     *
+     * @param context lifecycle context for the request
+     */
     public void runRouteMatchedHooks(final ThingifierApiLifecycleContext context) {
         for (ScopedHook<RouteMatchedHook> hook : routeMatchedHooks) {
             if (matches(hook, context)) {
@@ -178,6 +364,11 @@ public final class ThingifierApiLifecycleHookRegistry {
         }
     }
 
+    /**
+     * Runs matching body-parsed hooks until they complete or short-circuit.
+     *
+     * @param context lifecycle context for the request
+     */
     public void runBodyParsedHooks(final ThingifierApiLifecycleContext context) {
         for (ScopedHook<BodyParsedHook> hook : bodyParsedHooks) {
             if (matches(hook, context)) {
@@ -189,6 +380,11 @@ public final class ThingifierApiLifecycleHookRegistry {
         }
     }
 
+    /**
+     * Runs matching before-validation hooks until they complete or short-circuit.
+     *
+     * @param context lifecycle context for the request
+     */
     public void runBeforeValidationHooks(final ThingifierApiLifecycleContext context) {
         for (ScopedHook<BeforeValidationHook> hook : beforeValidationHooks) {
             if (matches(hook, context)) {
@@ -200,6 +396,11 @@ public final class ThingifierApiLifecycleHookRegistry {
         }
     }
 
+    /**
+     * Runs matching after-validation hooks until they complete or short-circuit.
+     *
+     * @param context lifecycle context for the request
+     */
     public void runAfterValidationHooks(final ThingifierApiLifecycleContext context) {
         for (ScopedHook<AfterValidationHook> hook : afterValidationHooks) {
             if (matches(hook, context)) {
@@ -211,6 +412,11 @@ public final class ThingifierApiLifecycleHookRegistry {
         }
     }
 
+    /**
+     * Runs matching before-action hooks until they complete or short-circuit.
+     *
+     * @param context lifecycle context for the request
+     */
     public void runBeforeActionHooks(final ThingifierApiLifecycleContext context) {
         for (ScopedHook<BeforeActionHook> hook : beforeActionHooks) {
             if (matches(hook, context)) {
@@ -222,6 +428,11 @@ public final class ThingifierApiLifecycleHookRegistry {
         }
     }
 
+    /**
+     * Runs matching after-action hooks until they complete or short-circuit.
+     *
+     * @param context lifecycle context for the request
+     */
     public void runAfterActionHooks(final ThingifierApiLifecycleContext context) {
         for (ScopedHook<AfterActionHook> hook : afterActionHooks) {
             if (matches(hook, context)) {
@@ -233,6 +444,13 @@ public final class ThingifierApiLifecycleHookRegistry {
         }
     }
 
+    /**
+     * Checks whether a scoped hook applies to the current request.
+     *
+     * @param hook scoped hook wrapper
+     * @param context lifecycle context for the request
+     * @return true when the hook scope matches the request path and verb
+     */
     private boolean matches(final ScopedHook<?> hook, final ThingifierApiLifecycleContext context) {
         return hook.matches(context.path(), context.routingVerb(), context.apiPathPrefix());
     }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/httpserver/ThingifierHttpApiRoutings.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/httpserver/ThingifierHttpApiRoutings.java
@@ -8,6 +8,13 @@ import java.util.List;
 import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.adapter.hooks.HookScope;
 import uk.co.compendiumdev.thingifier.adapter.hooks.ScopedHook;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.AfterActionHook;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.AfterValidationHook;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.BeforeActionHook;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.BeforeValidationHook;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.BodyParsedHook;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.RouteMatchedHook;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleHookRegistry;
 import uk.co.compendiumdev.thingifier.adapter.http.messagehooks.HttpApiHookRegistry;
 import uk.co.compendiumdev.thingifier.adapter.http.messagehooks.HttpApiRequestHook;
 import uk.co.compendiumdev.thingifier.adapter.http.messagehooks.HttpApiResponseHook;
@@ -38,6 +45,7 @@ public class ThingifierHttpApiRoutings {
     private List<ScopedHook<InternalHttpRequestHook>> preInternalHttpRequestHooks;
     private List<ScopedHook<InternalHttpResponseHook>> postInternalHttpResponseHooks;
     private final HttpApiHookRegistry httpApiHooks;
+    private final ThingifierApiLifecycleHookRegistry lifecycleHooks;
 
     // todo : we should be able to configure the API routing for authorisation and support logging
 
@@ -55,8 +63,11 @@ public class ThingifierHttpApiRoutings {
 
         // pre and post api request processing, using internal representations
         httpApiHooks = new HttpApiHookRegistry();
+        lifecycleHooks = new ThingifierApiLifecycleHookRegistry();
 
-        ThingifierHttpApiBridge apiBridge = new ThingifierHttpApiBridge(thingifier, httpApiHooks);
+        ThingifierHttpApiBridge apiBridge =
+                ThingifierHttpApiBridge.withHookRegistries(
+                        thingifier, httpApiHooks, lifecycleHooks);
 
         before(
                 (request, response) -> {
@@ -144,7 +155,14 @@ public class ThingifierHttpApiRoutings {
             }
             switch (defn.verb()) {
                 case GET:
-                    if (defn.status().isReturnedFromCall()) {
+                    if (!defn.status().isReturnedFromCall()) {
+                        get(
+                                defn.url(),
+                                (request, response) -> {
+                                    applyStaticResponse(defn, response);
+                                    return "";
+                                });
+                    } else {
                         get(
                                 defn.url(),
                                 (request, response) -> {
@@ -169,7 +187,14 @@ public class ThingifierHttpApiRoutings {
                     }
                     break;
                 case POST:
-                    if (defn.status().isReturnedFromCall()) {
+                    if (!defn.status().isReturnedFromCall()) {
+                        post(
+                                defn.url(),
+                                (request, response) -> {
+                                    applyStaticResponse(defn, response);
+                                    return "";
+                                });
+                    } else {
                         post(
                                 defn.url(),
                                 (request, response) -> {
@@ -207,7 +232,14 @@ public class ThingifierHttpApiRoutings {
                 default:
                     break;
                 case HEAD:
-                    if (defn.status().isReturnedFromCall()) {
+                    if (!defn.status().isReturnedFromCall()) {
+                        head(
+                                defn.url(),
+                                (request, response) -> {
+                                    applyStaticResponse(defn, response);
+                                    return "";
+                                });
+                    } else {
                         head(
                                 defn.url(),
                                 (request, response) -> {
@@ -401,6 +433,123 @@ public class ThingifierHttpApiRoutings {
             final Collection<RoutingVerb> verbs,
             final HttpApiResponseHook hook) {
         registerHttpApiResponseHook(HookScope.endpointAndVerbs(pathPattern, verbs), hook);
+    }
+
+    public void registerRouteMatchedHook(final RouteMatchedHook hook) {
+        lifecycleHooks.registerRouteMatchedHook(hook);
+    }
+
+    public void registerRouteMatchedHook(final HookScope scope, final RouteMatchedHook hook) {
+        lifecycleHooks.registerRouteMatchedHook(scope, hook);
+    }
+
+    public void registerRouteMatchedHook(final String pathPattern, final RouteMatchedHook hook) {
+        lifecycleHooks.registerRouteMatchedHook(pathPattern, hook);
+    }
+
+    public void registerRouteMatchedHook(
+            final String pathPattern,
+            final Collection<RoutingVerb> verbs,
+            final RouteMatchedHook hook) {
+        lifecycleHooks.registerRouteMatchedHook(pathPattern, verbs, hook);
+    }
+
+    public void registerBodyParsedHook(final BodyParsedHook hook) {
+        lifecycleHooks.registerBodyParsedHook(hook);
+    }
+
+    public void registerBodyParsedHook(final HookScope scope, final BodyParsedHook hook) {
+        lifecycleHooks.registerBodyParsedHook(scope, hook);
+    }
+
+    public void registerBodyParsedHook(final String pathPattern, final BodyParsedHook hook) {
+        lifecycleHooks.registerBodyParsedHook(pathPattern, hook);
+    }
+
+    public void registerBodyParsedHook(
+            final String pathPattern,
+            final Collection<RoutingVerb> verbs,
+            final BodyParsedHook hook) {
+        lifecycleHooks.registerBodyParsedHook(pathPattern, verbs, hook);
+    }
+
+    public void registerBeforeValidationHook(final BeforeValidationHook hook) {
+        lifecycleHooks.registerBeforeValidationHook(hook);
+    }
+
+    public void registerBeforeValidationHook(
+            final HookScope scope, final BeforeValidationHook hook) {
+        lifecycleHooks.registerBeforeValidationHook(scope, hook);
+    }
+
+    public void registerBeforeValidationHook(
+            final String pathPattern, final BeforeValidationHook hook) {
+        lifecycleHooks.registerBeforeValidationHook(pathPattern, hook);
+    }
+
+    public void registerBeforeValidationHook(
+            final String pathPattern,
+            final Collection<RoutingVerb> verbs,
+            final BeforeValidationHook hook) {
+        lifecycleHooks.registerBeforeValidationHook(pathPattern, verbs, hook);
+    }
+
+    public void registerAfterValidationHook(final AfterValidationHook hook) {
+        lifecycleHooks.registerAfterValidationHook(hook);
+    }
+
+    public void registerAfterValidationHook(final HookScope scope, final AfterValidationHook hook) {
+        lifecycleHooks.registerAfterValidationHook(scope, hook);
+    }
+
+    public void registerAfterValidationHook(
+            final String pathPattern, final AfterValidationHook hook) {
+        lifecycleHooks.registerAfterValidationHook(pathPattern, hook);
+    }
+
+    public void registerAfterValidationHook(
+            final String pathPattern,
+            final Collection<RoutingVerb> verbs,
+            final AfterValidationHook hook) {
+        lifecycleHooks.registerAfterValidationHook(pathPattern, verbs, hook);
+    }
+
+    public void registerBeforeActionHook(final BeforeActionHook hook) {
+        lifecycleHooks.registerBeforeActionHook(hook);
+    }
+
+    public void registerBeforeActionHook(final HookScope scope, final BeforeActionHook hook) {
+        lifecycleHooks.registerBeforeActionHook(scope, hook);
+    }
+
+    public void registerBeforeActionHook(final String pathPattern, final BeforeActionHook hook) {
+        lifecycleHooks.registerBeforeActionHook(pathPattern, hook);
+    }
+
+    public void registerBeforeActionHook(
+            final String pathPattern,
+            final Collection<RoutingVerb> verbs,
+            final BeforeActionHook hook) {
+        lifecycleHooks.registerBeforeActionHook(pathPattern, verbs, hook);
+    }
+
+    public void registerAfterActionHook(final AfterActionHook hook) {
+        lifecycleHooks.registerAfterActionHook(hook);
+    }
+
+    public void registerAfterActionHook(final HookScope scope, final AfterActionHook hook) {
+        lifecycleHooks.registerAfterActionHook(scope, hook);
+    }
+
+    public void registerAfterActionHook(final String pathPattern, final AfterActionHook hook) {
+        lifecycleHooks.registerAfterActionHook(pathPattern, hook);
+    }
+
+    public void registerAfterActionHook(
+            final String pathPattern,
+            final Collection<RoutingVerb> verbs,
+            final AfterActionHook hook) {
+        lifecycleHooks.registerAfterActionHook(pathPattern, verbs, hook);
     }
 
     public void registerInternalHttpResponseHook(final InternalHttpResponseHook hook) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/httpserver/ThingifierHttpApiRoutings.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/httpserver/ThingifierHttpApiRoutings.java
@@ -375,11 +375,25 @@ public class ThingifierHttpApiRoutings {
         }
     }
 
+    /**
+     * Registers a server-level hook that runs before every HTTP request.
+     *
+     * <p>This hook sees all app routes, not only generated Thingifier API routes.
+     *
+     * @param hook hook to run before request routing
+     */
     public void registerPreRequestHook(final HttpRequestResponseHook hook) {
         // pre-request hooks run pre-every-request
         preHttpRequestHooks.add(hook);
     }
 
+    /**
+     * Registers a server-level hook that runs after every HTTP response.
+     *
+     * <p>This hook sees all app routes, not only generated Thingifier API routes.
+     *
+     * @param hook hook to run after response creation
+     */
     public void registerPostResponseHook(final HttpRequestResponseHook hook) {
         // post-request hooks run after-every-response
         postHttpResponseHooks.add(hook);
@@ -389,20 +403,47 @@ public class ThingifierHttpApiRoutings {
        HttpApiRequestHooks are run in the API Bridge routing, prior to being
        processed by the API handlers - these will be unique to each thingifier.
     */
+    /**
+     * Registers an API request hook for every generated Thingifier API request.
+     *
+     * <p>These legacy hooks run before lifecycle hooks and can short-circuit before Thingifier
+     * route processing begins.
+     *
+     * @param hook hook to run before generated API processing
+     */
     public void registerHttpApiRequestHook(final HttpApiRequestHook hook) {
         // pre-request hooks run pre-every-api-request
         httpApiHooks.registerRequestHook(hook);
     }
 
+    /**
+     * Registers an API request hook with an explicit scope.
+     *
+     * @param scope route and verb scope
+     * @param hook hook to run before generated API processing
+     */
     public void registerHttpApiRequestHook(final HookScope scope, final HttpApiRequestHook hook) {
         httpApiHooks.registerRequestHook(scope, hook);
     }
 
+    /**
+     * Registers an API request hook for one endpoint path pattern.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param hook hook to run before generated API processing
+     */
     public void registerHttpApiRequestHook(
             final String pathPattern, final HttpApiRequestHook hook) {
         registerHttpApiRequestHook(HookScope.endpoint(pathPattern), hook);
     }
 
+    /**
+     * Registers an API request hook for one endpoint path pattern and selected verbs.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param verbs verbs that should run the hook
+     * @param hook hook to run before generated API processing
+     */
     public void registerHttpApiRequestHook(
             final String pathPattern,
             final Collection<RoutingVerb> verbs,
@@ -414,20 +455,47 @@ public class ThingifierHttpApiRoutings {
     HttpApiResponseHooks are run in the API Bridge routing, after being
     processed by the API handlers - these will be unique to each thingifier.
     */
+    /**
+     * Registers an API response hook for every generated Thingifier API response.
+     *
+     * <p>These legacy hooks run after lifecycle hooks and after generated API processing has
+     * created an HTTP API response.
+     *
+     * @param hook hook to run after generated API processing
+     */
     public void registerHttpApiResponseHook(final HttpApiResponseHook hook) {
         // pre-request hooks run pre-every-api-request
         httpApiHooks.registerResponseHook(hook);
     }
 
+    /**
+     * Registers an API response hook with an explicit scope.
+     *
+     * @param scope route and verb scope
+     * @param hook hook to run after generated API processing
+     */
     public void registerHttpApiResponseHook(final HookScope scope, final HttpApiResponseHook hook) {
         httpApiHooks.registerResponseHook(scope, hook);
     }
 
+    /**
+     * Registers an API response hook for one endpoint path pattern.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param hook hook to run after generated API processing
+     */
     public void registerHttpApiResponseHook(
             final String pathPattern, final HttpApiResponseHook hook) {
         registerHttpApiResponseHook(HookScope.endpoint(pathPattern), hook);
     }
 
+    /**
+     * Registers an API response hook for one endpoint path pattern and selected verbs.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param verbs verbs that should run the hook
+     * @param hook hook to run after generated API processing
+     */
     public void registerHttpApiResponseHook(
             final String pathPattern,
             final Collection<RoutingVerb> verbs,
@@ -435,18 +503,42 @@ public class ThingifierHttpApiRoutings {
         registerHttpApiResponseHook(HookScope.endpointAndVerbs(pathPattern, verbs), hook);
     }
 
+    /**
+     * Registers a route-matched lifecycle hook for every generated Thingifier API route.
+     *
+     * @param hook hook to run after route matching
+     */
     public void registerRouteMatchedHook(final RouteMatchedHook hook) {
         lifecycleHooks.registerRouteMatchedHook(hook);
     }
 
+    /**
+     * Registers a route-matched lifecycle hook with an explicit scope.
+     *
+     * @param scope route and verb scope
+     * @param hook hook to run after route matching
+     */
     public void registerRouteMatchedHook(final HookScope scope, final RouteMatchedHook hook) {
         lifecycleHooks.registerRouteMatchedHook(scope, hook);
     }
 
+    /**
+     * Registers a route-matched lifecycle hook for one endpoint path pattern.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param hook hook to run after route matching
+     */
     public void registerRouteMatchedHook(final String pathPattern, final RouteMatchedHook hook) {
         lifecycleHooks.registerRouteMatchedHook(pathPattern, hook);
     }
 
+    /**
+     * Registers a route-matched lifecycle hook for one endpoint path pattern and selected verbs.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param verbs verbs that should run the hook
+     * @param hook hook to run after route matching
+     */
     public void registerRouteMatchedHook(
             final String pathPattern,
             final Collection<RoutingVerb> verbs,
@@ -454,18 +546,42 @@ public class ThingifierHttpApiRoutings {
         lifecycleHooks.registerRouteMatchedHook(pathPattern, verbs, hook);
     }
 
+    /**
+     * Registers a body-parsed lifecycle hook for every generated Thingifier API route.
+     *
+     * @param hook hook to run after request body parsing
+     */
     public void registerBodyParsedHook(final BodyParsedHook hook) {
         lifecycleHooks.registerBodyParsedHook(hook);
     }
 
+    /**
+     * Registers a body-parsed lifecycle hook with an explicit scope.
+     *
+     * @param scope route and verb scope
+     * @param hook hook to run after request body parsing
+     */
     public void registerBodyParsedHook(final HookScope scope, final BodyParsedHook hook) {
         lifecycleHooks.registerBodyParsedHook(scope, hook);
     }
 
+    /**
+     * Registers a body-parsed lifecycle hook for one endpoint path pattern.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param hook hook to run after request body parsing
+     */
     public void registerBodyParsedHook(final String pathPattern, final BodyParsedHook hook) {
         lifecycleHooks.registerBodyParsedHook(pathPattern, hook);
     }
 
+    /**
+     * Registers a body-parsed lifecycle hook for one endpoint path pattern and selected verbs.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param verbs verbs that should run the hook
+     * @param hook hook to run after request body parsing
+     */
     public void registerBodyParsedHook(
             final String pathPattern,
             final Collection<RoutingVerb> verbs,
@@ -473,20 +589,45 @@ public class ThingifierHttpApiRoutings {
         lifecycleHooks.registerBodyParsedHook(pathPattern, verbs, hook);
     }
 
+    /**
+     * Registers a before-validation lifecycle hook for every generated Thingifier API route.
+     *
+     * @param hook hook to run before Thingifier validation
+     */
     public void registerBeforeValidationHook(final BeforeValidationHook hook) {
         lifecycleHooks.registerBeforeValidationHook(hook);
     }
 
+    /**
+     * Registers a before-validation lifecycle hook with an explicit scope.
+     *
+     * @param scope route and verb scope
+     * @param hook hook to run before Thingifier validation
+     */
     public void registerBeforeValidationHook(
             final HookScope scope, final BeforeValidationHook hook) {
         lifecycleHooks.registerBeforeValidationHook(scope, hook);
     }
 
+    /**
+     * Registers a before-validation lifecycle hook for one endpoint path pattern.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param hook hook to run before Thingifier validation
+     */
     public void registerBeforeValidationHook(
             final String pathPattern, final BeforeValidationHook hook) {
         lifecycleHooks.registerBeforeValidationHook(pathPattern, hook);
     }
 
+    /**
+     * Registers a before-validation lifecycle hook for one endpoint path pattern and selected
+     * verbs.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param verbs verbs that should run the hook
+     * @param hook hook to run before Thingifier validation
+     */
     public void registerBeforeValidationHook(
             final String pathPattern,
             final Collection<RoutingVerb> verbs,
@@ -494,19 +635,44 @@ public class ThingifierHttpApiRoutings {
         lifecycleHooks.registerBeforeValidationHook(pathPattern, verbs, hook);
     }
 
+    /**
+     * Registers an after-validation lifecycle hook for every generated Thingifier API route.
+     *
+     * @param hook hook to run after Thingifier validation
+     */
     public void registerAfterValidationHook(final AfterValidationHook hook) {
         lifecycleHooks.registerAfterValidationHook(hook);
     }
 
+    /**
+     * Registers an after-validation lifecycle hook with an explicit scope.
+     *
+     * @param scope route and verb scope
+     * @param hook hook to run after Thingifier validation
+     */
     public void registerAfterValidationHook(final HookScope scope, final AfterValidationHook hook) {
         lifecycleHooks.registerAfterValidationHook(scope, hook);
     }
 
+    /**
+     * Registers an after-validation lifecycle hook for one endpoint path pattern.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param hook hook to run after Thingifier validation
+     */
     public void registerAfterValidationHook(
             final String pathPattern, final AfterValidationHook hook) {
         lifecycleHooks.registerAfterValidationHook(pathPattern, hook);
     }
 
+    /**
+     * Registers an after-validation lifecycle hook for one endpoint path pattern and selected
+     * verbs.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param verbs verbs that should run the hook
+     * @param hook hook to run after Thingifier validation
+     */
     public void registerAfterValidationHook(
             final String pathPattern,
             final Collection<RoutingVerb> verbs,
@@ -514,18 +680,42 @@ public class ThingifierHttpApiRoutings {
         lifecycleHooks.registerAfterValidationHook(pathPattern, verbs, hook);
     }
 
+    /**
+     * Registers a before-action lifecycle hook for every generated Thingifier API route.
+     *
+     * @param hook hook to run before read or write execution
+     */
     public void registerBeforeActionHook(final BeforeActionHook hook) {
         lifecycleHooks.registerBeforeActionHook(hook);
     }
 
+    /**
+     * Registers a before-action lifecycle hook with an explicit scope.
+     *
+     * @param scope route and verb scope
+     * @param hook hook to run before read or write execution
+     */
     public void registerBeforeActionHook(final HookScope scope, final BeforeActionHook hook) {
         lifecycleHooks.registerBeforeActionHook(scope, hook);
     }
 
+    /**
+     * Registers a before-action lifecycle hook for one endpoint path pattern.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param hook hook to run before read or write execution
+     */
     public void registerBeforeActionHook(final String pathPattern, final BeforeActionHook hook) {
         lifecycleHooks.registerBeforeActionHook(pathPattern, hook);
     }
 
+    /**
+     * Registers a before-action lifecycle hook for one endpoint path pattern and selected verbs.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param verbs verbs that should run the hook
+     * @param hook hook to run before read or write execution
+     */
     public void registerBeforeActionHook(
             final String pathPattern,
             final Collection<RoutingVerb> verbs,
@@ -533,18 +723,42 @@ public class ThingifierHttpApiRoutings {
         lifecycleHooks.registerBeforeActionHook(pathPattern, verbs, hook);
     }
 
+    /**
+     * Registers an after-action lifecycle hook for every generated Thingifier API route.
+     *
+     * @param hook hook to run after read or write execution
+     */
     public void registerAfterActionHook(final AfterActionHook hook) {
         lifecycleHooks.registerAfterActionHook(hook);
     }
 
+    /**
+     * Registers an after-action lifecycle hook with an explicit scope.
+     *
+     * @param scope route and verb scope
+     * @param hook hook to run after read or write execution
+     */
     public void registerAfterActionHook(final HookScope scope, final AfterActionHook hook) {
         lifecycleHooks.registerAfterActionHook(scope, hook);
     }
 
+    /**
+     * Registers an after-action lifecycle hook for one endpoint path pattern.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param hook hook to run after read or write execution
+     */
     public void registerAfterActionHook(final String pathPattern, final AfterActionHook hook) {
         lifecycleHooks.registerAfterActionHook(pathPattern, hook);
     }
 
+    /**
+     * Registers an after-action lifecycle hook for one endpoint path pattern and selected verbs.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param verbs verbs that should run the hook
+     * @param hook hook to run after read or write execution
+     */
     public void registerAfterActionHook(
             final String pathPattern,
             final Collection<RoutingVerb> verbs,
@@ -552,21 +766,45 @@ public class ThingifierHttpApiRoutings {
         lifecycleHooks.registerAfterActionHook(pathPattern, verbs, hook);
     }
 
+    /**
+     * Registers an internal HTTP response hook for every generated response.
+     *
+     * @param hook hook to run after conversion to the internal HTTP representation
+     */
     public void registerInternalHttpResponseHook(final InternalHttpResponseHook hook) {
         // pre-request hooks run post api processing on an internal http representation
         postInternalHttpResponseHooks.add(ScopedHook.any(hook));
     }
 
+    /**
+     * Registers an internal HTTP response hook with an explicit scope.
+     *
+     * @param scope route and verb scope
+     * @param hook hook to run after conversion to the internal HTTP representation
+     */
     public void registerInternalHttpResponseHook(
             final HookScope scope, final InternalHttpResponseHook hook) {
         postInternalHttpResponseHooks.add(ScopedHook.forScope(scope, hook));
     }
 
+    /**
+     * Registers an internal HTTP response hook for one endpoint path pattern.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param hook hook to run after conversion to the internal HTTP representation
+     */
     public void registerInternalHttpResponseHook(
             final String pathPattern, final InternalHttpResponseHook hook) {
         registerInternalHttpResponseHook(HookScope.endpoint(pathPattern), hook);
     }
 
+    /**
+     * Registers an internal HTTP response hook for one endpoint path pattern and selected verbs.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param verbs verbs that should run the hook
+     * @param hook hook to run after conversion to the internal HTTP representation
+     */
     public void registerInternalHttpResponseHook(
             final String pathPattern,
             final Collection<RoutingVerb> verbs,
@@ -574,21 +812,45 @@ public class ThingifierHttpApiRoutings {
         registerInternalHttpResponseHook(HookScope.endpointAndVerbs(pathPattern, verbs), hook);
     }
 
+    /**
+     * Registers an internal HTTP request hook for every generated request.
+     *
+     * @param hook hook to run before conversion to the HTTP API representation
+     */
     public void registerInternalHttpRequestHook(final InternalHttpRequestHook hook) {
         // pre-request hooks run pre api routing on an internal http representation
         preInternalHttpRequestHooks.add(ScopedHook.any(hook));
     }
 
+    /**
+     * Registers an internal HTTP request hook with an explicit scope.
+     *
+     * @param scope route and verb scope
+     * @param hook hook to run before conversion to the HTTP API representation
+     */
     public void registerInternalHttpRequestHook(
             final HookScope scope, final InternalHttpRequestHook hook) {
         preInternalHttpRequestHooks.add(ScopedHook.forScope(scope, hook));
     }
 
+    /**
+     * Registers an internal HTTP request hook for one endpoint path pattern.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param hook hook to run before conversion to the HTTP API representation
+     */
     public void registerInternalHttpRequestHook(
             final String pathPattern, final InternalHttpRequestHook hook) {
         registerInternalHttpRequestHook(HookScope.endpoint(pathPattern), hook);
     }
 
+    /**
+     * Registers an internal HTTP request hook for one endpoint path pattern and selected verbs.
+     *
+     * @param pathPattern endpoint path pattern
+     * @param verbs verbs that should run the hook
+     * @param hook hook to run before conversion to the HTTP API representation
+     */
     public void registerInternalHttpRequestHook(
             final String pathPattern,
             final Collection<RoutingVerb> verbs,

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/internalhttp/conversion/ThingifierHttpApiBridge.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/internalhttp/conversion/ThingifierHttpApiBridge.java
@@ -12,6 +12,12 @@ import uk.co.compendiumdev.thingifier.api.http.HttpApiRequest;
 import uk.co.compendiumdev.thingifier.api.http.HttpApiResponse;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierHttpApi;
 
+/**
+ * Bridges the internal HTTP abstraction to the generated Thingifier HTTP API adapter.
+ *
+ * <p>The bridge is used by the server routing layer so request/response conversion, legacy hooks,
+ * and lifecycle hooks all flow into a single {@link ThingifierHttpApi} instance.
+ */
 public final class ThingifierHttpApiBridge {
 
     // todo: the methods here are all very similar, we should refactor this commonality
@@ -19,10 +25,22 @@ public final class ThingifierHttpApiBridge {
     private final Thingifier thingifier;
     private final ThingifierHttpApi thingifierHttpApi;
 
+    /**
+     * Creates a bridge with no HTTP API hooks.
+     *
+     * @param aThingifier Thingifier model and configuration
+     */
     public ThingifierHttpApiBridge(final Thingifier aThingifier) {
         this(aThingifier, (List<HttpApiRequestHook>) null, (List<HttpApiResponseHook>) null);
     }
 
+    /**
+     * Creates a bridge using legacy list-based API request and response hooks.
+     *
+     * @param aThingifier Thingifier model and configuration
+     * @param apiRequestHooks hooks run before generated API processing
+     * @param apiResponseHooks hooks run after generated API processing
+     */
     public ThingifierHttpApiBridge(
             final Thingifier aThingifier,
             List<HttpApiRequestHook> apiRequestHooks,
@@ -32,11 +50,25 @@ public final class ThingifierHttpApiBridge {
                 new ThingifierHttpApi(thingifier, apiRequestHooks, apiResponseHooks);
     }
 
+    /**
+     * Creates a bridge using the scoped legacy hook registry.
+     *
+     * @param aThingifier Thingifier model and configuration
+     * @param hookRegistry scoped request/response hook registry
+     */
     public ThingifierHttpApiBridge(
             final Thingifier aThingifier, final HttpApiHookRegistry hookRegistry) {
         this(aThingifier, hookRegistry, new ThingifierApiLifecycleHookRegistry());
     }
 
+    /**
+     * Creates a bridge using both scoped legacy hooks and lifecycle hooks.
+     *
+     * @param aThingifier Thingifier model and configuration
+     * @param hookRegistry scoped request/response hook registry
+     * @param lifecycleHooks lifecycle hook registry
+     * @return configured internal HTTP bridge
+     */
     public static ThingifierHttpApiBridge withHookRegistries(
             final Thingifier aThingifier,
             final HttpApiHookRegistry hookRegistry,
@@ -53,42 +85,103 @@ public final class ThingifierHttpApiBridge {
                 ThingifierHttpApi.withHookRegistries(thingifier, hookRegistry, lifecycleHooks);
     }
 
+    /**
+     * Handles an internal GET request.
+     *
+     * @param theRequest internal HTTP request
+     * @return internal HTTP response
+     */
     public InternalHttpResponse get(final InternalHttpRequest theRequest) {
         return toInternalResponse(thingifierHttpApi.get(toHttpApiRequest(theRequest)));
     }
 
+    /**
+     * Handles an internal HEAD request.
+     *
+     * @param theRequest internal HTTP request
+     * @return internal HTTP response
+     */
     public InternalHttpResponse head(final InternalHttpRequest theRequest) {
         return toInternalResponse(thingifierHttpApi.head(toHttpApiRequest(theRequest)));
     }
 
+    /**
+     * Handles an internal POST request.
+     *
+     * @param theRequest internal HTTP request
+     * @return internal HTTP response
+     */
     public InternalHttpResponse post(final InternalHttpRequest theRequest) {
         return toInternalResponse(thingifierHttpApi.post(toHttpApiRequest(theRequest)));
     }
 
+    /**
+     * Handles an internal DELETE request.
+     *
+     * @param theRequest internal HTTP request
+     * @return internal HTTP response
+     */
     public InternalHttpResponse delete(final InternalHttpRequest theRequest) {
         return toInternalResponse(thingifierHttpApi.delete(toHttpApiRequest(theRequest)));
     }
 
+    /**
+     * Handles an internal PUT request.
+     *
+     * @param theRequest internal HTTP request
+     * @return internal HTTP response
+     */
     public InternalHttpResponse put(final InternalHttpRequest theRequest) {
         return toInternalResponse(thingifierHttpApi.put(toHttpApiRequest(theRequest)));
     }
 
+    /**
+     * Handles an internal PATCH request.
+     *
+     * @param theRequest internal HTTP request
+     * @return internal HTTP response
+     */
     public InternalHttpResponse patch(final InternalHttpRequest theRequest) {
         return toInternalResponse(thingifierHttpApi.patch(toHttpApiRequest(theRequest)));
     }
 
+    /**
+     * Handles an internal QUERY request.
+     *
+     * @param theRequest internal HTTP request
+     * @return internal HTTP response
+     */
     public InternalHttpResponse queryRequest(final InternalHttpRequest theRequest) {
         return toInternalResponse(thingifierHttpApi.queryRequest(toHttpApiRequest(theRequest)));
     }
 
+    /**
+     * Handles the legacy query helper for an internal request.
+     *
+     * @param theRequest internal HTTP request
+     * @param query query expression
+     * @return internal HTTP response
+     */
     public InternalHttpResponse query(final InternalHttpRequest theRequest, final String query) {
         return toInternalResponse(thingifierHttpApi.query(toHttpApiRequest(theRequest), query));
     }
 
+    /**
+     * Converts an internal request to the HTTP API request type.
+     *
+     * @param theRequest internal HTTP request
+     * @return HTTP API request
+     */
     private HttpApiRequest toHttpApiRequest(final InternalHttpRequest theRequest) {
         return InternalHttpRequestToHttpApiRequest.convert(theRequest);
     }
 
+    /**
+     * Converts an HTTP API response back to the internal response type.
+     *
+     * @param theResponse HTTP API response
+     * @return internal HTTP response
+     */
     private InternalHttpResponse toInternalResponse(final HttpApiResponse theResponse) {
         return HttpApiResponseToInternalHttpResponse.convert(theResponse);
     }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/internalhttp/conversion/ThingifierHttpApiBridge.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/internalhttp/conversion/ThingifierHttpApiBridge.java
@@ -2,6 +2,7 @@ package uk.co.compendiumdev.thingifier.adapter.internalhttp.conversion;
 
 import java.util.List;
 import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleHookRegistry;
 import uk.co.compendiumdev.thingifier.adapter.http.messagehooks.HttpApiHookRegistry;
 import uk.co.compendiumdev.thingifier.adapter.http.messagehooks.HttpApiRequestHook;
 import uk.co.compendiumdev.thingifier.adapter.http.messagehooks.HttpApiResponseHook;
@@ -19,7 +20,7 @@ public final class ThingifierHttpApiBridge {
     private final ThingifierHttpApi thingifierHttpApi;
 
     public ThingifierHttpApiBridge(final Thingifier aThingifier) {
-        this(aThingifier, null, null);
+        this(aThingifier, (List<HttpApiRequestHook>) null, (List<HttpApiResponseHook>) null);
     }
 
     public ThingifierHttpApiBridge(
@@ -33,8 +34,23 @@ public final class ThingifierHttpApiBridge {
 
     public ThingifierHttpApiBridge(
             final Thingifier aThingifier, final HttpApiHookRegistry hookRegistry) {
+        this(aThingifier, hookRegistry, new ThingifierApiLifecycleHookRegistry());
+    }
+
+    public static ThingifierHttpApiBridge withHookRegistries(
+            final Thingifier aThingifier,
+            final HttpApiHookRegistry hookRegistry,
+            final ThingifierApiLifecycleHookRegistry lifecycleHooks) {
+        return new ThingifierHttpApiBridge(aThingifier, hookRegistry, lifecycleHooks);
+    }
+
+    private ThingifierHttpApiBridge(
+            final Thingifier aThingifier,
+            final HttpApiHookRegistry hookRegistry,
+            final ThingifierApiLifecycleHookRegistry lifecycleHooks) {
         this.thingifier = aThingifier;
-        this.thingifierHttpApi = new ThingifierHttpApi(thingifier, hookRegistry);
+        this.thingifierHttpApi =
+                ThingifierHttpApi.withHookRegistries(thingifier, hookRegistry, lifecycleHooks);
     }
 
     public InternalHttpResponse get(final InternalHttpRequest theRequest) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/ThingifierRestAPIHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/ThingifierRestAPIHandler.java
@@ -3,6 +3,8 @@ package uk.co.compendiumdev.thingifier.api;
 import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.DefaultThingifierApiRuntime;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierApiRuntime;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleContext;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleHookRegistry;
 import uk.co.compendiumdev.thingifier.api.http.ApiRequestEnvelope;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields;
@@ -26,13 +28,21 @@ public class ThingifierRestAPIHandler {
     }
 
     public ThingifierRestAPIHandler(final ThingifierApiRuntime runtime) {
+        this(runtime, new ThingifierApiLifecycleHookRegistry());
+    }
+
+    public ThingifierRestAPIHandler(
+            final ThingifierApiRuntime runtime,
+            final ThingifierApiLifecycleHookRegistry lifecycleHooks) {
         this.runtime = runtime;
-        this.get = new RestApiGetHandler(runtime);
-        this.delete = new RestApiDeleteHandler(runtime);
-        this.post = new RestApiPostHandler(runtime);
-        this.put = new RestApiPutHandler(runtime);
-        this.patch = new RestApiPatchHandler(runtime);
-        this.query = new RestApiQueryHandler(runtime);
+        ThingifierApiLifecycleHookRegistry hooks =
+                lifecycleHooks == null ? new ThingifierApiLifecycleHookRegistry() : lifecycleHooks;
+        this.get = new RestApiGetHandler(runtime, hooks);
+        this.delete = new RestApiDeleteHandler(runtime, hooks);
+        this.post = new RestApiPostHandler(runtime, hooks);
+        this.put = new RestApiPutHandler(runtime, hooks);
+        this.patch = new RestApiPatchHandler(runtime, hooks);
+        this.query = new RestApiQueryHandler(runtime, hooks);
     }
 
     // TODO: we should be able to accept xml with correct content type
@@ -54,8 +64,14 @@ public class ThingifierRestAPIHandler {
     }
 
     public ApiResponse get(final ApiRequestEnvelope request) {
+        return get(request, null);
+    }
+
+    public ApiResponse get(
+            final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
         ThingifierRequestContext context = contextFrom(request.headers());
-        return withRepository(get.handle(request.path(), request.queryParams(), context), context);
+        return withRepository(
+                get.handle(request.path(), request.queryParams(), context, lifecycle), context);
     }
 
     public ApiResponse head(
@@ -67,13 +83,24 @@ public class ThingifierRestAPIHandler {
     }
 
     public ApiResponse head(final ApiRequestEnvelope request) {
+        return head(request, null);
+    }
+
+    public ApiResponse head(
+            final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
         ThingifierRequestContext context = contextFrom(request.headers());
-        final ApiResponse response = get.handle(request.path(), request.queryParams(), context);
+        final ApiResponse response =
+                get.handle(request.path(), request.queryParams(), context, lifecycle);
         response.clearBody();
         return withRepository(response, context);
     }
 
     public ApiResponse query(final ApiRequestEnvelope request) {
+        return query(request, null);
+    }
+
+    public ApiResponse query(
+            final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
         ThingifierRequestContext context = contextFrom(request.headers());
         return withRepository(
                 query.handle(
@@ -81,7 +108,8 @@ public class ThingifierRestAPIHandler {
                         request.queryParams(),
                         request.queryBodyFormat(),
                         request.body(),
-                        context),
+                        context,
+                        lifecycle),
                 context);
     }
 
@@ -91,8 +119,13 @@ public class ThingifierRestAPIHandler {
     }
 
     public ApiResponse delete(final ApiRequestEnvelope request) {
+        return delete(request, null);
+    }
+
+    public ApiResponse delete(
+            final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
         ThingifierRequestContext context = contextFrom(request.headers());
-        return withRepository(delete.handle(request.path(), context), context);
+        return withRepository(delete.handle(request.path(), context, lifecycle), context);
     }
 
     public ApiResponse post(final String url, final BodyParser args, HttpHeadersBlock headers) {
@@ -101,8 +134,14 @@ public class ThingifierRestAPIHandler {
     }
 
     public ApiResponse post(final ApiRequestEnvelope request) {
+        return post(request, null);
+    }
+
+    public ApiResponse post(
+            final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
         ThingifierRequestContext context = contextFrom(request.headers());
-        return post(request.path(), request.bodyFields(), context);
+        return withRepository(
+                post.handle(request.path(), request.bodyFields(), context, lifecycle), context);
     }
 
     public ApiResponse post(
@@ -118,8 +157,14 @@ public class ThingifierRestAPIHandler {
     }
 
     public ApiResponse put(final ApiRequestEnvelope request) {
+        return put(request, null);
+    }
+
+    public ApiResponse put(
+            final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
         ThingifierRequestContext context = contextFrom(request.headers());
-        return put(request.path(), request.bodyFields(), context);
+        return withRepository(
+                put.handle(request.path(), request.bodyFields(), context, lifecycle), context);
     }
 
     public ApiResponse put(
@@ -140,8 +185,15 @@ public class ThingifierRestAPIHandler {
     }
 
     public ApiResponse patch(final ApiRequestEnvelope request) {
+        return patch(request, null);
+    }
+
+    public ApiResponse patch(
+            final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
         ThingifierRequestContext context = contextFrom(request.headers());
-        return patch(request.path(), request.body(), request.headers(), context);
+        return withRepository(
+                patch.handle(request.path(), request.body(), request.headers(), context, lifecycle),
+                context);
     }
 
     public ApiResponse patch(

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/ThingifierRestAPIHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/ThingifierRestAPIHandler.java
@@ -1,7 +1,9 @@
 package uk.co.compendiumdev.thingifier.api;
 
+import java.util.function.Supplier;
 import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.DefaultThingifierApiRuntime;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.RouteAuthPolicy;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierApiRuntime;
 import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleContext;
 import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleHookRegistry;
@@ -32,6 +34,7 @@ public class ThingifierRestAPIHandler {
     private final RestApiPatchHandler patch;
     private final RestApiGetHandler get;
     private final RestApiQueryHandler query;
+    private final RouteAuthPolicy authPolicy;
 
     /**
      * Creates a direct API facade for a Thingifier model.
@@ -73,6 +76,7 @@ public class ThingifierRestAPIHandler {
         this.put = new RestApiPutHandler(runtime, hooks);
         this.patch = new RestApiPatchHandler(runtime, hooks);
         this.query = new RestApiQueryHandler(runtime, hooks);
+        this.authPolicy = new RouteAuthPolicy(runtime);
     }
 
     // TODO: we should be able to accept xml with correct content type
@@ -98,8 +102,8 @@ public class ThingifierRestAPIHandler {
     public ApiResponse get(
             final String url, final QueryFilterParams queryParams, HttpHeadersBlock headers) {
         ThingifierRequestContext context = contextFrom(headers);
-        return withResponsePolicy(
-                RoutingVerb.GET, url, get.handle(url, queryParams, context), context);
+        return withAuthorizedResponsePolicy(
+                RoutingVerb.GET, url, context, null, () -> get.handle(url, queryParams, context));
     }
 
     /**
@@ -121,12 +125,13 @@ public class ThingifierRestAPIHandler {
      */
     public ApiResponse get(
             final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
-        ThingifierRequestContext context = contextFrom(request.headers());
-        return withResponsePolicy(
+        ThingifierRequestContext context = contextFrom(request.headers(), lifecycle);
+        return withAuthorizedResponsePolicy(
                 RoutingVerb.GET,
                 request.path(),
-                get.handle(request.path(), request.queryParams(), context, lifecycle),
-                context);
+                context,
+                lifecycle,
+                () -> get.handle(request.path(), request.queryParams(), context, lifecycle));
     }
 
     /**
@@ -140,9 +145,16 @@ public class ThingifierRestAPIHandler {
     public ApiResponse head(
             final String url, final QueryFilterParams queryParams, HttpHeadersBlock headers) {
         ThingifierRequestContext context = contextFrom(headers);
-        final ApiResponse response = get.handle(url, queryParams, context);
-        response.clearBody();
-        return withResponsePolicy(RoutingVerb.HEAD, url, response, context);
+        return withAuthorizedResponsePolicy(
+                RoutingVerb.HEAD,
+                url,
+                context,
+                null,
+                () -> {
+                    final ApiResponse response = get.handle(url, queryParams, context);
+                    response.clearBody();
+                    return response;
+                });
     }
 
     /**
@@ -164,11 +176,18 @@ public class ThingifierRestAPIHandler {
      */
     public ApiResponse head(
             final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
-        ThingifierRequestContext context = contextFrom(request.headers());
-        final ApiResponse response =
-                get.handle(request.path(), request.queryParams(), context, lifecycle);
-        response.clearBody();
-        return withResponsePolicy(RoutingVerb.HEAD, request.path(), response, context);
+        ThingifierRequestContext context = contextFrom(request.headers(), lifecycle);
+        return withAuthorizedResponsePolicy(
+                RoutingVerb.HEAD,
+                request.path(),
+                context,
+                lifecycle,
+                () -> {
+                    final ApiResponse response =
+                            get.handle(request.path(), request.queryParams(), context, lifecycle);
+                    response.clearBody();
+                    return response;
+                });
     }
 
     /**
@@ -190,18 +209,20 @@ public class ThingifierRestAPIHandler {
      */
     public ApiResponse query(
             final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
-        ThingifierRequestContext context = contextFrom(request.headers());
-        return withResponsePolicy(
+        ThingifierRequestContext context = contextFrom(request.headers(), lifecycle);
+        return withAuthorizedResponsePolicy(
                 RoutingVerb.QUERY,
                 request.path(),
-                query.handle(
-                        request.path(),
-                        request.queryParams(),
-                        request.queryBodyFormat(),
-                        request.body(),
-                        context,
-                        lifecycle),
-                context);
+                context,
+                lifecycle,
+                () ->
+                        query.handle(
+                                request.path(),
+                                request.queryParams(),
+                                request.queryBodyFormat(),
+                                request.body(),
+                                context,
+                                lifecycle));
     }
 
     /**
@@ -213,7 +234,8 @@ public class ThingifierRestAPIHandler {
      */
     public ApiResponse delete(final String url, HttpHeadersBlock headers) {
         ThingifierRequestContext context = contextFrom(headers);
-        return withResponsePolicy(RoutingVerb.DELETE, url, delete.handle(url, context), context);
+        return withAuthorizedResponsePolicy(
+                RoutingVerb.DELETE, url, context, null, () -> delete.handle(url, context));
     }
 
     /**
@@ -235,12 +257,13 @@ public class ThingifierRestAPIHandler {
      */
     public ApiResponse delete(
             final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
-        ThingifierRequestContext context = contextFrom(request.headers());
-        return withResponsePolicy(
+        ThingifierRequestContext context = contextFrom(request.headers(), lifecycle);
+        return withAuthorizedResponsePolicy(
                 RoutingVerb.DELETE,
                 request.path(),
-                delete.handle(request.path(), context, lifecycle),
-                context);
+                context,
+                lifecycle,
+                () -> delete.handle(request.path(), context, lifecycle));
     }
 
     /**
@@ -253,7 +276,12 @@ public class ThingifierRestAPIHandler {
      */
     public ApiResponse post(final String url, final BodyParser args, HttpHeadersBlock headers) {
         ThingifierRequestContext context = contextFrom(headers);
-        return post(url, args.bodyFields(), context);
+        return withAuthorizedResponsePolicy(
+                RoutingVerb.POST,
+                url,
+                context,
+                null,
+                () -> post.handle(url, args.bodyFields(), context));
     }
 
     /**
@@ -275,12 +303,13 @@ public class ThingifierRestAPIHandler {
      */
     public ApiResponse post(
             final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
-        ThingifierRequestContext context = contextFrom(request.headers());
-        return withResponsePolicy(
+        ThingifierRequestContext context = contextFrom(request.headers(), lifecycle);
+        return withAuthorizedResponsePolicy(
                 RoutingVerb.POST,
                 request.path(),
-                post.handle(request.path(), request.bodyFields(), context, lifecycle),
-                context);
+                context,
+                lifecycle,
+                () -> post.handle(request.path(), request.bodyFields(), context, lifecycle));
     }
 
     /**
@@ -295,8 +324,8 @@ public class ThingifierRestAPIHandler {
             final String url,
             final ApiBodyFields bodyFields,
             final ThingifierRequestContext context) {
-        return withResponsePolicy(
-                RoutingVerb.POST, url, post.handle(url, bodyFields, context), context);
+        return withAuthorizedResponsePolicy(
+                RoutingVerb.POST, url, context, null, () -> post.handle(url, bodyFields, context));
     }
 
     /**
@@ -309,7 +338,12 @@ public class ThingifierRestAPIHandler {
      */
     public ApiResponse put(final String url, final BodyParser args, HttpHeadersBlock headers) {
         ThingifierRequestContext context = contextFrom(headers);
-        return put(url, args.bodyFields(), context);
+        return withAuthorizedResponsePolicy(
+                RoutingVerb.PUT,
+                url,
+                context,
+                null,
+                () -> put.handle(url, args.bodyFields(), context));
     }
 
     /**
@@ -331,12 +365,13 @@ public class ThingifierRestAPIHandler {
      */
     public ApiResponse put(
             final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
-        ThingifierRequestContext context = contextFrom(request.headers());
-        return withResponsePolicy(
+        ThingifierRequestContext context = contextFrom(request.headers(), lifecycle);
+        return withAuthorizedResponsePolicy(
                 RoutingVerb.PUT,
                 request.path(),
-                put.handle(request.path(), request.bodyFields(), context, lifecycle),
-                context);
+                context,
+                lifecycle,
+                () -> put.handle(request.path(), request.bodyFields(), context, lifecycle));
     }
 
     /**
@@ -351,8 +386,8 @@ public class ThingifierRestAPIHandler {
             final String url,
             final ApiBodyFields bodyFields,
             final ThingifierRequestContext context) {
-        return withResponsePolicy(
-                RoutingVerb.PUT, url, put.handle(url, bodyFields, context), context);
+        return withAuthorizedResponsePolicy(
+                RoutingVerb.PUT, url, context, null, () -> put.handle(url, bodyFields, context));
     }
 
     /**
@@ -365,7 +400,12 @@ public class ThingifierRestAPIHandler {
      */
     public ApiResponse patch(final String url, final BodyParser args, HttpHeadersBlock headers) {
         ThingifierRequestContext context = contextFrom(headers);
-        return patch(url, args.rawBody(), headers, context);
+        return withAuthorizedResponsePolicy(
+                RoutingVerb.PATCH,
+                url,
+                context,
+                null,
+                () -> patch.handle(url, args.rawBody(), headers, context));
     }
 
     /**
@@ -378,7 +418,12 @@ public class ThingifierRestAPIHandler {
      */
     public ApiResponse patch(final String url, final String body, HttpHeadersBlock headers) {
         ThingifierRequestContext context = contextFrom(headers);
-        return patch(url, body, headers, context);
+        return withAuthorizedResponsePolicy(
+                RoutingVerb.PATCH,
+                url,
+                context,
+                null,
+                () -> patch.handle(url, body, headers, context));
     }
 
     /**
@@ -400,12 +445,19 @@ public class ThingifierRestAPIHandler {
      */
     public ApiResponse patch(
             final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
-        ThingifierRequestContext context = contextFrom(request.headers());
-        return withResponsePolicy(
+        ThingifierRequestContext context = contextFrom(request.headers(), lifecycle);
+        return withAuthorizedResponsePolicy(
                 RoutingVerb.PATCH,
                 request.path(),
-                patch.handle(request.path(), request.body(), request.headers(), context, lifecycle),
-                context);
+                context,
+                lifecycle,
+                () ->
+                        patch.handle(
+                                request.path(),
+                                request.body(),
+                                request.headers(),
+                                context,
+                                lifecycle));
     }
 
     /**
@@ -422,12 +474,62 @@ public class ThingifierRestAPIHandler {
             final String body,
             final HttpHeadersBlock headers,
             final ThingifierRequestContext context) {
-        return withResponsePolicy(
-                RoutingVerb.PATCH, url, patch.handle(url, body, headers, context), context);
+        return withAuthorizedResponsePolicy(
+                RoutingVerb.PATCH,
+                url,
+                context,
+                null,
+                () -> patch.handle(url, body, headers, context));
     }
 
     private ThingifierRequestContext contextFrom(final HttpHeadersBlock headers) {
         return runtime.contextFrom(headers);
+    }
+
+    /**
+     * Returns the lifecycle context when available, otherwise creates a direct-call context.
+     *
+     * <p>Lifecycle routing may have already stored an authenticated principal on the request
+     * context, so lifecycle-backed handler calls must reuse it.
+     *
+     * @param headers request headers used for direct context creation
+     * @param lifecycle lifecycle context, or null for direct calls
+     * @return active request context
+     */
+    private ThingifierRequestContext contextFrom(
+            final HttpHeadersBlock headers, final ThingifierApiLifecycleContext lifecycle) {
+        if (lifecycle != null) {
+            return lifecycle.requestContext();
+        }
+        return contextFrom(headers);
+    }
+
+    /**
+     * Applies route auth policy before executing a generated API handler.
+     *
+     * <p>HTTP lifecycle routing runs auth before body parsing, so lifecycle-backed calls skip this
+     * direct gate to avoid authenticating twice. Direct calls pass null lifecycle and are checked
+     * here before validation or mutation.
+     *
+     * @param verb routing verb used for auth and response-view lookup
+     * @param url generated API path
+     * @param context request context containing the active store
+     * @param lifecycle lifecycle context when called through HTTP processing, otherwise null
+     * @param action handler action to run when auth allows the request
+     * @return response after auth and normal response policy have been applied
+     */
+    private ApiResponse withAuthorizedResponsePolicy(
+            final RoutingVerb verb,
+            final String url,
+            final ThingifierRequestContext context,
+            final ThingifierApiLifecycleContext lifecycle,
+            final Supplier<ApiResponse> action) {
+        final ApiResponse authResponse =
+                lifecycle == null ? authPolicy.rejectIfNotAuthorized(verb, url, context) : null;
+        if (authResponse != null) {
+            return withResponsePolicy(verb, url, authResponse, context);
+        }
+        return withResponsePolicy(verb, url, action.get(), context);
     }
 
     /**

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/ThingifierRestAPIHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/ThingifierRestAPIHandler.java
@@ -17,6 +17,13 @@ import uk.co.compendiumdev.thingifier.api.restapihandlers.*;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
 
+/**
+ * Direct Thingifier API facade for REST-style operations.
+ *
+ * <p>This class is used both by in-process callers and by the HTTP API adapter. It applies the same
+ * response policy as HTTP routing so direct calls and server calls agree on relationship rendering,
+ * route response views, and entity-level default response views.
+ */
 public class ThingifierRestAPIHandler {
     private final ThingifierApiRuntime runtime;
     private final RestApiDeleteHandler delete;
@@ -26,14 +33,34 @@ public class ThingifierRestAPIHandler {
     private final RestApiGetHandler get;
     private final RestApiQueryHandler query;
 
+    /**
+     * Creates a direct API facade for a Thingifier model.
+     *
+     * @param aThingifier Thingifier model and runtime configuration
+     */
     public ThingifierRestAPIHandler(final Thingifier aThingifier) {
         this(new DefaultThingifierApiRuntime(aThingifier));
     }
 
+    /**
+     * Creates a direct API facade using an explicit runtime.
+     *
+     * @param runtime runtime services used by the generated API handlers
+     */
     public ThingifierRestAPIHandler(final ThingifierApiRuntime runtime) {
         this(runtime, new ThingifierApiLifecycleHookRegistry());
     }
 
+    /**
+     * Creates a direct API facade using explicit runtime services and lifecycle hooks.
+     *
+     * <p>The lifecycle registry is supplied by HTTP routing when a request is being processed
+     * through the full lifecycle. Direct callers that do not need hooks can use the simpler
+     * constructors.
+     *
+     * @param runtime runtime services used by the generated API handlers
+     * @param lifecycleHooks lifecycle hook registry, or null for an empty registry
+     */
     public ThingifierRestAPIHandler(
             final ThingifierApiRuntime runtime,
             final ThingifierApiLifecycleHookRegistry lifecycleHooks) {
@@ -60,6 +87,14 @@ public class ThingifierRestAPIHandler {
     // wrong type then it should not cross ref
     // TODO: possibly consider an X- header which has the number of items in the collection
 
+    /**
+     * Handles a GET request using discrete direct-call arguments.
+     *
+     * @param url generated API path
+     * @param queryParams query filters to apply
+     * @param headers request headers used to resolve request context
+     * @return API response with repository and response-view policy applied
+     */
     public ApiResponse get(
             final String url, final QueryFilterParams queryParams, HttpHeadersBlock headers) {
         ThingifierRequestContext context = contextFrom(headers);
@@ -67,10 +102,23 @@ public class ThingifierRestAPIHandler {
                 RoutingVerb.GET, url, get.handle(url, queryParams, context), context);
     }
 
+    /**
+     * Handles a GET request from a parsed request envelope.
+     *
+     * @param request parsed request envelope
+     * @return API response with repository and response-view policy applied
+     */
     public ApiResponse get(final ApiRequestEnvelope request) {
         return get(request, null);
     }
 
+    /**
+     * Handles a GET request from a parsed request envelope and lifecycle context.
+     *
+     * @param request parsed request envelope
+     * @param lifecycle lifecycle context for hook-enabled HTTP processing, or null
+     * @return API response with repository and response-view policy applied
+     */
     public ApiResponse get(
             final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
         ThingifierRequestContext context = contextFrom(request.headers());
@@ -81,6 +129,14 @@ public class ThingifierRestAPIHandler {
                 context);
     }
 
+    /**
+     * Handles a HEAD request using discrete direct-call arguments.
+     *
+     * @param url generated API path
+     * @param queryParams query filters to apply
+     * @param headers request headers used to resolve request context
+     * @return API response with any body cleared after GET semantics are evaluated
+     */
     public ApiResponse head(
             final String url, final QueryFilterParams queryParams, HttpHeadersBlock headers) {
         ThingifierRequestContext context = contextFrom(headers);
@@ -89,10 +145,23 @@ public class ThingifierRestAPIHandler {
         return withResponsePolicy(RoutingVerb.HEAD, url, response, context);
     }
 
+    /**
+     * Handles a HEAD request from a parsed request envelope.
+     *
+     * @param request parsed request envelope
+     * @return API response with any body cleared after GET semantics are evaluated
+     */
     public ApiResponse head(final ApiRequestEnvelope request) {
         return head(request, null);
     }
 
+    /**
+     * Handles a HEAD request from a parsed request envelope and lifecycle context.
+     *
+     * @param request parsed request envelope
+     * @param lifecycle lifecycle context for hook-enabled HTTP processing, or null
+     * @return API response with any body cleared after GET semantics are evaluated
+     */
     public ApiResponse head(
             final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
         ThingifierRequestContext context = contextFrom(request.headers());
@@ -102,10 +171,23 @@ public class ThingifierRestAPIHandler {
         return withResponsePolicy(RoutingVerb.HEAD, request.path(), response, context);
     }
 
+    /**
+     * Handles a QUERY request from a parsed request envelope.
+     *
+     * @param request parsed request envelope
+     * @return API response with repository and response-view policy applied
+     */
     public ApiResponse query(final ApiRequestEnvelope request) {
         return query(request, null);
     }
 
+    /**
+     * Handles a QUERY request from a parsed request envelope and lifecycle context.
+     *
+     * @param request parsed request envelope
+     * @param lifecycle lifecycle context for hook-enabled HTTP processing, or null
+     * @return API response with repository and response-view policy applied
+     */
     public ApiResponse query(
             final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
         ThingifierRequestContext context = contextFrom(request.headers());
@@ -122,15 +204,35 @@ public class ThingifierRestAPIHandler {
                 context);
     }
 
+    /**
+     * Handles a DELETE request using discrete direct-call arguments.
+     *
+     * @param url generated API path
+     * @param headers request headers used to resolve request context
+     * @return API response with repository and response-view policy applied
+     */
     public ApiResponse delete(final String url, HttpHeadersBlock headers) {
         ThingifierRequestContext context = contextFrom(headers);
         return withResponsePolicy(RoutingVerb.DELETE, url, delete.handle(url, context), context);
     }
 
+    /**
+     * Handles a DELETE request from a parsed request envelope.
+     *
+     * @param request parsed request envelope
+     * @return API response with repository and response-view policy applied
+     */
     public ApiResponse delete(final ApiRequestEnvelope request) {
         return delete(request, null);
     }
 
+    /**
+     * Handles a DELETE request from a parsed request envelope and lifecycle context.
+     *
+     * @param request parsed request envelope
+     * @param lifecycle lifecycle context for hook-enabled HTTP processing, or null
+     * @return API response with repository and response-view policy applied
+     */
     public ApiResponse delete(
             final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
         ThingifierRequestContext context = contextFrom(request.headers());
@@ -141,15 +243,36 @@ public class ThingifierRestAPIHandler {
                 context);
     }
 
+    /**
+     * Handles a POST request using a body parser.
+     *
+     * @param url generated API path
+     * @param args parsed body source
+     * @param headers request headers used to resolve request context
+     * @return API response with repository and response-view policy applied
+     */
     public ApiResponse post(final String url, final BodyParser args, HttpHeadersBlock headers) {
         ThingifierRequestContext context = contextFrom(headers);
         return post(url, args.bodyFields(), context);
     }
 
+    /**
+     * Handles a POST request from a parsed request envelope.
+     *
+     * @param request parsed request envelope
+     * @return API response with repository and response-view policy applied
+     */
     public ApiResponse post(final ApiRequestEnvelope request) {
         return post(request, null);
     }
 
+    /**
+     * Handles a POST request from a parsed request envelope and lifecycle context.
+     *
+     * @param request parsed request envelope
+     * @param lifecycle lifecycle context for hook-enabled HTTP processing, or null
+     * @return API response with repository and response-view policy applied
+     */
     public ApiResponse post(
             final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
         ThingifierRequestContext context = contextFrom(request.headers());
@@ -160,6 +283,14 @@ public class ThingifierRestAPIHandler {
                 context);
     }
 
+    /**
+     * Handles a POST request using already parsed body fields and request context.
+     *
+     * @param url generated API path
+     * @param bodyFields parsed request body fields
+     * @param context request context including store selection
+     * @return API response with repository and response-view policy applied
+     */
     public ApiResponse post(
             final String url,
             final ApiBodyFields bodyFields,
@@ -168,15 +299,36 @@ public class ThingifierRestAPIHandler {
                 RoutingVerb.POST, url, post.handle(url, bodyFields, context), context);
     }
 
+    /**
+     * Handles a PUT request using a body parser.
+     *
+     * @param url generated API path
+     * @param args parsed body source
+     * @param headers request headers used to resolve request context
+     * @return API response with repository and response-view policy applied
+     */
     public ApiResponse put(final String url, final BodyParser args, HttpHeadersBlock headers) {
         ThingifierRequestContext context = contextFrom(headers);
         return put(url, args.bodyFields(), context);
     }
 
+    /**
+     * Handles a PUT request from a parsed request envelope.
+     *
+     * @param request parsed request envelope
+     * @return API response with repository and response-view policy applied
+     */
     public ApiResponse put(final ApiRequestEnvelope request) {
         return put(request, null);
     }
 
+    /**
+     * Handles a PUT request from a parsed request envelope and lifecycle context.
+     *
+     * @param request parsed request envelope
+     * @param lifecycle lifecycle context for hook-enabled HTTP processing, or null
+     * @return API response with repository and response-view policy applied
+     */
     public ApiResponse put(
             final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
         ThingifierRequestContext context = contextFrom(request.headers());
@@ -187,6 +339,14 @@ public class ThingifierRestAPIHandler {
                 context);
     }
 
+    /**
+     * Handles a PUT request using already parsed body fields and request context.
+     *
+     * @param url generated API path
+     * @param bodyFields parsed request body fields
+     * @param context request context including store selection
+     * @return API response with repository and response-view policy applied
+     */
     public ApiResponse put(
             final String url,
             final ApiBodyFields bodyFields,
@@ -195,20 +355,49 @@ public class ThingifierRestAPIHandler {
                 RoutingVerb.PUT, url, put.handle(url, bodyFields, context), context);
     }
 
+    /**
+     * Handles a PATCH request using a body parser.
+     *
+     * @param url generated API path
+     * @param args parsed body source
+     * @param headers request headers used to resolve request context
+     * @return API response with repository and response-view policy applied
+     */
     public ApiResponse patch(final String url, final BodyParser args, HttpHeadersBlock headers) {
         ThingifierRequestContext context = contextFrom(headers);
         return patch(url, args.rawBody(), headers, context);
     }
 
+    /**
+     * Handles a PATCH request using raw body text.
+     *
+     * @param url generated API path
+     * @param body raw patch body
+     * @param headers request headers used to resolve request context
+     * @return API response with repository and response-view policy applied
+     */
     public ApiResponse patch(final String url, final String body, HttpHeadersBlock headers) {
         ThingifierRequestContext context = contextFrom(headers);
         return patch(url, body, headers, context);
     }
 
+    /**
+     * Handles a PATCH request from a parsed request envelope.
+     *
+     * @param request parsed request envelope
+     * @return API response with repository and response-view policy applied
+     */
     public ApiResponse patch(final ApiRequestEnvelope request) {
         return patch(request, null);
     }
 
+    /**
+     * Handles a PATCH request from a parsed request envelope and lifecycle context.
+     *
+     * @param request parsed request envelope
+     * @param lifecycle lifecycle context for hook-enabled HTTP processing, or null
+     * @return API response with repository and response-view policy applied
+     */
     public ApiResponse patch(
             final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
         ThingifierRequestContext context = contextFrom(request.headers());
@@ -219,6 +408,15 @@ public class ThingifierRestAPIHandler {
                 context);
     }
 
+    /**
+     * Handles a PATCH request using raw body text and an explicit request context.
+     *
+     * @param url generated API path
+     * @param body raw patch body
+     * @param headers request headers used by patch format handling
+     * @param context request context including store selection
+     * @return API response with repository and response-view policy applied
+     */
     public ApiResponse patch(
             final String url,
             final String body,
@@ -232,6 +430,13 @@ public class ThingifierRestAPIHandler {
         return runtime.contextFrom(headers);
     }
 
+    /**
+     * Attaches the active relationship repository to responses that need serialization support.
+     *
+     * @param response response returned by a verb handler
+     * @param context request context containing the active store
+     * @return the same response with relationship repository metadata, or null
+     */
     private ApiResponse withRepository(
             final ApiResponse response, final ThingifierRequestContext context) {
         if (response == null) {
@@ -240,6 +445,18 @@ public class ThingifierRestAPIHandler {
         return response.usingRelationships(context.store().relationships());
     }
 
+    /**
+     * Applies shared direct-API response policy after a verb handler runs.
+     *
+     * <p>This keeps direct API calls aligned with HTTP calls for relationship rendering and
+     * route/entity response views.
+     *
+     * @param verb routing verb used for route rule lookup
+     * @param url generated API path
+     * @param response response returned by the verb handler
+     * @param context request context containing the active store
+     * @return response after repository and response-view policy have been applied
+     */
     private ApiResponse withResponsePolicy(
             final RoutingVerb verb,
             final String url,
@@ -250,6 +467,16 @@ public class ThingifierRestAPIHandler {
         return responseWithRepository;
     }
 
+    /**
+     * Applies the response entity view chosen by route or entity-level API spec rules.
+     *
+     * <p>Route status-specific views win over entity defaults. Existing response overrides and
+     * error bodies are left alone because they already control their rendered shape.
+     *
+     * @param verb routing verb used for route rule lookup
+     * @param url generated API path
+     * @param response response to update in place
+     */
     private void applyResponseEntityView(
             final RoutingVerb verb, final String url, final ApiResponse response) {
         if (response == null
@@ -282,6 +509,11 @@ public class ThingifierRestAPIHandler {
         }
     }
 
+    /**
+     * Creates a resolver that asks the API spec for the default response view of each entity.
+     *
+     * @return resolver used by serializers when entity-level defaults apply
+     */
     private EntityResponseViewResolver defaultResponseViewResolver() {
         return entity -> {
             if (entity == null) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/ThingifierRestAPIHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/ThingifierRestAPIHandler.java
@@ -5,13 +5,16 @@ import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.DefaultThingifier
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierApiRuntime;
 import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleContext;
 import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleHookRegistry;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.api.http.ApiRequestEnvelope;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.BodyParser;
 import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
+import uk.co.compendiumdev.thingifier.api.response.EntityResponseViewResolver;
 import uk.co.compendiumdev.thingifier.api.restapihandlers.*;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
 
 public class ThingifierRestAPIHandler {
@@ -60,7 +63,8 @@ public class ThingifierRestAPIHandler {
     public ApiResponse get(
             final String url, final QueryFilterParams queryParams, HttpHeadersBlock headers) {
         ThingifierRequestContext context = contextFrom(headers);
-        return withRepository(get.handle(url, queryParams, context), context);
+        return withResponsePolicy(
+                RoutingVerb.GET, url, get.handle(url, queryParams, context), context);
     }
 
     public ApiResponse get(final ApiRequestEnvelope request) {
@@ -70,8 +74,11 @@ public class ThingifierRestAPIHandler {
     public ApiResponse get(
             final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
         ThingifierRequestContext context = contextFrom(request.headers());
-        return withRepository(
-                get.handle(request.path(), request.queryParams(), context, lifecycle), context);
+        return withResponsePolicy(
+                RoutingVerb.GET,
+                request.path(),
+                get.handle(request.path(), request.queryParams(), context, lifecycle),
+                context);
     }
 
     public ApiResponse head(
@@ -79,7 +86,7 @@ public class ThingifierRestAPIHandler {
         ThingifierRequestContext context = contextFrom(headers);
         final ApiResponse response = get.handle(url, queryParams, context);
         response.clearBody();
-        return withRepository(response, context);
+        return withResponsePolicy(RoutingVerb.HEAD, url, response, context);
     }
 
     public ApiResponse head(final ApiRequestEnvelope request) {
@@ -92,7 +99,7 @@ public class ThingifierRestAPIHandler {
         final ApiResponse response =
                 get.handle(request.path(), request.queryParams(), context, lifecycle);
         response.clearBody();
-        return withRepository(response, context);
+        return withResponsePolicy(RoutingVerb.HEAD, request.path(), response, context);
     }
 
     public ApiResponse query(final ApiRequestEnvelope request) {
@@ -102,7 +109,9 @@ public class ThingifierRestAPIHandler {
     public ApiResponse query(
             final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
         ThingifierRequestContext context = contextFrom(request.headers());
-        return withRepository(
+        return withResponsePolicy(
+                RoutingVerb.QUERY,
+                request.path(),
                 query.handle(
                         request.path(),
                         request.queryParams(),
@@ -115,7 +124,7 @@ public class ThingifierRestAPIHandler {
 
     public ApiResponse delete(final String url, HttpHeadersBlock headers) {
         ThingifierRequestContext context = contextFrom(headers);
-        return withRepository(delete.handle(url, context), context);
+        return withResponsePolicy(RoutingVerb.DELETE, url, delete.handle(url, context), context);
     }
 
     public ApiResponse delete(final ApiRequestEnvelope request) {
@@ -125,7 +134,11 @@ public class ThingifierRestAPIHandler {
     public ApiResponse delete(
             final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
         ThingifierRequestContext context = contextFrom(request.headers());
-        return withRepository(delete.handle(request.path(), context, lifecycle), context);
+        return withResponsePolicy(
+                RoutingVerb.DELETE,
+                request.path(),
+                delete.handle(request.path(), context, lifecycle),
+                context);
     }
 
     public ApiResponse post(final String url, final BodyParser args, HttpHeadersBlock headers) {
@@ -140,15 +153,19 @@ public class ThingifierRestAPIHandler {
     public ApiResponse post(
             final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
         ThingifierRequestContext context = contextFrom(request.headers());
-        return withRepository(
-                post.handle(request.path(), request.bodyFields(), context, lifecycle), context);
+        return withResponsePolicy(
+                RoutingVerb.POST,
+                request.path(),
+                post.handle(request.path(), request.bodyFields(), context, lifecycle),
+                context);
     }
 
     public ApiResponse post(
             final String url,
             final ApiBodyFields bodyFields,
             final ThingifierRequestContext context) {
-        return withRepository(post.handle(url, bodyFields, context), context);
+        return withResponsePolicy(
+                RoutingVerb.POST, url, post.handle(url, bodyFields, context), context);
     }
 
     public ApiResponse put(final String url, final BodyParser args, HttpHeadersBlock headers) {
@@ -163,15 +180,19 @@ public class ThingifierRestAPIHandler {
     public ApiResponse put(
             final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
         ThingifierRequestContext context = contextFrom(request.headers());
-        return withRepository(
-                put.handle(request.path(), request.bodyFields(), context, lifecycle), context);
+        return withResponsePolicy(
+                RoutingVerb.PUT,
+                request.path(),
+                put.handle(request.path(), request.bodyFields(), context, lifecycle),
+                context);
     }
 
     public ApiResponse put(
             final String url,
             final ApiBodyFields bodyFields,
             final ThingifierRequestContext context) {
-        return withRepository(put.handle(url, bodyFields, context), context);
+        return withResponsePolicy(
+                RoutingVerb.PUT, url, put.handle(url, bodyFields, context), context);
     }
 
     public ApiResponse patch(final String url, final BodyParser args, HttpHeadersBlock headers) {
@@ -191,7 +212,9 @@ public class ThingifierRestAPIHandler {
     public ApiResponse patch(
             final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
         ThingifierRequestContext context = contextFrom(request.headers());
-        return withRepository(
+        return withResponsePolicy(
+                RoutingVerb.PATCH,
+                request.path(),
                 patch.handle(request.path(), request.body(), request.headers(), context, lifecycle),
                 context);
     }
@@ -201,7 +224,8 @@ public class ThingifierRestAPIHandler {
             final String body,
             final HttpHeadersBlock headers,
             final ThingifierRequestContext context) {
-        return withRepository(patch.handle(url, body, headers, context), context);
+        return withResponsePolicy(
+                RoutingVerb.PATCH, url, patch.handle(url, body, headers, context), context);
     }
 
     private ThingifierRequestContext contextFrom(final HttpHeadersBlock headers) {
@@ -214,5 +238,60 @@ public class ThingifierRestAPIHandler {
             return null;
         }
         return response.usingRelationships(context.store().relationships());
+    }
+
+    private ApiResponse withResponsePolicy(
+            final RoutingVerb verb,
+            final String url,
+            final ApiResponse response,
+            final ThingifierRequestContext context) {
+        final ApiResponse responseWithRepository = withRepository(response, context);
+        applyResponseEntityView(verb, url, responseWithRepository);
+        return responseWithRepository;
+    }
+
+    private void applyResponseEntityView(
+            final RoutingVerb verb, final String url, final ApiResponse response) {
+        if (response == null
+                || response.isErrorResponse()
+                || response.hasABodyOverride()
+                || response.getTypeOfThingReturned() == null) {
+            return;
+        }
+
+        final EntityDefinition entity = response.getTypeOfThingReturned();
+        final String apiPathPrefix = runtime.apiConfig().getApiEndPointPrefix();
+        final String routeViewName =
+                runtime.apiSpec()
+                        .ruleFor(verb, url, apiPathPrefix)
+                        .map(rule -> rule.responseEntityViewFor(response.getStatusCode()))
+                        .orElse(null);
+        if (routeViewName != null) {
+            if (entity.hasViewNamed(routeViewName)) {
+                response.usingEntityView(entity.getViewNamed(routeViewName));
+            }
+            return;
+        }
+
+        if (response.hasResponseView()) {
+            return;
+        }
+
+        if (runtime.apiSpec().defaultResponseEntityViewFor(entity).isPresent()) {
+            response.usingEntityResponseViewResolver(defaultResponseViewResolver());
+        }
+    }
+
+    private EntityResponseViewResolver defaultResponseViewResolver() {
+        return entity -> {
+            if (entity == null) {
+                return null;
+            }
+            return runtime.apiSpec()
+                    .defaultResponseEntityViewFor(entity)
+                    .filter(entity::hasViewNamed)
+                    .map(entity::getViewNamed)
+                    .orElse(null);
+        };
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/ApiRoutingDefinition.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/ApiRoutingDefinition.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import uk.co.compendiumdev.thingifier.api.response.ResponseHeader;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityViewDefinition;
@@ -68,6 +69,10 @@ public final class ApiRoutingDefinition {
 
     public boolean hasObjectSchemaNamed(String aName) {
         return objectSchemas.containsKey(aName);
+    }
+
+    public Optional<EntityDefinition> objectSchemaNamed(final String name) {
+        return Optional.ofNullable(objectSchemas.get(name));
     }
 
     public Collection<EntityDefinition> getObjectSchemas() {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/ApiRoutingDefinition.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/ApiRoutingDefinition.java
@@ -10,6 +10,13 @@ import uk.co.compendiumdev.thingifier.api.response.ResponseHeader;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityViewDefinition;
 
+/**
+ * Holds generated route metadata used for API documentation and route registration.
+ *
+ * <p>The routing definition sits between the Thingifier model and adapters such as OpenAPI or the
+ * HTTP server. API spec rules are applied here so generated documentation and runtime route
+ * registration see the same visibility, payload, response view, and Allow-header metadata.
+ */
 public final class ApiRoutingDefinition {
 
     private List<RoutingDefinition> routings;
@@ -20,10 +27,24 @@ public final class ApiRoutingDefinition {
         objectSchemas = new HashMap<String, EntityDefinition>();
     }
 
+    /**
+     * Returns all generated route definitions.
+     *
+     * @return mutable collection of route definitions maintained by the generator
+     */
     public Collection<RoutingDefinition> definitions() {
         return routings;
     }
 
+    /**
+     * Adds a generated route without a special response header.
+     *
+     * @param documentation generated documentation text
+     * @param verb route verb
+     * @param url route path
+     * @param routingStatus configured routing status behavior
+     * @return the created route definition so callers can add payload metadata
+     */
     public RoutingDefinition addRouting(
             final String documentation,
             final RoutingVerb verb,
@@ -36,6 +57,16 @@ public final class ApiRoutingDefinition {
         return defn;
     }
 
+    /**
+     * Adds a generated route with a response header template.
+     *
+     * @param documentation generated documentation text
+     * @param verb route verb
+     * @param url route path
+     * @param routingStatus configured routing status behavior
+     * @param header response header metadata attached to the route
+     * @return the created route definition so callers can add payload metadata
+     */
     public RoutingDefinition addRouting(
             final String documentation,
             final RoutingVerb verb,
@@ -49,6 +80,14 @@ public final class ApiRoutingDefinition {
         return defn;
     }
 
+    /**
+     * Registers the model entity under the schema names generated routes may reference.
+     *
+     * <p>View names and create payload names are mapped back to the owning entity so API spec
+     * defaults can resolve from route payload metadata to entity view policy.
+     *
+     * @param entityDefn entity definition used by generated payload schemas
+     */
     public void addObjectSchema(EntityDefinition entityDefn) {
         // TODO this should be an object schema rather than entityDefinition
         // because we don't want it to be editable
@@ -67,18 +106,45 @@ public final class ApiRoutingDefinition {
         }
     }
 
+    /**
+     * Reports whether a generated payload schema name is known.
+     *
+     * @param aName schema name to look up
+     * @return true when the schema name has been registered
+     */
     public boolean hasObjectSchemaNamed(String aName) {
         return objectSchemas.containsKey(aName);
     }
 
+    /**
+     * Resolves a generated payload schema name back to the owning entity.
+     *
+     * <p>This powers entity-level default views because generated route metadata stores payload
+     * schema names, while the view definitions live on the entity.
+     *
+     * @param name generated payload schema name
+     * @return owning entity when the schema name is registered
+     */
     public Optional<EntityDefinition> objectSchemaNamed(final String name) {
         return Optional.ofNullable(objectSchemas.get(name));
     }
 
+    /**
+     * Returns the entity definitions registered as object schemas.
+     *
+     * @return collection of registered schema entities
+     */
     public Collection<EntityDefinition> getObjectSchemas() {
         return objectSchemas.values();
     }
 
+    /**
+     * Recomputes generated OPTIONS Allow headers from currently visible and callable routes.
+     *
+     * <p>Routes configured as method-not-allowed return a fixed 405 and are intentionally excluded
+     * from Allow. Disabled and documentation-hidden routes are also omitted from the advertised
+     * method list.
+     */
     public void updateOptionsAllowHeaders() {
         final List<RoutingVerb> verbOrder =
                 List.of(

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/RoutingDefinition.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/RoutingDefinition.java
@@ -6,9 +6,17 @@ import java.util.HashMap;
 import java.util.List;
 import uk.co.compendiumdev.thingifier.api.http.headers.headerparser.ContentTypeHeaderParser;
 import uk.co.compendiumdev.thingifier.api.response.ResponseHeader;
+import uk.co.compendiumdev.thingifier.api.security.SecuritySchemeNames;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.Field;
 
+/**
+ * Describes one generated or additional API route for documentation and registration.
+ *
+ * <p>Route definitions are deliberately metadata-heavy. They capture the public route contract,
+ * response headers, payload schema names, visibility, status behaviour, and security scheme names
+ * that adapters such as the OpenAPI generator need after Thingifier has generated its routes.
+ */
 public class RoutingDefinition {
     private final RoutingVerb verb;
     private final String url;
@@ -26,11 +34,20 @@ public class RoutingDefinition {
     private HashMap<String, String> responseHeaders;
     private boolean usesBasicAuth = false;
     private boolean usesBearerAuth = false;
+    private String bearerAuthSchemeName = SecuritySchemeNames.DEFAULT_BEARER_AUTH_SCHEME;
     private boolean hiddenFromDocumentation = false;
     private boolean disabled = false;
     private String requestEntityViewName;
     private HashMap<Integer, String> responseEntityViewNames;
 
+    /**
+     * Creates route metadata for one verb and path.
+     *
+     * @param verb generated route verb
+     * @param url generated route path
+     * @param routingStatus status behaviour for the route
+     * @param header optional legacy response header definition
+     */
     public RoutingDefinition(
             RoutingVerb verb, String url, RoutingStatus routingStatus, ResponseHeader header) {
         this.verb = verb;
@@ -56,28 +73,64 @@ public class RoutingDefinition {
         responseEntityViewNames = new HashMap<>();
     }
 
+    /**
+     * Returns the generated route verb.
+     *
+     * @return routing verb
+     */
     public RoutingVerb verb() {
         return this.verb;
     }
 
+    /**
+     * Returns the route status behaviour.
+     *
+     * @return routing status metadata
+     */
     public RoutingStatus status() {
         return routingStatus;
     }
 
+    /**
+     * Replaces the route status behaviour.
+     *
+     * @param status replacement status metadata
+     * @return this definition so route metadata can be chained
+     */
     public RoutingDefinition replaceStatus(final RoutingStatus status) {
         routingStatus = status;
         return this;
     }
 
+    /**
+     * Returns the normalized route path.
+     *
+     * @return route path without a leading slash
+     */
     public String url() {
         return url;
     }
 
+    /**
+     * Formats colon-prefixed path parameters with caller-supplied delimiters.
+     *
+     * <p>OpenAPI generation uses this to convert Thingifier's {@code :id} path parameters into
+     * {@code {id}} parameters while other renderers can choose different delimiters.
+     *
+     * @param prefix text to place before the parameter name
+     * @param postfix text to place after the parameter name
+     * @return formatted route path
+     */
     public String urlWithParamFormatter(String prefix, String postfix) {
         // replace \/:([^\/\?]+)
         return url.replaceAll("\\/:([^\\/\\?]+)", "/" + prefix + "$1" + postfix);
     }
 
+    /**
+     * Returns the legacy response header name attached to the route.
+     *
+     * @return header name, or an empty string when none is configured
+     */
     public String header() {
         if (header == null) {
             return "";
@@ -89,6 +142,11 @@ public class RoutingDefinition {
         return header.headerName;
     }
 
+    /**
+     * Returns the legacy response header value attached to the route.
+     *
+     * @return header value, or an empty string when none is configured
+     */
     public String headerValue() {
         if (header == null) {
             return "";
@@ -100,11 +158,24 @@ public class RoutingDefinition {
         return header.headerValue;
     }
 
+    /**
+     * Replaces the legacy response header metadata.
+     *
+     * @param header replacement header metadata
+     * @return this definition so route metadata can be chained
+     */
     public RoutingDefinition replaceHeader(final ResponseHeader header) {
         this.header = header;
         return this;
     }
 
+    /**
+     * Adds a named response header to the route metadata.
+     *
+     * @param headerName header name
+     * @param value header value
+     * @return this definition so route metadata can be chained
+     */
     public RoutingDefinition addResponseHeader(final String headerName, final String value) {
         if (headerName != null) {
             responseHeaders.put(headerName, value == null ? "" : value);
@@ -112,56 +183,121 @@ public class RoutingDefinition {
         return this;
     }
 
+    /**
+     * Reports whether the route defines response headers.
+     *
+     * @return true when response headers are present
+     */
     public boolean hasResponseHeaders() {
         return !responseHeaders.isEmpty();
     }
 
+    /**
+     * Returns the response header names configured for the route.
+     *
+     * @return response header names
+     */
     public Collection<String> getResponseHeaderNames() {
         return responseHeaders.keySet();
     }
 
+    /**
+     * Returns one configured response header value.
+     *
+     * @param headerName header name
+     * @return configured value, or null when absent
+     */
     public String getResponseHeaderValue(final String headerName) {
         return responseHeaders.get(headerName);
     }
 
+    /**
+     * Returns the route documentation text.
+     *
+     * @return documentation text, possibly empty
+     */
     public String getDocumentation() {
         return this.documentation;
     }
 
+    /**
+     * Replaces the route documentation text.
+     *
+     * @param documentation documentation text
+     * @return this definition so route metadata can be chained
+     */
     public RoutingDefinition addDocumentation(String documentation) {
         this.documentation = documentation;
         return this;
     }
 
+    /**
+     * Reports whether the route supports query filtering.
+     *
+     * @return true when filter metadata is present
+     */
     public boolean isFilterable() {
         return isFilterable;
     }
 
+    /**
+     * Marks the route as filterable using fields from an entity definition.
+     *
+     * @param definition entity whose fields can be used as filters
+     * @return this definition so route metadata can be chained
+     */
     public RoutingDefinition setAsFilterableFrom(final EntityDefinition definition) {
         isFilterable = true;
         filterableEntityDefn = definition;
         return this;
     }
 
+    /**
+     * Returns the entity whose fields can be used as filters.
+     *
+     * @return filterable entity definition, or null when the route is not filterable
+     */
     public EntityDefinition getFilterableEntity() {
         return filterableEntityDefn;
     }
 
+    /**
+     * Adds a possible status response to the route metadata.
+     *
+     * @param status status metadata to add
+     * @return this definition so route metadata can be chained
+     */
     public RoutingDefinition addPossibleStatus(final RoutingStatus status) {
         possibleStatusResponses.add(status);
         return this;
     }
 
+    /**
+     * Clears all possible status response metadata.
+     *
+     * @return this definition so route metadata can be chained
+     */
     public RoutingDefinition clearPossibleStatuses() {
         possibleStatusResponses.clear();
         return this;
     }
 
+    /**
+     * Returns possible status responses for documentation.
+     *
+     * @return mutable list of possible status metadata
+     */
     public List<RoutingStatus> getPossibleStatusReponses() {
         return possibleStatusResponses;
     }
 
     // quick hack method to allow creating a bunch of default rendered possible status codes
+    /**
+     * Adds several simple possible status responses.
+     *
+     * @param statusCodes status codes to add
+     * @return this definition so route metadata can be chained
+     */
     public RoutingDefinition addPossibleStatuses(final Integer... statusCodes) {
         for (Integer statusCode : statusCodes) {
             addPossibleStatus(RoutingStatus.returnValue(statusCode));
@@ -169,29 +305,65 @@ public class RoutingDefinition {
         return this;
     }
 
+    /**
+     * Associates a response status with a payload schema name.
+     *
+     * @param statusCode response status code
+     * @param objectSchemaName schema name returned for that status
+     * @return this definition so route metadata can be chained
+     */
     public RoutingDefinition returnPayload(final Integer statusCode, String objectSchemaName) {
         returnPayload.put(statusCode, objectSchemaName);
         return this;
     }
 
+    /**
+     * Clears all response payload schema metadata.
+     *
+     * @return this definition so route metadata can be chained
+     */
     public RoutingDefinition clearReturnPayloads() {
         returnPayload.clear();
         return this;
     }
 
+    /**
+     * Reports whether a status has response payload metadata.
+     *
+     * @param statusCode response status code
+     * @return true when a schema name is configured
+     */
     public boolean hasReturnPayloadFor(final Integer statusCode) {
         return returnPayload.containsKey(statusCode);
     }
 
+    /**
+     * Returns the response payload schema for a status.
+     *
+     * @param statusCode response status code
+     * @return schema name, or null when absent
+     */
     public String getReturnPayloadFor(final Integer statusCode) {
         return returnPayload.get(statusCode);
     }
 
+    /**
+     * Sets the request payload schema name.
+     *
+     * @param payloadName request payload schema name
+     * @return this definition so route metadata can be chained
+     */
     public RoutingDefinition requestPayload(String payloadName) {
         requestPayload = payloadName;
         return this;
     }
 
+    /**
+     * Replaces accepted request content types for routes with a request payload.
+     *
+     * @param contentTypes accepted content types
+     * @return this definition so route metadata can be chained
+     */
     public RoutingDefinition requestContentTypes(final String... contentTypes) {
         requestContentTypes.clear();
         if (contentTypes != null) {
@@ -204,14 +376,32 @@ public class RoutingDefinition {
         return this;
     }
 
+    /**
+     * Reports whether the route defines a request payload schema.
+     *
+     * @return true when request payload metadata is present
+     */
     public Boolean hasRequestPayload() {
         return requestPayload != null;
     }
 
+    /**
+     * Returns the request payload schema name.
+     *
+     * @return request payload schema name, or null when absent
+     */
     public String getRequestPayload() {
         return requestPayload;
     }
 
+    /**
+     * Returns accepted request content types.
+     *
+     * <p>When none are explicitly configured, Thingifier advertises its normal JSON and XML request
+     * content types.
+     *
+     * @return accepted content types
+     */
     public List<String> getRequestContentTypes() {
         if (requestContentTypes.isEmpty()) {
             return List.of(
@@ -222,38 +412,84 @@ public class RoutingDefinition {
         return new ArrayList<>(requestContentTypes);
     }
 
+    /**
+     * Sets the request entity view and matching create-payload schema name.
+     *
+     * @param viewName entity view used to validate request fields
+     * @return this definition so route metadata can be chained
+     */
     public RoutingDefinition requestEntityView(final String viewName) {
         requestEntityViewName = viewName;
         requestPayload("create_" + viewName);
         return this;
     }
 
+    /**
+     * Reports whether a request entity view is configured.
+     *
+     * @return true when a request entity view is present
+     */
     public boolean hasRequestEntityView() {
         return requestEntityViewName != null;
     }
 
+    /**
+     * Returns the request entity view name.
+     *
+     * @return request entity view name, or null when absent
+     */
     public String getRequestEntityView() {
         return requestEntityViewName;
     }
 
+    /**
+     * Sets the response entity view and matching payload schema for a status code.
+     *
+     * @param statusCode response status code
+     * @param viewName entity view used to render the response
+     * @return this definition so route metadata can be chained
+     */
     public RoutingDefinition responseEntityView(final int statusCode, final String viewName) {
         responseEntityViewNames.put(statusCode, viewName);
         returnPayload(statusCode, viewName);
         return this;
     }
 
+    /**
+     * Reports whether a response entity view is configured for a status.
+     *
+     * @param statusCode response status code
+     * @return true when a response view is configured
+     */
     public boolean hasResponseEntityViewFor(final int statusCode) {
         return responseEntityViewNames.containsKey(statusCode);
     }
 
+    /**
+     * Returns the response entity view for a status.
+     *
+     * @param statusCode response status code
+     * @return response entity view name, or null when absent
+     */
     public String getResponseEntityViewFor(final int statusCode) {
         return responseEntityViewNames.get(statusCode);
     }
 
+    /**
+     * Returns all status codes with response payload schemas.
+     *
+     * @return response payload status codes
+     */
     public Collection<Integer> returnPayloadStatusCodes() {
         return new ArrayList<>(returnPayload.keySet());
     }
 
+    /**
+     * Adds a request path parameter using the field name.
+     *
+     * @param aField field metadata for the path parameter
+     * @return this definition so route metadata can be chained
+     */
     public RoutingDefinition addRequestUrlParam(Field aField) {
         if (aField == null) {
             return this;
@@ -262,6 +498,13 @@ public class RoutingDefinition {
         return this;
     }
 
+    /**
+     * Adds a request path parameter with an explicit parameter name.
+     *
+     * @param parameterName path parameter name
+     * @param field field metadata for the path parameter
+     * @return this definition so route metadata can be chained
+     */
     public RoutingDefinition addRequestUrlParam(final String parameterName, final Field field) {
         if (parameterName == null || field == null) {
             return this;
@@ -270,10 +513,20 @@ public class RoutingDefinition {
         return this;
     }
 
+    /**
+     * Reports whether the route defines request path parameters.
+     *
+     * @return true when path parameter metadata is present
+     */
     public Boolean hasRequestUrlParams() {
         return !requestUrlParams.isEmpty();
     }
 
+    /**
+     * Returns field metadata for request path parameters.
+     *
+     * @return list of path parameter fields
+     */
     public List<Field> getRequestUrlParams() {
         List<Field> fields = new ArrayList<>();
         for (RequestUrlParameter parameter : requestUrlParams) {
@@ -282,64 +535,158 @@ public class RoutingDefinition {
         return fields;
     }
 
+    /**
+     * Returns full request path parameter metadata.
+     *
+     * @return path parameter metadata
+     */
     public List<RequestUrlParameter> getRequestUrlParameters() {
         return new ArrayList<>(requestUrlParams);
     }
 
+    /**
+     * Adds custom request header documentation.
+     *
+     * @param headerName header name
+     * @param headerType header schema type
+     * @return this definition so route metadata can be chained
+     */
     public RoutingDefinition addCustomHeader(String headerName, String headerType) {
         customHeaders.put(headerName, headerType);
         return this;
     }
 
+    /**
+     * Reports whether the route defines custom request headers.
+     *
+     * @return true when custom headers are present
+     */
     public boolean hasCustomHeaders() {
         return !customHeaders.keySet().isEmpty();
     }
 
+    /**
+     * Returns custom request header names.
+     *
+     * @return custom header names
+     */
     public Collection<String> getCustomHeaderNames() {
         return customHeaders.keySet();
     }
 
+    /**
+     * Returns the schema type for a custom request header.
+     *
+     * @param headerName header name
+     * @return header type, or null when absent
+     */
     public String getCustomHeaderType(String headerName) {
         return customHeaders.get(headerName);
     }
 
+    /**
+     * Reports whether a custom request header is already defined.
+     *
+     * @param headerName header name
+     * @return true when the header is present
+     */
     public boolean hasCustomHeaderNamed(String headerName) {
         return customHeaders.containsKey(headerName);
     }
 
+    /**
+     * Marks the route as requiring Basic authentication in generated documentation.
+     *
+     * @return this definition so route metadata can be chained
+     */
     public RoutingDefinition secureWithBasicAuth() {
         usesBasicAuth = true;
         return this;
     }
 
+    /**
+     * Reports whether the route is documented as Basic-auth secured.
+     *
+     * @return true when Basic auth should be documented
+     */
     public boolean isSecuredByBasicAuth() {
         return usesBasicAuth;
     }
 
+    /**
+     * Marks the route as requiring the legacy bearer auth scheme in generated documentation.
+     *
+     * @return this definition so route metadata can be chained
+     */
     public RoutingDefinition secureWithBearerAuth() {
+        return secureWithBearerAuth(SecuritySchemeNames.DEFAULT_BEARER_AUTH_SCHEME);
+    }
+
+    /**
+     * Marks the route as requiring a named bearer auth scheme in generated documentation.
+     *
+     * @param schemeName bearer security scheme name
+     * @return this definition so route metadata can be chained
+     */
+    public RoutingDefinition secureWithBearerAuth(final String schemeName) {
         usesBearerAuth = true;
+        bearerAuthSchemeName = SecuritySchemeNames.requireValid(schemeName);
         return this;
     }
 
+    /**
+     * Reports whether the route is documented as bearer-auth secured.
+     *
+     * @return true when bearer auth should be documented
+     */
     public boolean isSecuredByBearerAuth() {
         return usesBearerAuth;
     }
 
+    /**
+     * Returns the bearer auth security scheme name used in generated documentation.
+     *
+     * @return bearer security scheme name
+     */
+    public String bearerAuthSchemeName() {
+        return bearerAuthSchemeName;
+    }
+
+    /**
+     * Hides the route from generated documentation without disabling runtime registration.
+     *
+     * @return this definition so route metadata can be chained
+     */
     public RoutingDefinition hideFromDocumentation() {
         hiddenFromDocumentation = true;
         return this;
     }
 
+    /**
+     * Reports whether the route is hidden from generated documentation.
+     *
+     * @return true when hidden from docs
+     */
     public boolean isHiddenFromDocumentation() {
         return hiddenFromDocumentation;
     }
 
+    /**
+     * Disables the generated route and hides it from documentation.
+     *
+     * @return this definition so route metadata can be chained
+     */
     public RoutingDefinition disable() {
         disabled = true;
         hiddenFromDocumentation = true;
         return this;
     }
 
+    /**
+     * Reports whether the generated route is disabled.
+     *
+     * @return true when disabled
+     */
     public boolean isDisabled() {
         return disabled;
     }
@@ -349,15 +696,31 @@ public class RoutingDefinition {
         private final String name;
         private final Field field;
 
+        /**
+         * Creates request path parameter metadata.
+         *
+         * @param name path parameter name
+         * @param field field metadata for documentation
+         */
         public RequestUrlParameter(final String name, final Field field) {
             this.name = name;
             this.field = field;
         }
 
+        /**
+         * Returns the path parameter name.
+         *
+         * @return path parameter name
+         */
         public String name() {
             return name;
         }
 
+        /**
+         * Returns the field metadata for the path parameter.
+         *
+         * @return field metadata
+         */
         public Field field() {
             return field;
         }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/WriteMethodRoutePolicy.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/WriteMethodRoutePolicy.java
@@ -171,7 +171,8 @@ public final class WriteMethodRoutePolicy {
             Set<RelationshipWriteOperation> operations =
                     relationshipOperationsFor(route.verb(), thingRoute, apiPathPrefix);
             if (operations.contains(RelationshipWriteOperation.CREATE_AND_CONNECT)
-                    || operations.contains(RelationshipWriteOperation.CONNECT_EXISTING)) {
+                    || operations.contains(RelationshipWriteOperation.CONNECT_EXISTING)
+                    || operations.contains(RelationshipWriteOperation.UPDATE_CONNECTED)) {
                 route.replaceStatus(RoutingStatus.returnedFromCall());
             } else {
                 methodNotAllowed(route);

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ApiRequestEnvelope.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ApiRequestEnvelope.java
@@ -66,6 +66,24 @@ public final class ApiRequestEnvelope {
                 queryBodyFormat);
     }
 
+    public static ApiRequestEnvelope fromParsed(
+            final ThingifierHttpApi.HttpVerb verb,
+            final String path,
+            final QueryFilterParams queryParams,
+            final HttpHeadersBlock headers,
+            final ApiBodyFields bodyFields,
+            final String body,
+            final QueryBodyFormat queryBodyFormat) {
+        return new ApiRequestEnvelope(
+                verb,
+                path,
+                queryParams == null ? new QueryFilterParams() : queryParams,
+                headers == null ? new HttpHeadersBlock() : headers,
+                bodyFields == null ? ApiBodyFields.empty() : bodyFields,
+                body,
+                queryBodyFormat == null ? QueryBodyFormat.URL_ENCODED : queryBodyFormat);
+    }
+
     private static QueryBodyFormat queryBodyFormatFor(final HttpApiRequest request) {
         final ContentTypeHeaderParser contentType =
                 new ContentTypeHeaderParser(request.getContentTypeHeader());

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ApiRequestEnvelope.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ApiRequestEnvelope.java
@@ -7,11 +7,21 @@ import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
 import uk.co.compendiumdev.thingifier.api.http.headers.headerparser.ContentTypeHeaderParser;
 import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
 
+/**
+ * Parsed request data passed from HTTP handling into direct Thingifier API handlers.
+ *
+ * <p>The envelope preserves both raw request data and parsed body/query data so lifecycle hooks can
+ * intentionally replace either form before the mapped read or write operation runs.
+ */
 public final class ApiRequestEnvelope {
 
+    /** Identifies how a QUERY request body should be interpreted. */
     public enum QueryBodyFormat {
+        /** Query parameters encoded as a form-style key/value body. */
         URL_ENCODED,
+        /** JSONPath expression used to filter the mapped query result. */
         JSONPATH,
+        /** Thingifier structured query JSON document. */
         STRUCTURED_JSON
     }
 
@@ -40,6 +50,18 @@ public final class ApiRequestEnvelope {
         this.queryBodyFormat = queryBodyFormat;
     }
 
+    /**
+     * Parses an HTTP API request into a handler envelope.
+     *
+     * <p>POST and PUT bodies are parsed to field values immediately because write handlers consume
+     * fields. QUERY requests keep enough raw data to support URL-encoded, JSONPath, and structured
+     * JSON query bodies.
+     *
+     * @param request HTTP API request
+     * @param verb effective HTTP API verb
+     * @param thingNames XML entity names used by body parsing
+     * @return parsed request envelope
+     */
     public static ApiRequestEnvelope from(
             final HttpApiRequest request,
             final ThingifierHttpApi.HttpVerb verb,
@@ -66,6 +88,21 @@ public final class ApiRequestEnvelope {
                 queryBodyFormat);
     }
 
+    /**
+     * Creates an envelope from already parsed request parts.
+     *
+     * <p>Lifecycle hooks use this when a previous phase has replaced query parameters, body fields,
+     * raw body text, or query body format.
+     *
+     * @param verb effective HTTP API verb
+     * @param path generated API path
+     * @param queryParams query filters to expose to handlers
+     * @param headers request headers
+     * @param bodyFields parsed request body fields
+     * @param body raw request body
+     * @param queryBodyFormat QUERY body interpretation
+     * @return request envelope with null-safe defaults
+     */
     public static ApiRequestEnvelope fromParsed(
             final ThingifierHttpApi.HttpVerb verb,
             final String path,
@@ -84,6 +121,12 @@ public final class ApiRequestEnvelope {
                 queryBodyFormat == null ? QueryBodyFormat.URL_ENCODED : queryBodyFormat);
     }
 
+    /**
+     * Chooses the QUERY body format from the request Content-Type.
+     *
+     * @param request HTTP API request
+     * @return query body format used by query handling
+     */
     private static QueryBodyFormat queryBodyFormatFor(final HttpApiRequest request) {
         final ContentTypeHeaderParser contentType =
                 new ContentTypeHeaderParser(request.getContentTypeHeader());
@@ -96,6 +139,12 @@ public final class ApiRequestEnvelope {
         return QueryBodyFormat.URL_ENCODED;
     }
 
+    /**
+     * Combines URI query parameters with URL-encoded QUERY body parameters.
+     *
+     * @param request HTTP API request
+     * @return merged query filter parameters
+     */
     private static QueryFilterParams queryContentAndUriQueryParams(final HttpApiRequest request) {
         QueryFilterParams params = new QueryFilterParams();
         params.addAll(request.getFilterableQueryParams());
@@ -103,30 +152,65 @@ public final class ApiRequestEnvelope {
         return params;
     }
 
+    /**
+     * Returns the effective verb for the request.
+     *
+     * @return HTTP API verb used by handlers
+     */
     public ThingifierHttpApi.HttpVerb verb() {
         return verb;
     }
 
+    /**
+     * Returns the normalized generated API path.
+     *
+     * @return request path
+     */
     public String path() {
         return path;
     }
 
+    /**
+     * Returns query filter parameters visible to handlers.
+     *
+     * @return query filters
+     */
     public QueryFilterParams queryParams() {
         return queryParams;
     }
 
+    /**
+     * Returns request headers used for context and content negotiation.
+     *
+     * @return request headers
+     */
     public HttpHeadersBlock headers() {
         return headers;
     }
 
+    /**
+     * Returns parsed request body fields.
+     *
+     * @return parsed body fields, or an empty field set
+     */
     public ApiBodyFields bodyFields() {
         return bodyFields;
     }
 
+    /**
+     * Returns the raw request body.
+     *
+     * @return raw body text, never null
+     */
     public String body() {
         return body;
     }
 
+    /**
+     * Returns the format selected for a QUERY body.
+     *
+     * @return query body format
+     */
     public QueryBodyFormat queryBodyFormat() {
         return queryBodyFormat;
     }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.adapter.hooks.ScopedHook;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.DefaultThingifierApiRuntime;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.RouteAuthPolicy;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.SchemaCatalog;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierApiRuntime;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierSchemaCatalog;
@@ -232,6 +233,19 @@ public final class ThingifierHttpApi {
 
         if (httpResponse == null && isDisabledByApiSpec(request, effectiveVerb)) {
             httpResponse = disabledRouteResponse(request);
+        }
+
+        if (httpResponse == null && lifecycle != null) {
+            final ApiResponse authResponse =
+                    new RouteAuthPolicy(lifecycle.runtime())
+                            .rejectIfNotAuthorized(
+                                    lifecycle.routingVerb(),
+                                    lifecycle.path(),
+                                    lifecycle.requestContext(),
+                                    lifecycle.route());
+            if (authResponse != null) {
+                httpResponse = httpResponseFor(request, effectiveVerb, authResponse);
+            }
         }
 
         // validate request syntax

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
@@ -32,6 +32,7 @@ import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyField;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.JsonBodyValueConverter;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
+import uk.co.compendiumdev.thingifier.api.response.EntityResponseViewResolver;
 import uk.co.compendiumdev.thingifier.api.spec.ThingifierApiRouteRule;
 import uk.co.compendiumdev.thingifier.apiconfig.EntityPatchUpdateStyle;
 import uk.co.compendiumdev.thingifier.application.schema.RelationshipSpec;
@@ -393,17 +394,24 @@ public final class ThingifierHttpApi {
             return null;
         }
 
-        final Optional<ThingifierApiRouteRule> matchingRule = routeRuleFor(request, verb);
-        if (matchingRule.isEmpty() || !matchingRule.get().hasRequestEntityView()) {
-            return null;
-        }
-
         final EntityDefinition entity = targetEntityFor(request.getPath());
         if (entity == null) {
             return null;
         }
 
-        final String viewName = matchingRule.get().getRequestEntityView();
+        final Optional<String> configuredViewName =
+                thingifier
+                        .apiSpec()
+                        .requestEntityViewFor(
+                                routingVerbFor(verb),
+                                request.getPath(),
+                                thingifier.apiConfig().getApiEndPointPrefix(),
+                                entity);
+        if (configuredViewName.isEmpty()) {
+            return null;
+        }
+
+        final String viewName = configuredViewName.get();
         if (!entity.hasViewNamed(viewName)) {
             return new HttpApiResponse(
                     request.getHeaders(),
@@ -634,20 +642,43 @@ public final class ThingifierHttpApi {
         }
 
         final Optional<ThingifierApiRouteRule> matchingRule = routeRuleFor(request, verb);
-        if (matchingRule.isEmpty()) {
-            return;
-        }
-
-        final String viewName =
-                matchingRule.get().responseEntityViewFor(apiResponse.getStatusCode());
-        if (viewName == null || apiResponse.getTypeOfThingReturned() == null) {
+        if (apiResponse.getTypeOfThingReturned() == null) {
             return;
         }
 
         final EntityDefinition entity = apiResponse.getTypeOfThingReturned();
-        if (entity.hasViewNamed(viewName)) {
-            apiResponse.usingEntityView(entity.getViewNamed(viewName));
+        final String viewName =
+                matchingRule
+                        .map(rule -> rule.responseEntityViewFor(apiResponse.getStatusCode()))
+                        .orElse(null);
+        if (viewName != null) {
+            if (entity.hasViewNamed(viewName)) {
+                apiResponse.usingEntityView(entity.getViewNamed(viewName));
+            }
+            return;
         }
+
+        if (apiResponse.hasResponseView()) {
+            return;
+        }
+
+        if (thingifier.apiSpec().defaultResponseEntityViewFor(entity).isPresent()) {
+            apiResponse.usingEntityResponseViewResolver(defaultResponseViewResolver());
+        }
+    }
+
+    private EntityResponseViewResolver defaultResponseViewResolver() {
+        return entity -> {
+            if (entity == null) {
+                return null;
+            }
+            return thingifier
+                    .apiSpec()
+                    .defaultResponseEntityViewFor(entity)
+                    .filter(entity::hasViewNamed)
+                    .map(entity::getViewNamed)
+                    .orElse(null);
+        };
     }
 
     private EntityDefinition targetEntityFor(final String path) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
@@ -40,6 +40,12 @@ import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityViewDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
 
+/**
+ * HTTP-facing adapter for the generated Thingifier REST API.
+ *
+ * <p>The adapter coordinates legacy HTTP request/response hooks, lifecycle hooks, request syntax
+ * validation, direct API handler calls, response view policy, and final HTTP response rendering.
+ */
 public final class ThingifierHttpApi {
 
     // TODO: each 'session' could have its own thingifier to support multiple users
@@ -62,6 +68,13 @@ public final class ThingifierHttpApi {
     private final HttpApiHookRegistry apiHookRegistry;
     private final ThingifierApiLifecycleHookRegistry lifecycleHooks;
 
+    /**
+     * Verbs understood by the Thingifier HTTP adapter.
+     *
+     * <p>The adapter keeps this enum separate from {@link RoutingVerb} because HTTP handling also
+     * sees methods such as OPTIONS and TRACE which may not be processed by the generated Thingifier
+     * API lifecycle.
+     */
     public enum HttpVerb {
         GET,
         DELETE,
@@ -75,10 +88,25 @@ public final class ThingifierHttpApi {
         TRACE
     };
 
+    /**
+     * Creates an HTTP API adapter with no legacy or lifecycle hooks.
+     *
+     * @param aThingifier Thingifier model and configuration
+     */
     public ThingifierHttpApi(final Thingifier aThingifier) {
         this(aThingifier, (List<HttpApiRequestHook>) null, (List<HttpApiResponseHook>) null);
     }
 
+    /**
+     * Creates an HTTP API adapter using legacy list-based request and response hooks.
+     *
+     * <p>This constructor is kept for backwards compatibility; scoped hook registries and lifecycle
+     * hooks can be supplied through the newer constructors.
+     *
+     * @param aThingifier Thingifier model and configuration
+     * @param apiRequestHooks legacy hooks run before API processing
+     * @param apiResponseHooks legacy hooks run after API processing
+     */
     public ThingifierHttpApi(
             final Thingifier aThingifier,
             List<HttpApiRequestHook> apiRequestHooks,
@@ -90,6 +118,14 @@ public final class ThingifierHttpApi {
                 new ThingifierApiLifecycleHookRegistry());
     }
 
+    /**
+     * Creates an HTTP API adapter using legacy hook lists plus lifecycle hooks.
+     *
+     * @param aThingifier Thingifier model and configuration
+     * @param apiRequestHooks legacy hooks run before API processing
+     * @param apiResponseHooks legacy hooks run after API processing
+     * @param lifecycleHooks lifecycle hooks run inside Thingifier API processing
+     */
     public ThingifierHttpApi(
             final Thingifier aThingifier,
             List<HttpApiRequestHook> apiRequestHooks,
@@ -117,11 +153,25 @@ public final class ThingifierHttpApi {
         jsonThing = new JsonThing(thingifier.apiConfig().jsonOutput());
     }
 
+    /**
+     * Creates an HTTP API adapter with the scoped legacy hook registry.
+     *
+     * @param aThingifier Thingifier model and configuration
+     * @param apiHookRegistry scoped request/response hook registry
+     */
     public ThingifierHttpApi(
             final Thingifier aThingifier, final HttpApiHookRegistry apiHookRegistry) {
         this(aThingifier, apiHookRegistry, new ThingifierApiLifecycleHookRegistry());
     }
 
+    /**
+     * Creates an HTTP API adapter with scoped legacy hooks and lifecycle hooks.
+     *
+     * @param aThingifier Thingifier model and configuration
+     * @param apiHookRegistry scoped request/response hook registry
+     * @param lifecycleHooks lifecycle hooks run inside Thingifier API processing
+     * @return configured HTTP API adapter
+     */
     public static ThingifierHttpApi withHookRegistries(
             final Thingifier aThingifier,
             final HttpApiHookRegistry apiHookRegistry,
@@ -143,6 +193,16 @@ public final class ThingifierHttpApi {
         jsonThing = new JsonThing(thingifier.apiConfig().jsonOutput());
     }
 
+    /**
+     * Processes one HTTP API request through hooks, validation, routing, and response hooks.
+     *
+     * <p>The order deliberately preserves legacy request hooks first and legacy response hooks
+     * last, with lifecycle hooks only applied to generated Thingifier API operations.
+     *
+     * @param request HTTP API request
+     * @param verb original HTTP method before method override handling
+     * @return rendered HTTP API response
+     */
     private HttpApiResponse handleRequest(final HttpApiRequest request, HttpVerb verb) {
 
         // if the request.url has the 'prefix' then remove the prefix and process the request
@@ -209,6 +269,13 @@ public final class ThingifierHttpApi {
         return runTheHttpApiResponseHooksOn(request, httpResponse, effectiveVerb);
     }
 
+    /**
+     * Builds the lifecycle context after the route has been mapped.
+     *
+     * @param request HTTP API request
+     * @param effectiveVerb verb after method override handling
+     * @return lifecycle context shared by every lifecycle phase
+     */
     private ThingifierApiLifecycleContext lifecycleContextFor(
             final HttpApiRequest request, final HttpVerb effectiveVerb) {
         ThingifierApiRuntime runtime = new DefaultThingifierApiRuntime(thingifier);
@@ -222,6 +289,12 @@ public final class ThingifierHttpApi {
                 thingifier.apiConfig().getApiEndPointPrefix());
     }
 
+    /**
+     * Reports whether lifecycle hooks should run for a verb.
+     *
+     * @param verb effective HTTP API verb
+     * @return true for dynamic Thingifier API operations
+     */
     private boolean supportsLifecycle(final HttpVerb verb) {
         switch (verb) {
             case GET:
@@ -237,6 +310,14 @@ public final class ThingifierHttpApi {
         }
     }
 
+    /**
+     * Converts an {@link ApiResponse} to an HTTP response, including HEAD body suppression.
+     *
+     * @param request original HTTP API request
+     * @param effectiveVerb verb after method override handling
+     * @param apiResponse structured API response
+     * @return rendered HTTP API response
+     */
     private HttpApiResponse httpResponseFor(
             final HttpApiRequest request,
             final HttpVerb effectiveVerb,
@@ -264,10 +345,24 @@ public final class ThingifierHttpApi {
         return httpResponse;
     }
 
+    /**
+     * Reports whether API spec disables the matched generated route.
+     *
+     * @param request HTTP API request
+     * @param verb effective HTTP API verb
+     * @return true when a route rule disables this request
+     */
     private boolean isDisabledByApiSpec(final HttpApiRequest request, final HttpVerb verb) {
         return routeRuleFor(request, verb).map(ThingifierApiRouteRule::isDisabled).orElse(false);
     }
 
+    /**
+     * Finds the API spec route rule matching the request and verb.
+     *
+     * @param request HTTP API request
+     * @param verb effective HTTP API verb
+     * @return matching route rule, or empty when the verb is not a generated routing verb
+     */
     private Optional<ThingifierApiRouteRule> routeRuleFor(
             final HttpApiRequest request, final HttpVerb verb) {
         try {
@@ -282,6 +377,12 @@ public final class ThingifierHttpApi {
         }
     }
 
+    /**
+     * Creates the legacy not-found style response used for disabled generated routes.
+     *
+     * @param request HTTP API request
+     * @return HTTP API response representing the disabled route
+     */
     private HttpApiResponse disabledRouteResponse(final HttpApiRequest request) {
         return new HttpApiResponse(
                 request.getHeaders(),
@@ -291,7 +392,13 @@ public final class ThingifierHttpApi {
                 xmlEntityNamesFor(request.getPath()));
     }
 
-    /** return an error response if the request is invalid, null if valid */
+    /**
+     * Validates HTTP request syntax before generated API processing.
+     *
+     * @param request HTTP API request
+     * @param verb effective HTTP API verb
+     * @return error response when syntax is invalid, otherwise null
+     */
     public HttpApiResponse validateRequestSyntax(
             final HttpApiRequest request, final HttpVerb verb) {
 
@@ -315,6 +422,16 @@ public final class ThingifierHttpApi {
         return httpResponse;
     }
 
+    /**
+     * Routes and processes a request without lifecycle hook state.
+     *
+     * <p>This path is used by backwards-compatible constructors and direct adapter calls. Response
+     * entity view policy is still applied after the direct API handler returns.
+     *
+     * @param request HTTP API request
+     * @param verb effective HTTP API verb
+     * @return structured API response
+     */
     public ApiResponse routeAndProcessRequest(final HttpApiRequest request, HttpVerb verb) {
 
         ApiResponse apiResponse = null;
@@ -351,6 +468,15 @@ public final class ThingifierHttpApi {
         return apiResponse;
     }
 
+    /**
+     * Routes and processes a request using an existing lifecycle context.
+     *
+     * <p>The context carries parsed body data, mapped commands or queries, hook replacements, and
+     * the final response through the lifecycle phases.
+     *
+     * @param lifecycle lifecycle context for the request
+     * @return structured API response
+     */
     public ApiResponse routeAndProcessRequest(final ThingifierApiLifecycleContext lifecycle) {
 
         ApiResponse apiResponse = null;
@@ -388,6 +514,16 @@ public final class ThingifierHttpApi {
         return apiResponse;
     }
 
+    /**
+     * Rejects write input fields that are not allowed by the configured request entity view.
+     *
+     * <p>Route request views take precedence over entity default request views. This check happens
+     * before body-parsed lifecycle hooks because it protects the public API input contract.
+     *
+     * @param request HTTP API request
+     * @param verb effective HTTP API verb
+     * @return error response when disallowed input fields are present, otherwise null
+     */
     private HttpApiResponse validateEntityViewInput(
             final HttpApiRequest request, final HttpVerb verb) {
         if (verb != HttpVerb.POST && verb != HttpVerb.PUT && verb != HttpVerb.PATCH) {
@@ -449,6 +585,14 @@ public final class ThingifierHttpApi {
                 xmlEntityNamesFor(request.getPath()));
     }
 
+    /**
+     * Extracts body fields relevant to entity-view input validation.
+     *
+     * @param request HTTP API request
+     * @param verb effective HTTP API verb
+     * @param entity target entity definition
+     * @return fields that may be checked against the input view
+     */
     private List<ApiBodyField> entityViewInputFields(
             final HttpApiRequest request, final HttpVerb verb, final EntityDefinition entity) {
         if (verb == HttpVerb.PATCH) {
@@ -460,6 +604,13 @@ public final class ThingifierHttpApi {
                 .topLevelFields();
     }
 
+    /**
+     * Extracts field names affected by a PATCH request.
+     *
+     * @param request HTTP API request
+     * @param entity target entity definition
+     * @return fields touched by the patch document
+     */
     private List<ApiBodyField> patchInputFields(
             final HttpApiRequest request, final EntityDefinition entity) {
         final Optional<EntityPatchUpdateStyle> style =
@@ -475,6 +626,12 @@ public final class ThingifierHttpApi {
         return objectPatchInputFields(request.getBody());
     }
 
+    /**
+     * Extracts top-level fields from Thingifier's object-style PATCH body.
+     *
+     * @param rawBody raw request body
+     * @return fields present in the object patch document
+     */
     private List<ApiBodyField> objectPatchInputFields(final String rawBody) {
         try {
             final JsonNode document = JsonBodyValueConverter.readTree(rawBody);
@@ -487,6 +644,13 @@ public final class ThingifierHttpApi {
         }
     }
 
+    /**
+     * Extracts top-level fields touched by an RFC 6902 JSON Patch document.
+     *
+     * @param request HTTP API request
+     * @param entity target entity definition
+     * @return fields referenced or produced by the patch document
+     */
     private List<ApiBodyField> jsonPatchInputFields(
             final HttpApiRequest request, final EntityDefinition entity) {
         final List<ApiBodyField> inputFields = new ArrayList<>();
@@ -516,6 +680,12 @@ public final class ThingifierHttpApi {
         return inputFields;
     }
 
+    /**
+     * Adds fields supplied by a JSON Patch operation which replaces the document root.
+     *
+     * @param inputFields accumulating field list
+     * @param operation JSON Patch operation node
+     */
     private void addRootReplacementFields(
             final List<ApiBodyField> inputFields, final JsonNode operation) {
         final JsonNode path = operation.get("path");
@@ -529,11 +699,28 @@ public final class ThingifierHttpApi {
         }
     }
 
+    /**
+     * Converts a JSON object into Thingifier body fields.
+     *
+     * @param document JSON object node
+     * @return top-level body fields
+     */
     private List<ApiBodyField> bodyFieldsForObject(final JsonNode document) {
         return ApiBodyFields.fromMap(JsonBodyValueConverter.objectNodeAsMap(document))
                 .topLevelFields();
     }
 
+    /**
+     * Determines fields that would exist after a root-replacing JSON Patch operation.
+     *
+     * <p>Root replacement can introduce or remove many fields at once, so the existing instance is
+     * patched in memory and the resulting top-level fields are checked against the request view.
+     *
+     * @param request HTTP API request
+     * @param entity target entity definition
+     * @param operations JSON Patch operation array
+     * @return resulting top-level fields when they can be calculated
+     */
     private Optional<List<ApiBodyField>> rootResultFieldsForJsonPatch(
             final HttpApiRequest request,
             final EntityDefinition entity,
@@ -563,6 +750,12 @@ public final class ThingifierHttpApi {
         return Optional.empty();
     }
 
+    /**
+     * Reports whether a JSON Patch document contains an operation against the root path.
+     *
+     * @param operations JSON Patch operation array
+     * @return true when a supported operation targets the root document
+     */
     private boolean hasRootReplacementOperation(final JsonNode operations) {
         for (JsonNode operation : operations) {
             if (!operation.isObject()) {
@@ -580,6 +773,12 @@ public final class ThingifierHttpApi {
         return false;
     }
 
+    /**
+     * Reports whether a JSON Patch operation can replace the root document.
+     *
+     * @param operationNode patch operation name node
+     * @return true when the operation may produce a new root object
+     */
     private boolean rootReplacementOperation(final JsonNode operationNode) {
         if (operationNode == null || !operationNode.isTextual()) {
             return false;
@@ -596,6 +795,13 @@ public final class ThingifierHttpApi {
         }
     }
 
+    /**
+     * Resolves the instance targeted by an instance route.
+     *
+     * @param request HTTP API request
+     * @param entity target entity definition
+     * @return matching instance, or null when the route is not an instance route
+     */
     private EntityInstance targetInstanceFor(
             final HttpApiRequest request, final EntityDefinition entity) {
         final SchemaCatalog schema = new ThingifierSchemaCatalog(thingifier);
@@ -610,6 +816,12 @@ public final class ThingifierHttpApi {
                 .findByQueryIdentifier(entity, ((InstanceRoute) route).identifier());
     }
 
+    /**
+     * Adds the top-level field name from a JSON Pointer.
+     *
+     * @param inputFields accumulating field list
+     * @param pointerNode JSON Pointer node from a patch operation
+     */
     private void addJsonPointerTopLevelField(
             final List<ApiBodyField> inputFields, final JsonNode pointerNode) {
         if (pointerNode == null || !pointerNode.isTextual()) {
@@ -622,6 +834,12 @@ public final class ThingifierHttpApi {
         }
     }
 
+    /**
+     * Extracts the first path segment from a JSON Pointer.
+     *
+     * @param pointer JSON Pointer text
+     * @return unescaped top-level field name, or null for a root/non-pointer value
+     */
     private String jsonPointerTopLevelFieldName(final String pointer) {
         if (pointer == null || pointer.isEmpty() || !pointer.startsWith("/")) {
             return null;
@@ -633,6 +851,16 @@ public final class ThingifierHttpApi {
         return escapedToken.replace("~1", "/").replace("~0", "~");
     }
 
+    /**
+     * Applies route-specific or entity-default response views to a structured response.
+     *
+     * <p>HTTP adapter responses use the same precedence as direct API responses: explicit route
+     * response view first, existing response view next, then entity default resolver.
+     *
+     * @param request HTTP API request
+     * @param verb effective HTTP API verb
+     * @param apiResponse structured API response
+     */
     private void applyResponseEntityView(
             final HttpApiRequest request, final HttpVerb verb, final ApiResponse apiResponse) {
         if (apiResponse == null
@@ -667,6 +895,11 @@ public final class ThingifierHttpApi {
         }
     }
 
+    /**
+     * Creates a resolver for entity-level default response views.
+     *
+     * @return resolver used when no route-specific view was applied
+     */
     private EntityResponseViewResolver defaultResponseViewResolver() {
         return entity -> {
             if (entity == null) {
@@ -681,6 +914,12 @@ public final class ThingifierHttpApi {
         };
     }
 
+    /**
+     * Resolves the entity targeted by a generated route path.
+     *
+     * @param path generated API path
+     * @return target or related entity, or null when the path does not map to a Thingifier entity
+     */
     private EntityDefinition targetEntityFor(final String path) {
         final SchemaCatalog schema = new ThingifierSchemaCatalog(thingifier);
         final ThingRoute route = new ThingRouteMapper(schema).map(path);
@@ -711,6 +950,12 @@ public final class ThingifierHttpApi {
         return null;
     }
 
+    /**
+     * Returns XML entity names that should be accepted or emitted for a path.
+     *
+     * @param path generated API path
+     * @return singular and plural entity names, or an empty list when no entity route matches
+     */
     private List<String> xmlEntityNamesFor(final String path) {
         final EntityDefinition entity = targetEntityFor(path);
         if (entity == null) {
@@ -719,34 +964,83 @@ public final class ThingifierHttpApi {
         return List.of(entity.getName(), entity.getPlural());
     }
 
+    /**
+     * Handles a GET request.
+     *
+     * @param request HTTP API request
+     * @return HTTP API response
+     */
     public HttpApiResponse get(final HttpApiRequest request) {
         return handleRequest(request, HttpVerb.GET);
     }
 
+    /**
+     * Handles a HEAD request.
+     *
+     * @param request HTTP API request
+     * @return HTTP API response
+     */
     public HttpApiResponse head(final HttpApiRequest request) {
         return handleRequest(request, HttpVerb.HEAD);
     }
 
+    /**
+     * Handles a DELETE request.
+     *
+     * @param request HTTP API request
+     * @return HTTP API response
+     */
     public HttpApiResponse delete(final HttpApiRequest request) {
         return handleRequest(request, HttpVerb.DELETE);
     }
 
+    /**
+     * Handles a POST request.
+     *
+     * @param request HTTP API request
+     * @return HTTP API response
+     */
     public HttpApiResponse post(final HttpApiRequest request) {
         return handleRequest(request, HttpVerb.POST);
     }
 
+    /**
+     * Handles a PUT request.
+     *
+     * @param request HTTP API request
+     * @return HTTP API response
+     */
     public HttpApiResponse put(final HttpApiRequest request) {
         return handleRequest(request, HttpVerb.PUT);
     }
 
+    /**
+     * Handles a PATCH request.
+     *
+     * @param request HTTP API request
+     * @return HTTP API response
+     */
     public HttpApiResponse patch(final HttpApiRequest request) {
         return handleRequest(request, HttpVerb.PATCH);
     }
 
+    /**
+     * Handles a QUERY request.
+     *
+     * @param request HTTP API request
+     * @return HTTP API response
+     */
     public HttpApiResponse queryRequest(final HttpApiRequest request) {
         return handleRequest(request, HttpVerb.QUERY);
     }
 
+    /**
+     * Handles the legacy query helper by applying a JSONPath-style query to a GET request.
+     *
+     * @param request HTTP API request
+     * @param query query expression
+     * @return HTTP API response
+     */
     public HttpApiResponse query(final HttpApiRequest request, final String query) {
 
         HttpApiResponse httpResponse = runTheHttpApiRequestHooksOn(request, HttpVerb.GET);
@@ -768,6 +1062,14 @@ public final class ThingifierHttpApi {
         return runTheHttpApiResponseHooksOn(request, httpResponse, HttpVerb.GET);
     }
 
+    /**
+     * Runs legacy HTTP API response hooks in registration order.
+     *
+     * @param request HTTP API request
+     * @param response response produced by generated API processing
+     * @param verb effective HTTP API verb
+     * @return original or replacement response from hooks
+     */
     private HttpApiResponse runTheHttpApiResponseHooksOn(
             final HttpApiRequest request, final HttpApiResponse response, final HttpVerb verb) {
         if (apiHookRegistry != null) {
@@ -797,6 +1099,13 @@ public final class ThingifierHttpApi {
         return response;
     }
 
+    /**
+     * Runs legacy HTTP API request hooks in registration order.
+     *
+     * @param request HTTP API request
+     * @param verb effective HTTP API verb
+     * @return short-circuit response from hooks, or null to continue processing
+     */
     private HttpApiResponse runTheHttpApiRequestHooksOn(
             final HttpApiRequest request, final HttpVerb verb) {
         if (apiHookRegistry != null) {
@@ -825,6 +1134,12 @@ public final class ThingifierHttpApi {
         return null;
     }
 
+    /**
+     * Converts an HTTP adapter verb to the generated routing verb enum.
+     *
+     * @param verb HTTP adapter verb
+     * @return matching routing verb, or null when no generated route verb exists
+     */
     private RoutingVerb routingVerbFor(final HttpVerb verb) {
         if (verb == null) {
             return null;

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
@@ -10,7 +10,9 @@ import java.util.List;
 import java.util.Optional;
 import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.adapter.hooks.ScopedHook;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.DefaultThingifierApiRuntime;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.SchemaCatalog;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierApiRuntime;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierSchemaCatalog;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.CollectionRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.InstanceRoute;
@@ -18,9 +20,12 @@ import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.Relationshi
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.RelationshipInstanceRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRouteMapper;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleContext;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleHookRegistry;
 import uk.co.compendiumdev.thingifier.adapter.http.messagehooks.HttpApiHookRegistry;
 import uk.co.compendiumdev.thingifier.adapter.http.messagehooks.HttpApiRequestHook;
 import uk.co.compendiumdev.thingifier.adapter.http.messagehooks.HttpApiResponseHook;
+import uk.co.compendiumdev.thingifier.api.ThingifierRestAPIHandler;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.api.ermodelconversion.JsonThing;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyField;
@@ -54,6 +59,7 @@ public final class ThingifierHttpApi {
     private List<HttpApiRequestHook> apiRequestHooks;
     private List<HttpApiResponseHook> apiResponseHooks;
     private final HttpApiHookRegistry apiHookRegistry;
+    private final ThingifierApiLifecycleHookRegistry lifecycleHooks;
 
     public enum HttpVerb {
         GET,
@@ -69,15 +75,29 @@ public final class ThingifierHttpApi {
     };
 
     public ThingifierHttpApi(final Thingifier aThingifier) {
-        this(aThingifier, null, null);
+        this(aThingifier, (List<HttpApiRequestHook>) null, (List<HttpApiResponseHook>) null);
     }
 
     public ThingifierHttpApi(
             final Thingifier aThingifier,
             List<HttpApiRequestHook> apiRequestHooks,
             List<HttpApiResponseHook> apiResponseHooks) {
+        this(
+                aThingifier,
+                apiRequestHooks,
+                apiResponseHooks,
+                new ThingifierApiLifecycleHookRegistry());
+    }
+
+    public ThingifierHttpApi(
+            final Thingifier aThingifier,
+            List<HttpApiRequestHook> apiRequestHooks,
+            List<HttpApiResponseHook> apiResponseHooks,
+            final ThingifierApiLifecycleHookRegistry lifecycleHooks) {
         this.thingifier = aThingifier;
         this.apiHookRegistry = null;
+        this.lifecycleHooks =
+                lifecycleHooks == null ? new ThingifierApiLifecycleHookRegistry() : lifecycleHooks;
 
         // request hooks are used to do initial processing and possibly prevent processing
         if (apiRequestHooks == null) {
@@ -98,11 +118,27 @@ public final class ThingifierHttpApi {
 
     public ThingifierHttpApi(
             final Thingifier aThingifier, final HttpApiHookRegistry apiHookRegistry) {
+        this(aThingifier, apiHookRegistry, new ThingifierApiLifecycleHookRegistry());
+    }
+
+    public static ThingifierHttpApi withHookRegistries(
+            final Thingifier aThingifier,
+            final HttpApiHookRegistry apiHookRegistry,
+            final ThingifierApiLifecycleHookRegistry lifecycleHooks) {
+        return new ThingifierHttpApi(aThingifier, apiHookRegistry, lifecycleHooks);
+    }
+
+    private ThingifierHttpApi(
+            final Thingifier aThingifier,
+            final HttpApiHookRegistry apiHookRegistry,
+            final ThingifierApiLifecycleHookRegistry lifecycleHooks) {
         this.thingifier = aThingifier;
         this.apiRequestHooks = new ArrayList<>();
         this.apiResponseHooks = new ArrayList<>();
         this.apiHookRegistry =
                 apiHookRegistry == null ? new HttpApiHookRegistry() : apiHookRegistry;
+        this.lifecycleHooks =
+                lifecycleHooks == null ? new ThingifierApiLifecycleHookRegistry() : lifecycleHooks;
         jsonThing = new JsonThing(thingifier.apiConfig().jsonOutput());
     }
 
@@ -120,14 +156,22 @@ public final class ThingifierHttpApi {
         }
 
         final HttpVerb effectiveVerb = MethodOverrideParser.getEffectiveVerb(request, verb);
-        if (isDisabledByApiSpec(request, effectiveVerb)) {
-            return disabledRouteResponse(request);
-        }
 
         // any pre-request override processing
         HttpApiResponse httpResponse = runTheHttpApiRequestHooksOn(request, effectiveVerb);
 
-        // TODO: consider 'validation' hooks which can be used to override/augment validation
+        ThingifierApiLifecycleContext lifecycle = null;
+        if (httpResponse == null && supportsLifecycle(effectiveVerb)) {
+            lifecycle = lifecycleContextFor(request, effectiveVerb);
+            lifecycleHooks.runRouteMatchedHooks(lifecycle);
+            if (lifecycle.shouldShortCircuit()) {
+                httpResponse = httpResponseFor(request, effectiveVerb, lifecycle.apiResponse());
+            }
+        }
+
+        if (httpResponse == null && isDisabledByApiSpec(request, effectiveVerb)) {
+            httpResponse = disabledRouteResponse(request);
+        }
 
         // validate request syntax
         if (httpResponse == null) {
@@ -142,8 +186,72 @@ public final class ThingifierHttpApi {
 
         // no httpResponse generated after validation so it is not in error
         if (httpResponse == null) {
-            ApiResponse apiResponse = routeAndProcessRequest(request, effectiveVerb);
+            if (lifecycle != null) {
+                ApiRequestEnvelope parsedEnvelope =
+                        ApiRequestEnvelope.from(
+                                request, effectiveVerb, xmlEntityNamesFor(request.getPath()));
+                lifecycle.applyParsedEnvelope(parsedEnvelope);
+                lifecycleHooks.runBodyParsedHooks(lifecycle);
+                if (lifecycle.shouldShortCircuit()) {
+                    httpResponse = httpResponseFor(request, effectiveVerb, lifecycle.apiResponse());
+                } else {
+                    ApiResponse apiResponse = routeAndProcessRequest(lifecycle);
+                    httpResponse = httpResponseFor(request, effectiveVerb, apiResponse);
+                }
+            } else {
+                ApiResponse apiResponse = routeAndProcessRequest(request, effectiveVerb);
+                httpResponse = httpResponseFor(request, effectiveVerb, apiResponse);
+            }
+        }
 
+        // run any post processing response hooks
+        return runTheHttpApiResponseHooksOn(request, httpResponse, effectiveVerb);
+    }
+
+    private ThingifierApiLifecycleContext lifecycleContextFor(
+            final HttpApiRequest request, final HttpVerb effectiveVerb) {
+        ThingifierApiRuntime runtime = new DefaultThingifierApiRuntime(thingifier);
+        ThingRoute route = new ThingRouteMapper(runtime.schema()).map(request.getPath());
+        return new ThingifierApiLifecycleContext(
+                runtime,
+                request,
+                effectiveVerb,
+                routingVerbFor(effectiveVerb),
+                route,
+                thingifier.apiConfig().getApiEndPointPrefix());
+    }
+
+    private boolean supportsLifecycle(final HttpVerb verb) {
+        switch (verb) {
+            case GET:
+            case HEAD:
+            case QUERY:
+            case DELETE:
+            case POST:
+            case PUT:
+            case PATCH:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private HttpApiResponse httpResponseFor(
+            final HttpApiRequest request,
+            final HttpVerb effectiveVerb,
+            final ApiResponse apiResponse) {
+        HttpApiResponse httpResponse =
+                new HttpApiResponse(
+                        request.getHeaders(),
+                        apiResponse,
+                        jsonThing,
+                        thingifier.apiConfig(),
+                        xmlEntityNamesFor(request.getPath()));
+
+        if (effectiveVerb == HttpVerb.HEAD) {
+            final int bodyLength = httpResponse.getBody().getBytes(StandardCharsets.UTF_8).length;
+            apiResponse.clearBody();
+            apiResponse.setHeader("Content-Length", Integer.toString(bodyLength));
             httpResponse =
                     new HttpApiResponse(
                             request.getHeaders(),
@@ -151,24 +259,8 @@ public final class ThingifierHttpApi {
                             jsonThing,
                             thingifier.apiConfig(),
                             xmlEntityNamesFor(request.getPath()));
-
-            if (effectiveVerb == HttpVerb.HEAD) {
-                final int bodyLength =
-                        httpResponse.getBody().getBytes(StandardCharsets.UTF_8).length;
-                apiResponse.clearBody();
-                apiResponse.setHeader("Content-Length", Integer.toString(bodyLength));
-                httpResponse =
-                        new HttpApiResponse(
-                                request.getHeaders(),
-                                apiResponse,
-                                jsonThing,
-                                thingifier.apiConfig(),
-                                xmlEntityNamesFor(request.getPath()));
-            }
         }
-
-        // run any post processing response hooks
-        return runTheHttpApiResponseHooksOn(request, httpResponse, effectiveVerb);
+        return httpResponse;
     }
 
     private boolean isDisabledByApiSpec(final HttpApiRequest request, final HttpVerb verb) {
@@ -255,6 +347,43 @@ public final class ThingifierHttpApi {
         }
 
         applyResponseEntityView(request, verb, apiResponse);
+        return apiResponse;
+    }
+
+    public ApiResponse routeAndProcessRequest(final ThingifierApiLifecycleContext lifecycle) {
+
+        ApiResponse apiResponse = null;
+        ApiRequestEnvelope envelope = lifecycle.toEnvelope();
+        ThingifierRestAPIHandler api =
+                new ThingifierRestAPIHandler(lifecycle.runtime(), lifecycleHooks);
+
+        switch (lifecycle.effectiveVerb()) {
+            case GET:
+                apiResponse = api.get(envelope, lifecycle);
+                break;
+            case HEAD:
+                apiResponse = api.get(envelope, lifecycle);
+                break;
+            case QUERY:
+                apiResponse = api.query(envelope, lifecycle);
+                break;
+            case DELETE:
+                apiResponse = api.delete(envelope, lifecycle);
+                break;
+            case POST:
+                apiResponse = api.post(envelope, lifecycle);
+                break;
+            case PUT:
+                apiResponse = api.put(envelope, lifecycle);
+                break;
+            case PATCH:
+                apiResponse = api.patch(envelope, lifecycle);
+                break;
+            default:
+                break;
+        }
+
+        applyResponseEntityView(lifecycle.request(), lifecycle.effectiveVerb(), apiResponse);
         return apiResponse;
     }
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierRequestContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierRequestContext.java
@@ -2,26 +2,56 @@ package uk.co.compendiumdev.thingifier.api.http;
 
 import static uk.co.compendiumdev.thingifier.api.http.ThingifierHttpApi.HTTP_SESSION_HEADER_NAME;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
+import uk.co.compendiumdev.thingifier.api.security.SecuritySchemeNames;
 import uk.co.compendiumdev.thingifier.core.EntityRelModel;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
 import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
 
+/**
+ * Request-scoped Thingifier runtime context.
+ *
+ * <p>The context selects the active store for a request, preserves the headers used to make that
+ * decision, and carries authenticated principals produced by API-spec auth policy. It is shared by
+ * direct and HTTP request handling so both paths see the same store and security state.
+ */
 public final class ThingifierRequestContext {
 
     private final String databaseName;
     private final ThingStore store;
     private final HttpHeadersBlock headers;
+    private final Map<String, Object> authenticatedPrincipals;
 
+    /**
+     * Creates a request context for one selected store.
+     *
+     * @param databaseName active database/store name
+     * @param store active Thingifier store
+     * @param headers request headers used to create the context
+     */
     private ThingifierRequestContext(
             final String databaseName, final ThingStore store, final HttpHeadersBlock headers) {
         this.databaseName = databaseName;
         this.store = store;
         this.headers = headers;
+        this.authenticatedPrincipals = new HashMap<>();
     }
 
+    /**
+     * Creates a request context from request headers.
+     *
+     * <p>The session header selects a per-session store. When no session header is present,
+     * Thingifier uses the default store.
+     *
+     * @param thingifier model and store owner
+     * @param requestHeaders request headers, possibly null
+     * @return request context for the selected store
+     */
     public static ThingifierRequestContext from(
             final Thingifier thingifier, final HttpHeadersBlock requestHeaders) {
         HttpHeadersBlock safeHeaders =
@@ -32,6 +62,12 @@ public final class ThingifierRequestContext {
                 databaseName, thingifier.getStore(databaseName), safeHeaders);
     }
 
+    /**
+     * Resolves the database name from the Thingifier session header.
+     *
+     * @param requestHeaders request headers
+     * @return selected database/store name
+     */
     private static String databaseNameFrom(final HttpHeadersBlock requestHeaders) {
         String sessionHeaderValue = requestHeaders.get(HTTP_SESSION_HEADER_NAME);
         if (sessionHeaderValue.isEmpty()) {
@@ -40,14 +76,31 @@ public final class ThingifierRequestContext {
         return sessionHeaderValue;
     }
 
+    /**
+     * Returns the active database/store name.
+     *
+     * @return database name
+     */
     public String databaseName() {
         return databaseName;
     }
 
+    /**
+     * Returns the active store for the request.
+     *
+     * @return request store
+     */
     public ThingStore store() {
         return store;
     }
 
+    /**
+     * Reports whether an entity instance exists with a route/query identifier.
+     *
+     * @param entity entity definition to search
+     * @param identifier route or query identifier
+     * @return true when a matching entity instance exists
+     */
     public boolean hasEntityInstanceWithIdentifier(
             final EntityDefinition entity, final String identifier) {
         if (entity == null) {
@@ -57,7 +110,54 @@ public final class ThingifierRequestContext {
         return found != null;
     }
 
+    /**
+     * Returns the request headers associated with this context.
+     *
+     * @return header block used by the request
+     */
     public HttpHeadersBlock headers() {
         return headers;
+    }
+
+    /**
+     * Stores an authenticated principal for a named security scheme.
+     *
+     * <p>Applications can retrieve this later from lifecycle hooks or direct handler code when
+     * route-level auth has already established a principal.
+     *
+     * @param schemeName security scheme name
+     * @param principal authenticated principal object
+     */
+    public void setAuthenticatedPrincipal(final String schemeName, final Object principal) {
+        authenticatedPrincipals.put(SecuritySchemeNames.requireValid(schemeName), principal);
+    }
+
+    /**
+     * Returns the authenticated principal for a named security scheme.
+     *
+     * @param schemeName security scheme name
+     * @return principal object, or null when no principal has been stored
+     */
+    public Object authenticatedPrincipal(final String schemeName) {
+        return authenticatedPrincipals.get(SecuritySchemeNames.requireValid(schemeName));
+    }
+
+    /**
+     * Reports whether a named security scheme has authenticated this request.
+     *
+     * @param schemeName security scheme name
+     * @return true when the scheme has an authenticated principal entry
+     */
+    public boolean hasAuthenticatedPrincipal(final String schemeName) {
+        return authenticatedPrincipals.containsKey(SecuritySchemeNames.requireValid(schemeName));
+    }
+
+    /**
+     * Returns all authenticated principals by scheme name.
+     *
+     * @return immutable copy of authenticated principal entries
+     */
+    public Map<String, Object> authenticatedPrincipals() {
+        return Collections.unmodifiableMap(new HashMap<>(authenticatedPrincipals));
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierRequestContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierRequestContext.java
@@ -4,12 +4,14 @@ import static uk.co.compendiumdev.thingifier.api.http.ThingifierHttpApi.HTTP_SES
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
 import uk.co.compendiumdev.thingifier.api.security.SecuritySchemeNames;
 import uk.co.compendiumdev.thingifier.core.EntityRelModel;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.instance.NamedValue;
 import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
 import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
 
@@ -108,6 +110,58 @@ public final class ThingifierRequestContext {
         }
         EntityInstance found = store.entityQueries().findByQueryIdentifier(entity, identifier);
         return found != null;
+    }
+
+    /**
+     * Reports whether a source instance is related to a target matched by supplied field values.
+     *
+     * <p>Generated route mappers use this to decide whether a relationship collection write should
+     * update an already connected target while keeping repository lookups inside request context
+     * services.
+     *
+     * @param sourceEntity source entity definition
+     * @param sourceIdentifier route/query identifier for the source instance
+     * @param targetEntity target entity definition
+     * @param relationshipName relationship from source to target
+     * @param targetReferenceFields field values that identify the target
+     * @return true when source and target instances exist and are already related
+     */
+    public boolean hasRelatedEntityInstanceMatchingFields(
+            final EntityDefinition sourceEntity,
+            final String sourceIdentifier,
+            final EntityDefinition targetEntity,
+            final String relationshipName,
+            final List<NamedValue> targetReferenceFields) {
+        if (sourceEntity == null || targetEntity == null || targetReferenceFields == null) {
+            return false;
+        }
+
+        EntityInstance source =
+                store.entityQueries().findByQueryIdentifier(sourceEntity, sourceIdentifier);
+        EntityInstance target = referencedEntityInstance(targetEntity, targetReferenceFields);
+        if (source == null || target == null) {
+            return false;
+        }
+
+        for (EntityInstance related : store.relationships().listRelated(source, relationshipName)) {
+            if (related.getInternalId().equals(target.getInternalId())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private EntityInstance referencedEntityInstance(
+            final EntityDefinition entity, final List<NamedValue> referenceFields) {
+        for (NamedValue reference : referenceFields) {
+            EntityInstance found =
+                    store.entityQueries()
+                            .findByField(entity, reference.getName(), reference.asString());
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
     }
 
     /**

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponse.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponse.java
@@ -10,6 +10,13 @@ import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
 import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstanceDraft;
 import uk.co.compendiumdev.thingifier.core.repository.RelationshipRepository;
 
+/**
+ * Represents a Thingifier API result before it is rendered as HTTP, JSON, XML, or another format.
+ *
+ * <p>The response keeps structured domain data instead of eagerly storing a serialized body. This
+ * lets adapters apply entity views, relationship rendering, content negotiation, and header
+ * behavior consistently across direct API calls and HTTP requests.
+ */
 public final class ApiResponse {
 
     // TODO: instance GUID or instance-id should actually be the primary key
@@ -34,6 +41,11 @@ public final class ApiResponse {
     private String body;
     private RelationshipRepository relationshipRepository;
 
+    /**
+     * Creates an empty API response for a status code.
+     *
+     * @param aStatusCode HTTP-style status code to expose through adapters
+     */
     public ApiResponse(final int aStatusCode) {
         this.statusCode = aStatusCode;
         headers = new HttpHeadersBlock();
@@ -48,6 +60,13 @@ public final class ApiResponse {
         responseViewResolver = null;
     }
 
+    /**
+     * Creates an API response that may contain error messages.
+     *
+     * @param aStatusCode HTTP-style status code to expose through adapters
+     * @param isError true when the body should be rendered as error messages
+     * @param theErrorMessages error messages to include in the response body
+     */
     public ApiResponse(
             final int aStatusCode,
             final boolean isError,
@@ -61,18 +80,39 @@ public final class ApiResponse {
         this.errorMessages.addAll(theErrorMessages);
     }
 
+    /**
+     * Returns the HTTP-style status code for this API result.
+     *
+     * @return response status code
+     */
     public int getStatusCode() {
         return this.statusCode;
     }
 
+    /**
+     * Creates a normal 200 OK response with no body.
+     *
+     * @return empty success response
+     */
     public static ApiResponse success() {
         return new ApiResponse(200);
     }
 
+    /**
+     * Creates a 204 No Content response.
+     *
+     * @return empty no-content response
+     */
     public static ApiResponse noContent() {
         return new ApiResponse(204);
     }
 
+    /**
+     * Sets the response body to one persisted entity instance.
+     *
+     * @param instance instance to render
+     * @return this response so additional metadata can be chained
+     */
     public ApiResponse returnSingleInstance(final EntityInstance instance) {
         this.isCollection = false;
         draftToReturn = null;
@@ -83,6 +123,12 @@ public final class ApiResponse {
         return this;
     }
 
+    /**
+     * Sets the response body to a collection of persisted entity instances.
+     *
+     * @param items instances to render as a collection
+     * @return this response so additional metadata can be chained
+     */
     public ApiResponse returnInstanceCollection(final List<EntityInstance> items) {
         thingsToReturn.clear();
         draftToReturn = null;
@@ -95,6 +141,15 @@ public final class ApiResponse {
         return this;
     }
 
+    /**
+     * Sets the response body to one draft entity.
+     *
+     * <p>Drafts are used when validation or parsing needs to return the would-be entity shape
+     * before an instance has been persisted.
+     *
+     * @param draft draft instance to render
+     * @return this response so additional metadata can be chained
+     */
     public ApiResponse returnSingleDraft(final EntityInstanceDraft draft) {
         this.isCollection = false;
         thingsToReturn.clear();
@@ -108,19 +163,43 @@ public final class ApiResponse {
            HEADERS
     */
 
+    /**
+     * Sets or replaces a response header.
+     *
+     * @param headername header name
+     * @param value header value
+     * @return this response so additional metadata can be chained
+     */
     public ApiResponse setHeader(final String headername, final String value) {
         this.headers.put(headername, value);
         return this;
     }
 
+    /**
+     * Returns a response header value.
+     *
+     * @param headername header name
+     * @return header value, or null when the header is not present
+     */
     public String getHeaderValue(final String headername) {
         return headers.get(headername);
     }
 
+    /**
+     * Sets the Location header for create-style responses.
+     *
+     * @param location resource location to advertise
+     * @return this response so additional metadata can be chained
+     */
     public ApiResponse setLocationHeader(final String location) {
         return setHeader("Location", location);
     }
 
+    /**
+     * Returns the mutable header block associated with this response.
+     *
+     * @return response headers
+     */
     public HttpHeadersBlock getHeaders() {
         return headers;
     }
@@ -129,6 +208,16 @@ public final class ApiResponse {
            SPECIAL CASE RESPONSES
     */
 
+    /**
+     * Creates the standard 201 Created response for a persisted entity instance.
+     *
+     * <p>The response includes the created instance, Location header, and optional primary-key
+     * header according to the API configuration.
+     *
+     * @param thingInstance created entity instance, possibly null
+     * @param apiConfig API configuration controlling response headers and URLs
+     * @return created response
+     */
     public static ApiResponse created(
             final EntityInstance thingInstance, ThingifierApiConfig apiConfig) {
         ApiResponse response = new ApiResponse(201);
@@ -153,28 +242,64 @@ public final class ApiResponse {
            ERROR MESSAGES
     */
 
+    /**
+     * Creates a 404 error response with one message.
+     *
+     * @param errorMessage message to render in the error body
+     * @return error response
+     */
     public static ApiResponse error404(final String errorMessage) {
         return error(404, errorMessage);
     }
 
+    /**
+     * Creates an error response with one message.
+     *
+     * @param statusCode HTTP-style error status code
+     * @param errorMessage message to render in the error body
+     * @return error response
+     */
     public static ApiResponse error(final int statusCode, final String errorMessage) {
         Collection<String> localErrorMessages = new ArrayList<>();
         localErrorMessages.add(errorMessage);
         return error(statusCode, localErrorMessages);
     }
 
+    /**
+     * Creates an error response with multiple messages.
+     *
+     * @param statusCode HTTP-style error status code
+     * @param errorMessages messages to render in the error body
+     * @return error response
+     */
     public static ApiResponse error(final int statusCode, final Collection<String> errorMessages) {
         return new ApiResponse(statusCode, true, errorMessages);
     }
 
+    /**
+     * Reports whether this response body should be rendered as errors.
+     *
+     * @return true when this is an error response
+     */
     public boolean isErrorResponse() {
         return isErrorResponse;
     }
 
+    /**
+     * Returns the response error messages.
+     *
+     * @return error messages, empty when no errors were recorded
+     */
     public Collection<String> getErrorMessages() {
         return errorMessages;
     }
 
+    /**
+     * Returns the single persisted instance in the response body.
+     *
+     * @return returned persisted entity instance
+     * @throws IllegalStateException when the response contains a collection or draft
+     */
     public EntityInstance getReturnedInstance() {
         if (isCollection) {
             throw new IllegalStateException("response contains a collection, not an instance");
@@ -187,10 +312,21 @@ public final class ApiResponse {
         return thingsToReturn.get(0);
     }
 
+    /**
+     * Reports whether the response contains a draft instance.
+     *
+     * @return true when the response body is a draft
+     */
     public boolean hasReturnedDraft() {
         return draftToReturn != null;
     }
 
+    /**
+     * Returns the draft instance in the response body.
+     *
+     * @return returned draft entity
+     * @throws IllegalStateException when the response does not contain a draft
+     */
     public EntityInstanceDraft getReturnedDraft() {
         if (isCollection || draftToReturn == null) {
             throw new IllegalStateException("response does not contain a draft instance");
@@ -198,6 +334,12 @@ public final class ApiResponse {
         return draftToReturn;
     }
 
+    /**
+     * Returns the persisted instance collection in the response body.
+     *
+     * @return returned entity instances
+     * @throws IllegalStateException when the response contains a single instance
+     */
     public List<EntityInstance> getReturnedInstanceCollection() {
         if (!isCollection) {
             throw new IllegalStateException("response contains an instance, not a collection");
@@ -205,10 +347,24 @@ public final class ApiResponse {
         return thingsToReturn;
     }
 
+    /**
+     * Reports whether the response body is a collection.
+     *
+     * @return true when the body is a collection of entity instances
+     */
     public boolean isCollection() {
         return isCollection;
     }
 
+    /**
+     * Sets the entity definition for results when it cannot be inferred from instances.
+     *
+     * <p>This matters for empty collections because serializers still need to know the entity type
+     * to choose collection names and response views.
+     *
+     * @param thingDefinition entity definition represented by the response
+     * @return this response so additional metadata can be chained
+     */
     public ApiResponse resultContainsType(final EntityDefinition thingDefinition) {
         if (thingDefinition != null) {
             this.typeOfResults = thingDefinition;
@@ -216,25 +372,60 @@ public final class ApiResponse {
         return this;
     }
 
+    /**
+     * Supplies the relationship repository needed when serializers include relationship fields.
+     *
+     * @param relationships relationship repository associated with the request context
+     * @return this response so additional metadata can be chained
+     */
     public ApiResponse usingRelationships(final RelationshipRepository relationships) {
         this.relationshipRepository = relationships;
         return this;
     }
 
+    /**
+     * Returns the relationship repository available to serializers.
+     *
+     * @return relationship repository, or null when relationship expansion is unavailable
+     */
     public RelationshipRepository getRelationshipRepository() {
         return relationshipRepository;
     }
 
+    /**
+     * Returns the entity type represented by this response.
+     *
+     * @return entity definition for the response body, or null when the response has no entity body
+     */
     public EntityDefinition getTypeOfThingReturned() {
         return typeOfResults;
     }
 
+    /**
+     * Applies one explicit entity view to this response.
+     *
+     * <p>This is used for route-level response views where every rendered entity should use the
+     * same view. Setting it clears any entity-dependent resolver.
+     *
+     * @param view view to apply during response serialization
+     * @return this response so additional metadata can be chained
+     */
     public ApiResponse usingEntityView(final EntityViewDefinition view) {
         responseView = view;
         responseViewResolver = null;
         return this;
     }
 
+    /**
+     * Applies an entity-dependent response view resolver.
+     *
+     * <p>Use this when the response may render entities whose default views differ, for example a
+     * relationship collection returning related entities rather than the route's parent entity.
+     * Setting a resolver clears any explicit single response view.
+     *
+     * @param viewResolver resolver consulted during serialization
+     * @return this response so additional metadata can be chained
+     */
     public ApiResponse usingEntityResponseViewResolver(
             final EntityResponseViewResolver viewResolver) {
         responseViewResolver = viewResolver;
@@ -242,14 +433,33 @@ public final class ApiResponse {
         return this;
     }
 
+    /**
+     * Reports whether response serialization should apply a view.
+     *
+     * @return true when either an explicit view or a resolver is present
+     */
     public boolean hasResponseView() {
         return responseView != null || responseViewResolver != null;
     }
 
+    /**
+     * Returns the explicit single response view.
+     *
+     * <p>This method remains for backwards compatibility. Prefer {@link #responseViewFor} when
+     * rendering because a resolver may be in use.
+     *
+     * @return explicit response view, or null when none is configured
+     */
     public EntityViewDefinition getResponseView() {
         return responseView;
     }
 
+    /**
+     * Resolves the response view for a specific entity being serialized.
+     *
+     * @param entity entity currently being rendered
+     * @return matching response view, or null when no response view applies
+     */
     public EntityViewDefinition responseViewFor(final EntityDefinition entity) {
         if (responseViewResolver != null) {
             return responseViewResolver.viewFor(entity);
@@ -257,29 +467,63 @@ public final class ApiResponse {
         return responseView;
     }
 
+    /**
+     * Reports whether the response has a body to serialize.
+     *
+     * @return true when a structured body or body override is present
+     */
     public boolean hasABody() {
         return this.hasBody;
     }
 
+    /**
+     * Appends an additional error message to the response.
+     *
+     * @param message error message to append
+     * @return this response so additional metadata can be chained
+     */
     public ApiResponse addToErrorMessages(final String message) {
         errorMessages.add(message);
         return this;
     }
 
+    /**
+     * Removes any response body while leaving status and headers intact.
+     *
+     * <p>HEAD handling uses this so the response can advertise the body length without returning
+     * the body content.
+     */
     public void clearBody() {
         this.hasBody = false;
         this.body = null;
     }
 
+    /**
+     * Replaces structured response serialization with an explicit body string.
+     *
+     * <p>Hooks and special handlers use this when they need full control over the response body.
+     *
+     * @param bodyDetails body text to return through adapters
+     */
     public void setBody(final String bodyDetails) {
         this.hasBody = true;
         this.body = bodyDetails;
     }
 
+    /**
+     * Reports whether this response has an explicit body override.
+     *
+     * @return true when {@link #setBody(String)} has supplied body text
+     */
     public boolean hasABodyOverride() {
         return this.body != null;
     }
 
+    /**
+     * Returns the explicit body override.
+     *
+     * @return body override text, or null when structured serialization should be used
+     */
     public String getBody() {
         return this.body;
     }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponse.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponse.java
@@ -30,6 +30,7 @@ public final class ApiResponse {
     private HttpHeadersBlock headers;
     private EntityDefinition typeOfResults;
     private EntityViewDefinition responseView;
+    private EntityResponseViewResolver responseViewResolver;
     private String body;
     private RelationshipRepository relationshipRepository;
 
@@ -44,6 +45,7 @@ public final class ApiResponse {
         hasBody = false;
         body = null;
         responseView = null;
+        responseViewResolver = null;
     }
 
     public ApiResponse(
@@ -229,14 +231,29 @@ public final class ApiResponse {
 
     public ApiResponse usingEntityView(final EntityViewDefinition view) {
         responseView = view;
+        responseViewResolver = null;
+        return this;
+    }
+
+    public ApiResponse usingEntityResponseViewResolver(
+            final EntityResponseViewResolver viewResolver) {
+        responseViewResolver = viewResolver;
+        responseView = null;
         return this;
     }
 
     public boolean hasResponseView() {
-        return responseView != null;
+        return responseView != null || responseViewResolver != null;
     }
 
     public EntityViewDefinition getResponseView() {
+        return responseView;
+    }
+
+    public EntityViewDefinition responseViewFor(final EntityDefinition entity) {
+        if (responseViewResolver != null) {
+            return responseViewResolver.viewFor(entity);
+        }
         return responseView;
     }
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseAsJson.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseAsJson.java
@@ -3,6 +3,7 @@ package uk.co.compendiumdev.thingifier.api.response;
 import com.google.gson.Gson;
 import java.util.*;
 import uk.co.compendiumdev.thingifier.api.ermodelconversion.JsonThing;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
 
 public final class ApiResponseAsJson {
@@ -45,12 +46,16 @@ public final class ApiResponseAsJson {
             }
 
             if (typeName.length() > 0) {
+                final EntityDefinition entity =
+                        apiResponse.getTypeOfThingReturned() == null
+                                ? things.get(0).getEntity()
+                                : apiResponse.getTypeOfThingReturned();
                 output =
                         jsonThing.asJsonTypedArrayWithContentsUntyped(
                                 apiResponse.getReturnedInstanceCollection(),
                                 typeName,
                                 apiResponse.getRelationshipRepository(),
-                                apiResponse.getResponseView());
+                                apiResponse.responseViewFor(entity));
             } else {
                 if (things.size() == 0) {
                     output = "{}";
@@ -61,7 +66,12 @@ public final class ApiResponseAsJson {
 
         } else {
             if (apiResponse.hasReturnedDraft()) {
-                return jsonThing.asJsonObject(apiResponse.getReturnedDraft()).toString();
+                return jsonThing
+                        .asJsonObject(
+                                apiResponse.getReturnedDraft(),
+                                apiResponse.responseViewFor(
+                                        apiResponse.getReturnedDraft().getEntity()))
+                        .toString();
             }
             EntityInstance instance = apiResponse.getReturnedInstance();
 
@@ -70,7 +80,7 @@ public final class ApiResponseAsJson {
                     .asJsonObject(
                             instance,
                             apiResponse.getRelationshipRepository(),
-                            apiResponse.getResponseView())
+                            apiResponse.responseViewFor(instance.getEntity()))
                     .toString();
         }
     }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseAsJson.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseAsJson.java
@@ -6,6 +6,12 @@ import uk.co.compendiumdev.thingifier.api.ermodelconversion.JsonThing;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
 
+/**
+ * Renders an {@link ApiResponse} as a JSON response body.
+ *
+ * <p>The renderer asks the response for the view to use for each entity so route-specific views and
+ * entity-level defaults are applied at serialization time.
+ */
 public final class ApiResponseAsJson {
     private final ApiResponse apiResponse;
     private final JsonThing jsonThing;
@@ -15,6 +21,11 @@ public final class ApiResponseAsJson {
         this.jsonThing = aJsonThing;
     }
 
+    /**
+     * Serializes the API response body to JSON.
+     *
+     * @return JSON response body, or an empty string when the response has no body
+     */
     public String getJson() {
 
         if (!apiResponse.hasABody()) {
@@ -86,12 +97,24 @@ public final class ApiResponseAsJson {
     }
 
     // error messages should always be plural to make it easier to parse
+    /**
+     * Serializes one error message using Thingifier's standard JSON error shape.
+     *
+     * @param errorMessage error message to include
+     * @return JSON error response body
+     */
     public static String getErrorMessageJson(final String errorMessage) {
         Collection<String> localErrorMessages = new ArrayList<>();
         localErrorMessages.add(errorMessage);
         return getErrorMessageJson(localErrorMessages);
     }
 
+    /**
+     * Serializes multiple error messages using Thingifier's standard JSON error shape.
+     *
+     * @param myErrorMessages error messages to include
+     * @return JSON error response body
+     */
     public static String getErrorMessageJson(final Collection<String> myErrorMessages) {
         Map errorResponseBody = new HashMap<String, Collection<String>>();
         errorResponseBody.put("errorMessages", myErrorMessages);

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseAsJsonLines.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseAsJsonLines.java
@@ -65,7 +65,9 @@ public final class ApiResponseAsJsonLines {
             objects.add(
                     jsonThing
                             .asJsonObject(
-                                    apiResponse.getReturnedDraft(), apiResponse.getResponseView())
+                                    apiResponse.getReturnedDraft(),
+                                    apiResponse.responseViewFor(
+                                            apiResponse.getReturnedDraft().getEntity()))
                             .toString());
             return objects;
         }
@@ -79,7 +81,7 @@ public final class ApiResponseAsJsonLines {
                 .asJsonObject(
                         instance,
                         apiResponse.getRelationshipRepository(),
-                        apiResponse.getResponseView())
+                        apiResponse.responseViewFor(instance.getEntity()))
                 .toString();
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseAsJsonLines.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseAsJsonLines.java
@@ -6,6 +6,12 @@ import java.util.List;
 import uk.co.compendiumdev.thingifier.api.ermodelconversion.JsonThing;
 import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
 
+/**
+ * Renders an {@link ApiResponse} as JSON Lines or an RFC 7464 JSON text sequence.
+ *
+ * <p>Each entity is serialized individually, so the renderer resolves the response view for each
+ * instance rather than assuming a single global view.
+ */
 public final class ApiResponseAsJsonLines {
 
     private static final String RECORD_SEPARATOR = "\u001E";
@@ -18,6 +24,11 @@ public final class ApiResponseAsJsonLines {
         this.jsonThing = jsonThing;
     }
 
+    /**
+     * Serializes the response as newline-delimited JSON objects.
+     *
+     * @return JSON Lines body, or an empty string when there are no records
+     */
     public String getJsonLines() {
         List<String> jsonObjects = jsonObjects();
         if (jsonObjects.isEmpty()) {
@@ -26,6 +37,11 @@ public final class ApiResponseAsJsonLines {
         return String.join("\n", jsonObjects) + "\n";
     }
 
+    /**
+     * Serializes the response as a JSON text sequence with record separators.
+     *
+     * @return JSON sequence body, or an empty string when there are no records
+     */
     public String getJsonSequence() {
         List<String> jsonObjects = jsonObjects();
         if (jsonObjects.isEmpty()) {
@@ -39,6 +55,11 @@ public final class ApiResponseAsJsonLines {
         return sequence.toString();
     }
 
+    /**
+     * Builds the individual JSON objects used by both streaming representations.
+     *
+     * @return serialized JSON objects without line separators
+     */
     private List<String> jsonObjects() {
         List<String> objects = new ArrayList<>();
         if (!apiResponse.hasABody()) {
@@ -76,6 +97,12 @@ public final class ApiResponseAsJsonLines {
         return objects;
     }
 
+    /**
+     * Serializes one persisted instance with its applicable response view.
+     *
+     * @param instance instance to serialize
+     * @return JSON object text
+     */
     private String jsonFor(final EntityInstance instance) {
         return jsonThing
                 .asJsonObject(

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseAsXml.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseAsXml.java
@@ -7,6 +7,12 @@ import uk.co.compendiumdev.thingifier.api.http.bodyparser.xml.StringToXML;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
 
+/**
+ * Renders an {@link ApiResponse} as an XML response body.
+ *
+ * <p>XML rendering follows the same response-view selection as JSON rendering so default entity
+ * views and route response views hide or expose the same fields across representations.
+ */
 public final class ApiResponseAsXml {
     private final ApiResponse apiResponse;
     private final JsonThing jsonThing;
@@ -18,6 +24,11 @@ public final class ApiResponseAsXml {
         this.xmlThing = new XmlThing(jsonThing);
     }
 
+    /**
+     * Serializes the API response body to XML.
+     *
+     * @return XML response body, or an empty string when the response has no body
+     */
     public String getXml() {
 
         if (!apiResponse.hasABody()) {
@@ -95,12 +106,24 @@ public final class ApiResponseAsXml {
         }
     }
 
+    /**
+     * Serializes one error message using Thingifier's standard XML error shape.
+     *
+     * @param errorMessage error message to include
+     * @return XML error response body
+     */
     public static String getErrorMessageXml(final String errorMessage) {
         Collection<String> localErrorMessages = new ArrayList<>();
         localErrorMessages.add(errorMessage);
         return getErrorMessageXml(localErrorMessages);
     }
 
+    /**
+     * Serializes multiple error messages using Thingifier's standard XML error shape.
+     *
+     * @param myErrorMessages error messages to include
+     * @return XML error response body
+     */
     public static String getErrorMessageXml(final Collection<String> myErrorMessages) {
         return StringToXML.getStringCollectionAsXml(
                 "errorMessages", "errorMessage", myErrorMessages);

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseAsXml.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseAsXml.java
@@ -59,7 +59,7 @@ public final class ApiResponseAsXml {
                                 thingsToReturn,
                                 apiResponse.getTypeOfThingReturned(),
                                 apiResponse.getRelationshipRepository(),
-                                apiResponse.getResponseView());
+                                apiResponse.responseViewFor(apiResponse.getTypeOfThingReturned()));
             } catch (Exception e) {
                 // TODO: if this happens then the status code is going to be wrong, should probably
                 // throw an exception instead
@@ -71,7 +71,9 @@ public final class ApiResponseAsXml {
             return output;
         } else {
             if (apiResponse.hasReturnedDraft()) {
-                return xmlThing.getSingleObjectXml(apiResponse.getReturnedDraft());
+                return xmlThing.getSingleObjectXml(
+                        apiResponse.getReturnedDraft(),
+                        apiResponse.responseViewFor(apiResponse.getReturnedDraft().getEntity()));
             }
             EntityInstance instance = apiResponse.getReturnedInstance();
 
@@ -81,7 +83,7 @@ public final class ApiResponseAsXml {
                         xmlThing.getSingleObjectXml(
                                 instance,
                                 apiResponse.getRelationshipRepository(),
-                                apiResponse.getResponseView());
+                                apiResponse.responseViewFor(instance.getEntity()));
             } catch (Exception e) {
                 // TODO: if this happens then the status code is going to be wrong
                 output = getErrorMessageXml(e.getMessage());

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseBodyRows.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseBodyRows.java
@@ -28,7 +28,7 @@ final class ApiResponseBodyRows {
             return names;
         }
 
-        EntityViewDefinition view = apiResponse.getResponseView();
+        EntityViewDefinition view = apiResponse.responseViewFor(entity);
         for (String fieldName : entity.getFieldNames()) {
             if (view != null && !view.isResponseVisible(fieldName)) {
                 continue;

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseBodyRows.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponseBodyRows.java
@@ -13,6 +13,12 @@ import uk.co.compendiumdev.thingifier.core.domain.definitions.field.instance.Nam
 import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
 import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstanceDraft;
 
+/**
+ * Converts an {@link ApiResponse} into field names and rows for tabular response formats.
+ *
+ * <p>The tabular formats cannot include nested object fields, and they must respect response views
+ * so the same public field visibility applies as JSON and XML rendering.
+ */
 final class ApiResponseBodyRows {
 
     private final ApiResponse apiResponse;
@@ -21,6 +27,11 @@ final class ApiResponseBodyRows {
         this.apiResponse = apiResponse;
     }
 
+    /**
+     * Returns the visible scalar field names for the response entity type.
+     *
+     * @return ordered field names suitable for a table header
+     */
     public List<String> fieldNames() {
         List<String> names = new ArrayList<>();
         EntityDefinition entity = entityDefinition();
@@ -43,6 +54,11 @@ final class ApiResponseBodyRows {
         return names;
     }
 
+    /**
+     * Returns the response body as scalar string rows.
+     *
+     * @return rows matching the order returned by {@link #fieldNames()}
+     */
     public List<List<String>> rows() {
         List<List<String>> rows = new ArrayList<>();
         if (!apiResponse.hasABody() || apiResponse.isErrorResponse()) {
@@ -66,6 +82,11 @@ final class ApiResponseBodyRows {
         return rows;
     }
 
+    /**
+     * Resolves the entity definition represented by the response body.
+     *
+     * @return response entity definition, or null when no entity body is present
+     */
     private EntityDefinition entityDefinition() {
         if (apiResponse.getTypeOfThingReturned() != null) {
             return apiResponse.getTypeOfThingReturned();
@@ -86,6 +107,13 @@ final class ApiResponseBodyRows {
         return apiResponse.getReturnedInstance().getEntity();
     }
 
+    /**
+     * Converts a persisted instance into a table row.
+     *
+     * @param instance instance to render
+     * @param fieldNames fields selected for the table
+     * @return scalar string values for the selected fields
+     */
     private List<String> rowFor(final EntityInstance instance, final List<String> fieldNames) {
         List<String> row = new ArrayList<>();
         for (String fieldName : fieldNames) {
@@ -95,6 +123,13 @@ final class ApiResponseBodyRows {
         return row;
     }
 
+    /**
+     * Converts a draft instance into a table row using explicit, protected, and default values.
+     *
+     * @param draft draft to render
+     * @param fieldNames fields selected for the table
+     * @return scalar string values for the selected fields
+     */
     private List<String> rowFor(final EntityInstanceDraft draft, final List<String> fieldNames) {
         List<String> row = new ArrayList<>();
         Map<String, String> values = new HashMap<>();

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/EntityResponseViewResolver.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/EntityResponseViewResolver.java
@@ -3,7 +3,20 @@ package uk.co.compendiumdev.thingifier.api.response;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityViewDefinition;
 
+/**
+ * Resolves the response view to use for each entity rendered in an {@link ApiResponse}.
+ *
+ * <p>A resolver is used when the correct response view depends on the entity being serialized, such
+ * as entity-level API defaults on relationship routes. The older single-view response setting is
+ * still useful when one explicit route view should be applied to every rendered instance.
+ */
 public interface EntityResponseViewResolver {
 
+    /**
+     * Finds the response view that should be applied to the supplied entity.
+     *
+     * @param entity entity currently being serialized
+     * @return entity view to apply, or null when the entity should render with its full model shape
+     */
     EntityViewDefinition viewFor(EntityDefinition entity);
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/EntityResponseViewResolver.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/EntityResponseViewResolver.java
@@ -1,0 +1,9 @@
+package uk.co.compendiumdev.thingifier.api.response;
+
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityViewDefinition;
+
+public interface EntityResponseViewResolver {
+
+    EntityViewDefinition viewFor(EntityDefinition entity);
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/LifecycleWriteSupport.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/LifecycleWriteSupport.java
@@ -1,0 +1,128 @@
+package uk.co.compendiumdev.thingifier.api.restapihandlers;
+
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingCommandResultApiMapper;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingWriteRequestMapping;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierApiRuntime;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleContext;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleHookRegistry;
+import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
+import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
+import uk.co.compendiumdev.thingifier.application.ThingCommandResult;
+import uk.co.compendiumdev.thingifier.application.ThingCommandService;
+
+final class LifecycleWriteSupport {
+
+    private LifecycleWriteSupport() {}
+
+    static ApiResponse execute(
+            final ThingifierApiRuntime runtime,
+            final ThingifierApiLifecycleHookRegistry lifecycleHooks,
+            final ThingifierApiLifecycleContext lifecycle,
+            final ThingWriteRequestMapping mapping,
+            final ThingifierRequestContext context,
+            final CommandRemapper remapper) {
+        ThingCommandResultApiMapper apiMapper =
+                new ThingCommandResultApiMapper(runtime.apiConfig());
+        if (mapping.isError()) {
+            return apiMapper.map(mapping.getError());
+        }
+
+        if (lifecycle == null) {
+            ThingCommandResult result =
+                    runtime.commandService(context).execute(mapping.getCommand());
+            return apiMapper.map(mapping, result);
+        }
+
+        final ThingWriteRequestMapping[] activeMapping = {mapping};
+        lifecycle.useMappedWriteCommand(mapping.getCommand());
+        ThingCommandService commandService = runtime.commandService(context);
+        ThingCommandResult finalResult =
+                commandService.runInTransaction(
+                        () ->
+                                executeInsideTransaction(
+                                        commandService,
+                                        lifecycleHooks,
+                                        lifecycle,
+                                        activeMapping,
+                                        apiMapper,
+                                        remapper));
+
+        if (lifecycle.shouldShortCircuit() || lifecycle.apiResponse() != null) {
+            return lifecycle.apiResponse();
+        }
+        return mapResult(apiMapper, lifecycle, activeMapping[0], finalResult);
+    }
+
+    private static ThingCommandResult executeInsideTransaction(
+            final ThingCommandService commandService,
+            final ThingifierApiLifecycleHookRegistry lifecycleHooks,
+            final ThingifierApiLifecycleContext lifecycle,
+            final ThingWriteRequestMapping[] activeMapping,
+            final ThingCommandResultApiMapper apiMapper,
+            final CommandRemapper remapper) {
+        lifecycleHooks.runBeforeValidationHooks(lifecycle);
+        if (lifecycle.shouldShortCircuit()) {
+            return ThingCommandResult.success();
+        }
+
+        if (shouldRemapCommand(lifecycle) && remapper != null) {
+            ThingWriteRequestMapping remapped = remapper.remap();
+            if (remapped.isError()) {
+                lifecycle.shortCircuitWith(apiMapper.map(remapped.getError()));
+                return ThingCommandResult.success();
+            }
+            activeMapping[0] = remapped;
+            lifecycle.useMappedWriteCommand(remapped.getCommand());
+        }
+
+        ThingCommandResult validationResult = commandService.validate(lifecycle.writeCommand());
+        lifecycle.replaceValidationResult(validationResult);
+        lifecycleHooks.runAfterValidationHooks(lifecycle);
+        if (lifecycle.shouldShortCircuit()) {
+            return ThingCommandResult.success();
+        }
+        if (lifecycle.validationResult() != null && lifecycle.validationResult().isError()) {
+            return lifecycle.validationResult();
+        }
+
+        lifecycleHooks.runBeforeActionHooks(lifecycle);
+        if (lifecycle.shouldShortCircuit()) {
+            return ThingCommandResult.success();
+        }
+
+        ThingCommandResult actionResult = commandService.applyValidated(lifecycle.writeCommand());
+        lifecycle.replaceWriteCommandResult(actionResult);
+        lifecycle.useApiResponse(mapResult(apiMapper, lifecycle, activeMapping[0], actionResult));
+        lifecycleHooks.runAfterActionHooks(lifecycle);
+
+        ThingCommandResult finalResult =
+                lifecycle.writeCommandResult() == null
+                        ? actionResult
+                        : lifecycle.writeCommandResult();
+        if (finalResult != actionResult && !lifecycle.apiResponseWasReplaced()) {
+            lifecycle.useApiResponse(
+                    mapResult(apiMapper, lifecycle, activeMapping[0], finalResult));
+        }
+        return finalResult;
+    }
+
+    private static boolean shouldRemapCommand(final ThingifierApiLifecycleContext lifecycle) {
+        return (lifecycle.bodyFieldsWereReplaced() || lifecycle.rawBodyWasReplaced())
+                && !lifecycle.writeCommandWasReplaced();
+    }
+
+    private static ApiResponse mapResult(
+            final ThingCommandResultApiMapper apiMapper,
+            final ThingifierApiLifecycleContext lifecycle,
+            final ThingWriteRequestMapping mapping,
+            final ThingCommandResult result) {
+        if (mapping != null && lifecycle.writeCommand() == mapping.getCommand()) {
+            return apiMapper.map(mapping, result);
+        }
+        return apiMapper.map(lifecycle.writeCommand(), result);
+    }
+
+    interface CommandRemapper {
+        ThingWriteRequestMapping remap();
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/LifecycleWriteSupport.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/LifecycleWriteSupport.java
@@ -10,10 +10,29 @@ import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
 import uk.co.compendiumdev.thingifier.application.ThingCommandResult;
 import uk.co.compendiumdev.thingifier.application.ThingCommandService;
 
+/**
+ * Runs write-command lifecycle phases around Thingifier validation and apply steps.
+ *
+ * <p>The helper keeps POST, PUT, PATCH, and DELETE handlers consistent. It preserves the existing
+ * transaction boundary while allowing hooks to inspect or replace mapped commands, validation
+ * results, action results, and API responses.
+ */
 final class LifecycleWriteSupport {
 
+    /** Prevents construction because this class only provides static write lifecycle helpers. */
     private LifecycleWriteSupport() {}
 
+    /**
+     * Executes a mapped write request with optional lifecycle hook processing.
+     *
+     * @param runtime runtime services used to map results
+     * @param lifecycleHooks lifecycle hook registry
+     * @param lifecycle lifecycle context, or null for normal direct execution
+     * @param mapping mapped write request
+     * @param context request context containing the active store
+     * @param remapper callback used when hooks mutate request data before validation
+     * @return API response for the write operation
+     */
     static ApiResponse execute(
             final ThingifierApiRuntime runtime,
             final ThingifierApiLifecycleHookRegistry lifecycleHooks,
@@ -53,6 +72,20 @@ final class LifecycleWriteSupport {
         return mapResult(apiMapper, lifecycle, activeMapping[0], finalResult);
     }
 
+    /**
+     * Runs validation, action, and hook phases inside the write transaction.
+     *
+     * <p>If an after-action hook changes the command result to an error, the transaction returns
+     * that error result so normal rollback behavior is preserved.
+     *
+     * @param commandService command service owning the transaction
+     * @param lifecycleHooks lifecycle hook registry
+     * @param lifecycle lifecycle context for the request
+     * @param activeMapping current mapping, updated when remapping occurs
+     * @param apiMapper mapper used to convert command results to API responses
+     * @param remapper callback used when hooks mutate request data before validation
+     * @return final command result used by the transaction
+     */
     private static ThingCommandResult executeInsideTransaction(
             final ThingCommandService commandService,
             final ThingifierApiLifecycleHookRegistry lifecycleHooks,
@@ -106,11 +139,26 @@ final class LifecycleWriteSupport {
         return finalResult;
     }
 
+    /**
+     * Reports whether hook-mutated request data should be mapped into a new write command.
+     *
+     * @param lifecycle lifecycle context after before-validation hooks
+     * @return true when body data changed but the command was not explicitly replaced
+     */
     private static boolean shouldRemapCommand(final ThingifierApiLifecycleContext lifecycle) {
         return (lifecycle.bodyFieldsWereReplaced() || lifecycle.rawBodyWasReplaced())
                 && !lifecycle.writeCommandWasReplaced();
     }
 
+    /**
+     * Maps a command result back to an API response using the best available mapping context.
+     *
+     * @param apiMapper command result mapper
+     * @param lifecycle lifecycle context for the request
+     * @param mapping original or remapped request mapping
+     * @param result command result to map
+     * @return API response for the command result
+     */
     private static ApiResponse mapResult(
             final ThingCommandResultApiMapper apiMapper,
             final ThingifierApiLifecycleContext lifecycle,
@@ -122,7 +170,13 @@ final class LifecycleWriteSupport {
         return apiMapper.map(lifecycle.writeCommand(), result);
     }
 
+    /** Callback used to rebuild a write mapping after hooks replace request data. */
     interface CommandRemapper {
+        /**
+         * Remaps the current lifecycle request data to a write request mapping.
+         *
+         * @return remapped write request mapping
+         */
         ThingWriteRequestMapping remap();
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiDeleteHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiDeleteHandler.java
@@ -16,18 +16,40 @@ import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields;
 import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
 
+/**
+ * Handles generated Thingifier DELETE routes.
+ *
+ * <p>The handler maps entity and relationship deletes to write commands, checks declarative write
+ * policy, then delegates lifecycle-aware validation and execution.
+ */
 public class RestApiDeleteHandler {
     private final ThingifierApiRuntime runtime;
     private final ThingifierApiLifecycleHookRegistry lifecycleHooks;
 
+    /**
+     * Creates a DELETE handler from a Thingifier model.
+     *
+     * @param aThingifier Thingifier model and configuration
+     */
     public RestApiDeleteHandler(final Thingifier aThingifier) {
         this(new DefaultThingifierApiRuntime(aThingifier));
     }
 
+    /**
+     * Creates a DELETE handler with no lifecycle hooks.
+     *
+     * @param runtime runtime services used by the handler
+     */
     public RestApiDeleteHandler(final ThingifierApiRuntime runtime) {
         this(runtime, new ThingifierApiLifecycleHookRegistry());
     }
 
+    /**
+     * Creates a DELETE handler with lifecycle hooks.
+     *
+     * @param runtime runtime services used by the handler
+     * @param lifecycleHooks lifecycle hooks for write processing
+     */
     public RestApiDeleteHandler(
             final ThingifierApiRuntime runtime,
             final ThingifierApiLifecycleHookRegistry lifecycleHooks) {
@@ -36,14 +58,36 @@ public class RestApiDeleteHandler {
                 lifecycleHooks == null ? new ThingifierApiLifecycleHookRegistry() : lifecycleHooks;
     }
 
+    /**
+     * Handles a DELETE request using raw headers to resolve context.
+     *
+     * @param url generated API path
+     * @param requestHeaders request headers used to resolve context
+     * @return API response for the DELETE
+     */
     public ApiResponse handle(final String url, HttpHeadersBlock requestHeaders) {
         return handle(url, runtime.contextFrom(requestHeaders));
     }
 
+    /**
+     * Handles a DELETE request without lifecycle hook state.
+     *
+     * @param url generated API path
+     * @param context request context containing the active store
+     * @return API response for the DELETE
+     */
     public ApiResponse handle(final String url, final ThingifierRequestContext context) {
         return handle(url, context, null);
     }
 
+    /**
+     * Handles a DELETE request with optional lifecycle hook state.
+     *
+     * @param url generated API path
+     * @param context request context containing the active store
+     * @param lifecycle lifecycle context, or null for direct processing
+     * @return API response for the DELETE
+     */
     public ApiResponse handle(
             final String url,
             final ThingifierRequestContext context,

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiDeleteHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiDeleteHandler.java
@@ -2,29 +2,38 @@ package uk.co.compendiumdev.thingifier.api.restapihandlers;
 
 import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.DefaultThingifierApiRuntime;
-import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingCommandResultApiMapper;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingWriteRequestMapper;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingWriteRequestMapping;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierApiRuntime;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.WriteMethodPolicy;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRouteMapper;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleContext;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleHookRegistry;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields;
 import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
-import uk.co.compendiumdev.thingifier.application.ThingCommandResult;
 
 public class RestApiDeleteHandler {
     private final ThingifierApiRuntime runtime;
+    private final ThingifierApiLifecycleHookRegistry lifecycleHooks;
 
     public RestApiDeleteHandler(final Thingifier aThingifier) {
         this(new DefaultThingifierApiRuntime(aThingifier));
     }
 
     public RestApiDeleteHandler(final ThingifierApiRuntime runtime) {
+        this(runtime, new ThingifierApiLifecycleHookRegistry());
+    }
+
+    public RestApiDeleteHandler(
+            final ThingifierApiRuntime runtime,
+            final ThingifierApiLifecycleHookRegistry lifecycleHooks) {
         this.runtime = runtime;
+        this.lifecycleHooks =
+                lifecycleHooks == null ? new ThingifierApiLifecycleHookRegistry() : lifecycleHooks;
     }
 
     public ApiResponse handle(final String url, HttpHeadersBlock requestHeaders) {
@@ -32,6 +41,13 @@ public class RestApiDeleteHandler {
     }
 
     public ApiResponse handle(final String url, final ThingifierRequestContext context) {
+        return handle(url, context, null);
+    }
+
+    public ApiResponse handle(
+            final String url,
+            final ThingifierRequestContext context,
+            final ThingifierApiLifecycleContext lifecycle) {
         ThingRoute route = new ThingRouteMapper(runtime.schema()).map(url);
         ApiResponse policyResponse =
                 new WriteMethodPolicy(runtime)
@@ -43,13 +59,12 @@ public class RestApiDeleteHandler {
 
         ThingWriteRequestMapping mapping =
                 new ThingWriteRequestMapper(runtime.schema()).mapDelete(route);
-        ThingCommandResultApiMapper apiMapper =
-                new ThingCommandResultApiMapper(runtime.apiConfig());
-        if (mapping.isError()) {
-            return apiMapper.map(mapping.getError());
-        }
-
-        ThingCommandResult result = runtime.commandService(context).execute(mapping.getCommand());
-        return apiMapper.map(mapping, result);
+        return LifecycleWriteSupport.execute(
+                runtime,
+                lifecycleHooks,
+                lifecycle,
+                mapping,
+                context,
+                () -> new ThingWriteRequestMapper(runtime.schema()).mapDelete(route));
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiGetHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiGetHandler.java
@@ -10,22 +10,34 @@ import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.CollectionR
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.RelationshipCollectionRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRouteMapper;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleContext;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleHookRegistry;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierHttpApi;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
 import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
+import uk.co.compendiumdev.thingifier.application.query.ThingReadQuery;
 import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
 import uk.co.compendiumdev.thingifier.core.query.RepositoryQueryResult;
 
 public class RestApiGetHandler {
     private final ThingifierApiRuntime runtime;
+    private final ThingifierApiLifecycleHookRegistry lifecycleHooks;
 
     public RestApiGetHandler(final Thingifier aThingifier) {
         this(new DefaultThingifierApiRuntime(aThingifier));
     }
 
     public RestApiGetHandler(final ThingifierApiRuntime runtime) {
+        this(runtime, new ThingifierApiLifecycleHookRegistry());
+    }
+
+    public RestApiGetHandler(
+            final ThingifierApiRuntime runtime,
+            final ThingifierApiLifecycleHookRegistry lifecycleHooks) {
         this.runtime = runtime;
+        this.lifecycleHooks =
+                lifecycleHooks == null ? new ThingifierApiLifecycleHookRegistry() : lifecycleHooks;
     }
 
     public ApiResponse handle(
@@ -39,9 +51,16 @@ public class RestApiGetHandler {
             final String url,
             final QueryFilterParams queryParams,
             final ThingifierRequestContext context) {
+        return handle(url, queryParams, context, null);
+    }
+
+    public ApiResponse handle(
+            final String url,
+            final QueryFilterParams queryParams,
+            final ThingifierRequestContext context,
+            final ThingifierApiLifecycleContext lifecycle) {
         ThingReadResultApiMapper apiMapper = new ThingReadResultApiMapper(runtime.apiConfig());
 
-        RepositoryQueryResult queryResults;
         ThingRoute route = new ThingRouteMapper(runtime.schema()).map(url);
         EffectiveQueryParams effectiveQueryParams =
                 EffectiveQueryParams.forGet(runtime.apiConfig(), route, queryParams, url);
@@ -56,9 +75,69 @@ public class RestApiGetHandler {
             return apiMapper.map(mapping.getError());
         }
 
-        queryResults = runtime.queryService().execute(mapping.getQuery(), context.store());
+        if (lifecycle == null) {
+            RepositoryQueryResult queryResults =
+                    runtime.queryService().execute(mapping.getQuery(), context.store());
+            return advertiseQueryableCollections(route, apiMapper.map(url, queryResults));
+        }
 
-        ApiResponse response = apiMapper.map(url, queryResults);
+        lifecycle.useMappedReadQuery(mapping.getQuery());
+        lifecycleHooks.runBeforeValidationHooks(lifecycle);
+        if (lifecycle.shouldShortCircuit()) {
+            return lifecycle.apiResponse();
+        }
+
+        if (lifecycle.queryParamsWereReplaced() && !lifecycle.readQueryWasReplaced()) {
+            ThingReadRequestMapping remappedMapping =
+                    mapReadQuery(url, route, lifecycle.queryParams());
+            if (remappedMapping.isError()) {
+                return apiMapper.map(remappedMapping.getError());
+            }
+            lifecycle.useMappedReadQuery(remappedMapping.getQuery());
+        }
+
+        lifecycleHooks.runAfterValidationHooks(lifecycle);
+        if (lifecycle.shouldShortCircuit()) {
+            return lifecycle.apiResponse();
+        }
+
+        lifecycleHooks.runBeforeActionHooks(lifecycle);
+        if (lifecycle.shouldShortCircuit()) {
+            return lifecycle.apiResponse();
+        }
+
+        ThingReadQuery activeQuery = lifecycle.readQuery();
+        RepositoryQueryResult queryResults =
+                runtime.queryService().execute(activeQuery, context.store());
+        lifecycle.replaceReadQueryResult(queryResults);
+
+        ApiResponse response =
+                advertiseQueryableCollections(route, apiMapper.map(url, queryResults));
+        lifecycle.useApiResponse(response);
+        lifecycleHooks.runAfterActionHooks(lifecycle);
+
+        RepositoryQueryResult finalResult =
+                lifecycle.readQueryResult() == null ? queryResults : lifecycle.readQueryResult();
+        if (finalResult != queryResults && !lifecycle.apiResponseWasReplaced()) {
+            lifecycle.useApiResponse(
+                    advertiseQueryableCollections(route, apiMapper.map(url, finalResult)));
+        }
+        return lifecycle.apiResponse();
+    }
+
+    private ThingReadRequestMapping mapReadQuery(
+            final String url, final ThingRoute route, final QueryFilterParams queryParams) {
+        EffectiveQueryParams effectiveQueryParams =
+                EffectiveQueryParams.forGet(runtime.apiConfig(), route, queryParams, url);
+        if (effectiveQueryParams.isError()) {
+            return ThingReadRequestMapping.error(effectiveQueryParams.error());
+        }
+        return new ThingReadRequestMapper(runtime.schema())
+                .map(route, effectiveQueryParams.queryParams());
+    }
+
+    private ApiResponse advertiseQueryableCollections(
+            final ThingRoute route, final ApiResponse response) {
         if (route instanceof CollectionRoute || route instanceof RelationshipCollectionRoute) {
             response.setHeader(
                     ThingifierHttpApi.ACCEPT_QUERY_HEADER,

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiGetHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiGetHandler.java
@@ -20,18 +20,41 @@ import uk.co.compendiumdev.thingifier.application.query.ThingReadQuery;
 import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
 import uk.co.compendiumdev.thingifier.core.query.RepositoryQueryResult;
 
+/**
+ * Handles generated Thingifier GET routes.
+ *
+ * <p>The handler maps route and query parameters to a read query. When lifecycle hooks are active,
+ * hooks can replace query parameters or the mapped read query before execution and inspect or
+ * replace the repository result afterwards.
+ */
 public class RestApiGetHandler {
     private final ThingifierApiRuntime runtime;
     private final ThingifierApiLifecycleHookRegistry lifecycleHooks;
 
+    /**
+     * Creates a GET handler from a Thingifier model.
+     *
+     * @param aThingifier Thingifier model and configuration
+     */
     public RestApiGetHandler(final Thingifier aThingifier) {
         this(new DefaultThingifierApiRuntime(aThingifier));
     }
 
+    /**
+     * Creates a GET handler with no lifecycle hooks.
+     *
+     * @param runtime runtime services used by the handler
+     */
     public RestApiGetHandler(final ThingifierApiRuntime runtime) {
         this(runtime, new ThingifierApiLifecycleHookRegistry());
     }
 
+    /**
+     * Creates a GET handler with lifecycle hooks.
+     *
+     * @param runtime runtime services used by the handler
+     * @param lifecycleHooks lifecycle hooks for read processing
+     */
     public RestApiGetHandler(
             final ThingifierApiRuntime runtime,
             final ThingifierApiLifecycleHookRegistry lifecycleHooks) {
@@ -40,6 +63,14 @@ public class RestApiGetHandler {
                 lifecycleHooks == null ? new ThingifierApiLifecycleHookRegistry() : lifecycleHooks;
     }
 
+    /**
+     * Handles a GET request using raw headers to resolve context.
+     *
+     * @param url generated API path
+     * @param queryParams query filters to apply
+     * @param requestHeaders request headers used to resolve context
+     * @return API response for the GET
+     */
     public ApiResponse handle(
             final String url,
             final QueryFilterParams queryParams,
@@ -47,6 +78,14 @@ public class RestApiGetHandler {
         return handle(url, queryParams, runtime.contextFrom(requestHeaders));
     }
 
+    /**
+     * Handles a GET request without lifecycle hook state.
+     *
+     * @param url generated API path
+     * @param queryParams query filters to apply
+     * @param context request context containing the active store
+     * @return API response for the GET
+     */
     public ApiResponse handle(
             final String url,
             final QueryFilterParams queryParams,
@@ -54,6 +93,15 @@ public class RestApiGetHandler {
         return handle(url, queryParams, context, null);
     }
 
+    /**
+     * Handles a GET request with optional lifecycle hook state.
+     *
+     * @param url generated API path
+     * @param queryParams query filters to apply
+     * @param context request context containing the active store
+     * @param lifecycle lifecycle context, or null for direct processing
+     * @return API response for the GET
+     */
     public ApiResponse handle(
             final String url,
             final QueryFilterParams queryParams,
@@ -125,6 +173,14 @@ public class RestApiGetHandler {
         return lifecycle.apiResponse();
     }
 
+    /**
+     * Remaps a read query after hooks replace query parameters.
+     *
+     * @param url generated API path
+     * @param route mapped generated route
+     * @param queryParams replacement query filters
+     * @return mapped read request or mapping error
+     */
     private ThingReadRequestMapping mapReadQuery(
             final String url, final ThingRoute route, final QueryFilterParams queryParams) {
         EffectiveQueryParams effectiveQueryParams =
@@ -136,6 +192,13 @@ public class RestApiGetHandler {
                 .map(route, effectiveQueryParams.queryParams());
     }
 
+    /**
+     * Adds Accept-Query advertising to collection routes which can be queried.
+     *
+     * @param route mapped generated route
+     * @param response response to update
+     * @return same response with query advertising where applicable
+     */
     private ApiResponse advertiseQueryableCollections(
             final ThingRoute route, final ApiResponse response) {
         if (route instanceof CollectionRoute || route instanceof RelationshipCollectionRoute) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPatchHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPatchHandler.java
@@ -5,29 +5,38 @@ import java.util.Set;
 import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.DefaultThingifierApiRuntime;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.EntityPatchDocumentMapper;
-import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingCommandResultApiMapper;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingWriteRequestMapping;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierApiRuntime;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.WriteMethodPolicy;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.InstanceRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRouteMapper;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleContext;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleHookRegistry;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
 import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
 import uk.co.compendiumdev.thingifier.apiconfig.EntityPatchUpdateStyle;
-import uk.co.compendiumdev.thingifier.application.ThingCommandResult;
 
 public class RestApiPatchHandler {
     private final ThingifierApiRuntime runtime;
+    private final ThingifierApiLifecycleHookRegistry lifecycleHooks;
 
     public RestApiPatchHandler(final Thingifier aThingifier) {
         this(new DefaultThingifierApiRuntime(aThingifier));
     }
 
     public RestApiPatchHandler(final ThingifierApiRuntime runtime) {
+        this(runtime, new ThingifierApiLifecycleHookRegistry());
+    }
+
+    public RestApiPatchHandler(
+            final ThingifierApiRuntime runtime,
+            final ThingifierApiLifecycleHookRegistry lifecycleHooks) {
         this.runtime = runtime;
+        this.lifecycleHooks =
+                lifecycleHooks == null ? new ThingifierApiLifecycleHookRegistry() : lifecycleHooks;
     }
 
     public ApiResponse handle(
@@ -35,6 +44,15 @@ public class RestApiPatchHandler {
             final String rawBody,
             final HttpHeadersBlock requestHeaders,
             final ThingifierRequestContext context) {
+        return handle(url, rawBody, requestHeaders, context, null);
+    }
+
+    public ApiResponse handle(
+            final String url,
+            final String rawBody,
+            final HttpHeadersBlock requestHeaders,
+            final ThingifierRequestContext context,
+            final ThingifierApiLifecycleContext lifecycle) {
         ThingRoute route = new ThingRouteMapper(runtime.schema()).map(url);
         WriteMethodPolicy policy = new WriteMethodPolicy(runtime);
         ApiResponse policyResponse =
@@ -62,14 +80,20 @@ public class RestApiPatchHandler {
                                 style.orElse(EntityPatchUpdateStyle.PARTIAL_JSON_UPDATE),
                                 route,
                                 rawBody);
-        ThingCommandResultApiMapper apiMapper =
-                new ThingCommandResultApiMapper(runtime.apiConfig());
-        if (mapping.isError()) {
-            return apiMapper.map(mapping.getError());
-        }
+        return LifecycleWriteSupport.execute(
+                runtime,
+                lifecycleHooks,
+                lifecycle,
+                mapping,
+                context,
+                () ->
+                        new EntityPatchDocumentMapper(runtime.schema())
+                                .map(patchStyle(requestHeaders), route, lifecycle.rawBody()));
+    }
 
-        ThingCommandResult result = runtime.commandService(context).execute(mapping.getCommand());
-        return apiMapper.map(mapping, result);
+    private EntityPatchUpdateStyle patchStyle(final HttpHeadersBlock requestHeaders) {
+        return EntityPatchUpdateStyle.fromContentType(requestHeaders.get("Content-Type"))
+                .orElse(EntityPatchUpdateStyle.PARTIAL_JSON_UPDATE);
     }
 
     private ApiResponse unsupportedPatchContentType(

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPatchHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPatchHandler.java
@@ -19,18 +19,40 @@ import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
 import uk.co.compendiumdev.thingifier.apiconfig.EntityPatchUpdateStyle;
 
+/**
+ * Handles generated Thingifier PATCH routes.
+ *
+ * <p>The handler validates PATCH content type policy, maps the patch document to a write command,
+ * and delegates lifecycle-aware validation and execution.
+ */
 public class RestApiPatchHandler {
     private final ThingifierApiRuntime runtime;
     private final ThingifierApiLifecycleHookRegistry lifecycleHooks;
 
+    /**
+     * Creates a PATCH handler from a Thingifier model.
+     *
+     * @param aThingifier Thingifier model and configuration
+     */
     public RestApiPatchHandler(final Thingifier aThingifier) {
         this(new DefaultThingifierApiRuntime(aThingifier));
     }
 
+    /**
+     * Creates a PATCH handler with no lifecycle hooks.
+     *
+     * @param runtime runtime services used by the handler
+     */
     public RestApiPatchHandler(final ThingifierApiRuntime runtime) {
         this(runtime, new ThingifierApiLifecycleHookRegistry());
     }
 
+    /**
+     * Creates a PATCH handler with lifecycle hooks.
+     *
+     * @param runtime runtime services used by the handler
+     * @param lifecycleHooks lifecycle hooks for write processing
+     */
     public RestApiPatchHandler(
             final ThingifierApiRuntime runtime,
             final ThingifierApiLifecycleHookRegistry lifecycleHooks) {
@@ -39,6 +61,15 @@ public class RestApiPatchHandler {
                 lifecycleHooks == null ? new ThingifierApiLifecycleHookRegistry() : lifecycleHooks;
     }
 
+    /**
+     * Handles a PATCH request without lifecycle hook state.
+     *
+     * @param url generated API path
+     * @param rawBody raw patch body
+     * @param requestHeaders request headers used for content type policy
+     * @param context request context containing the active store
+     * @return API response for the PATCH
+     */
     public ApiResponse handle(
             final String url,
             final String rawBody,
@@ -47,6 +78,16 @@ public class RestApiPatchHandler {
         return handle(url, rawBody, requestHeaders, context, null);
     }
 
+    /**
+     * Handles a PATCH request with optional lifecycle hook state.
+     *
+     * @param url generated API path
+     * @param rawBody raw patch body
+     * @param requestHeaders request headers used for content type policy
+     * @param context request context containing the active store
+     * @param lifecycle lifecycle context, or null for direct processing
+     * @return API response for the PATCH
+     */
     public ApiResponse handle(
             final String url,
             final String rawBody,
@@ -91,11 +132,23 @@ public class RestApiPatchHandler {
                                 .map(patchStyle(requestHeaders), route, lifecycle.rawBody()));
     }
 
+    /**
+     * Resolves the PATCH update style from the request headers, defaulting to partial JSON update.
+     *
+     * @param requestHeaders request headers containing Content-Type
+     * @return selected patch style
+     */
     private EntityPatchUpdateStyle patchStyle(final HttpHeadersBlock requestHeaders) {
         return EntityPatchUpdateStyle.fromContentType(requestHeaders.get("Content-Type"))
                 .orElse(EntityPatchUpdateStyle.PARTIAL_JSON_UPDATE);
     }
 
+    /**
+     * Creates the standard response for unsupported PATCH media types.
+     *
+     * @param allowedStyles PATCH styles allowed by policy
+     * @return unsupported-media-type response with Accept-Patch header
+     */
     private ApiResponse unsupportedPatchContentType(
             final Set<EntityPatchUpdateStyle> allowedStyles) {
         return ApiResponse.error(415, "Unsupported PATCH Content Type")

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPostHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPostHandler.java
@@ -17,18 +17,40 @@ import uk.co.compendiumdev.thingifier.api.http.bodyparser.BodyParser;
 import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
 
+/**
+ * Handles generated Thingifier POST routes.
+ *
+ * <p>The handler maps the route and parsed body to a write command, checks declarative write
+ * policy, then delegates lifecycle-aware validation and execution to {@link LifecycleWriteSupport}.
+ */
 public class RestApiPostHandler {
     private final ThingifierApiRuntime runtime;
     private final ThingifierApiLifecycleHookRegistry lifecycleHooks;
 
+    /**
+     * Creates a POST handler from a Thingifier model.
+     *
+     * @param aThingifier Thingifier model and configuration
+     */
     public RestApiPostHandler(final Thingifier aThingifier) {
         this(new DefaultThingifierApiRuntime(aThingifier));
     }
 
+    /**
+     * Creates a POST handler with no lifecycle hooks.
+     *
+     * @param runtime runtime services used by the handler
+     */
     public RestApiPostHandler(final ThingifierApiRuntime runtime) {
         this(runtime, new ThingifierApiLifecycleHookRegistry());
     }
 
+    /**
+     * Creates a POST handler with lifecycle hooks.
+     *
+     * @param runtime runtime services used by the handler
+     * @param lifecycleHooks lifecycle hooks for write processing
+     */
     public RestApiPostHandler(
             final ThingifierApiRuntime runtime,
             final ThingifierApiLifecycleHookRegistry lifecycleHooks) {
@@ -37,16 +59,40 @@ public class RestApiPostHandler {
                 lifecycleHooks == null ? new ThingifierApiLifecycleHookRegistry() : lifecycleHooks;
     }
 
+    /**
+     * Handles a POST request using a body parser and raw headers.
+     *
+     * @param url generated API path
+     * @param args parsed body source
+     * @param requestHeaders request headers used to resolve context
+     * @return API response for the POST
+     */
     public ApiResponse handle(
             final String url, final BodyParser args, final HttpHeadersBlock requestHeaders) {
         return handle(url, args.bodyFields(), runtime.contextFrom(requestHeaders));
     }
 
+    /**
+     * Handles a POST request using a body parser and explicit request context.
+     *
+     * @param url generated API path
+     * @param args parsed body source
+     * @param context request context containing the active store
+     * @return API response for the POST
+     */
     public ApiResponse handle(
             final String url, final BodyParser args, final ThingifierRequestContext context) {
         return handle(url, args.bodyFields(), context);
     }
 
+    /**
+     * Handles a POST request without lifecycle hook state.
+     *
+     * @param url generated API path
+     * @param bodyFields parsed request body fields
+     * @param context request context containing the active store
+     * @return API response for the POST
+     */
     public ApiResponse handle(
             final String url,
             final ApiBodyFields bodyFields,
@@ -54,6 +100,15 @@ public class RestApiPostHandler {
         return handle(url, bodyFields, context, null);
     }
 
+    /**
+     * Handles a POST request with optional lifecycle hook state.
+     *
+     * @param url generated API path
+     * @param bodyFields parsed request body fields
+     * @param context request context containing the active store
+     * @param lifecycle lifecycle context, or null for direct processing
+     * @return API response for the POST
+     */
     public ApiResponse handle(
             final String url,
             final ApiBodyFields bodyFields,

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPostHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPostHandler.java
@@ -2,30 +2,39 @@ package uk.co.compendiumdev.thingifier.api.restapihandlers;
 
 import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.DefaultThingifierApiRuntime;
-import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingCommandResultApiMapper;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingWriteRequestMapper;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingWriteRequestMapping;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierApiRuntime;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.WriteMethodPolicy;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRouteMapper;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleContext;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleHookRegistry;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.BodyParser;
 import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
-import uk.co.compendiumdev.thingifier.application.ThingCommandResult;
 
 public class RestApiPostHandler {
     private final ThingifierApiRuntime runtime;
+    private final ThingifierApiLifecycleHookRegistry lifecycleHooks;
 
     public RestApiPostHandler(final Thingifier aThingifier) {
         this(new DefaultThingifierApiRuntime(aThingifier));
     }
 
     public RestApiPostHandler(final ThingifierApiRuntime runtime) {
+        this(runtime, new ThingifierApiLifecycleHookRegistry());
+    }
+
+    public RestApiPostHandler(
+            final ThingifierApiRuntime runtime,
+            final ThingifierApiLifecycleHookRegistry lifecycleHooks) {
         this.runtime = runtime;
+        this.lifecycleHooks =
+                lifecycleHooks == null ? new ThingifierApiLifecycleHookRegistry() : lifecycleHooks;
     }
 
     public ApiResponse handle(
@@ -42,6 +51,14 @@ public class RestApiPostHandler {
             final String url,
             final ApiBodyFields bodyFields,
             final ThingifierRequestContext context) {
+        return handle(url, bodyFields, context, null);
+    }
+
+    public ApiResponse handle(
+            final String url,
+            final ApiBodyFields bodyFields,
+            final ThingifierRequestContext context,
+            final ThingifierApiLifecycleContext lifecycle) {
         ThingRoute route = new ThingRouteMapper(runtime.schema()).map(url);
         ApiResponse policyResponse =
                 new WriteMethodPolicy(runtime)
@@ -52,13 +69,14 @@ public class RestApiPostHandler {
 
         ThingWriteRequestMapping mapping =
                 new ThingWriteRequestMapper(runtime.schema()).mapPost(route, bodyFields);
-        ThingCommandResultApiMapper apiMapper =
-                new ThingCommandResultApiMapper(runtime.apiConfig());
-        if (mapping.isError()) {
-            return apiMapper.map(mapping.getError());
-        }
-
-        ThingCommandResult result = runtime.commandService(context).execute(mapping.getCommand());
-        return apiMapper.map(mapping, result);
+        return LifecycleWriteSupport.execute(
+                runtime,
+                lifecycleHooks,
+                lifecycle,
+                mapping,
+                context,
+                () ->
+                        new ThingWriteRequestMapper(runtime.schema())
+                                .mapPost(route, lifecycle.bodyFields()));
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPostHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPostHandler.java
@@ -115,23 +115,26 @@ public class RestApiPostHandler {
             final ThingifierRequestContext context,
             final ThingifierApiLifecycleContext lifecycle) {
         ThingRoute route = new ThingRouteMapper(runtime.schema()).map(url);
+        WriteMethodPolicy writePolicy = new WriteMethodPolicy(runtime);
         ApiResponse policyResponse =
-                new WriteMethodPolicy(runtime)
-                        .rejectIfNotAllowed(RoutingVerb.POST, route, bodyFields, context);
+                writePolicy.rejectIfNotAllowed(RoutingVerb.POST, route, bodyFields, context);
         if (policyResponse != null) {
             return policyResponse;
         }
 
-        ThingWriteRequestMapping mapping =
-                new ThingWriteRequestMapper(runtime.schema()).mapPost(route, bodyFields);
+        ThingWriteRequestMapper mapper =
+                new ThingWriteRequestMapper(
+                        runtime.schema(),
+                        runtime.apiConfig().writeMethods().entities(),
+                        writePolicy.relationshipOperationsFor(RoutingVerb.POST, route),
+                        context);
+        ThingWriteRequestMapping mapping = mapper.mapPost(route, bodyFields);
         return LifecycleWriteSupport.execute(
                 runtime,
                 lifecycleHooks,
                 lifecycle,
                 mapping,
                 context,
-                () ->
-                        new ThingWriteRequestMapper(runtime.schema())
-                                .mapPost(route, lifecycle.bodyFields()));
+                () -> mapper.mapPost(route, lifecycle.bodyFields()));
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPutHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPutHandler.java
@@ -17,18 +17,40 @@ import uk.co.compendiumdev.thingifier.api.http.bodyparser.BodyParser;
 import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
 
+/**
+ * Handles generated Thingifier PUT routes.
+ *
+ * <p>The handler maps PUT into a create or update command according to identifier policy, checks
+ * declarative write policy, then delegates lifecycle-aware validation and execution.
+ */
 public class RestApiPutHandler {
     private final ThingifierApiRuntime runtime;
     private final ThingifierApiLifecycleHookRegistry lifecycleHooks;
 
+    /**
+     * Creates a PUT handler from a Thingifier model.
+     *
+     * @param aThingifier Thingifier model and configuration
+     */
     public RestApiPutHandler(final Thingifier aThingifier) {
         this(new DefaultThingifierApiRuntime(aThingifier));
     }
 
+    /**
+     * Creates a PUT handler with no lifecycle hooks.
+     *
+     * @param runtime runtime services used by the handler
+     */
     public RestApiPutHandler(final ThingifierApiRuntime runtime) {
         this(runtime, new ThingifierApiLifecycleHookRegistry());
     }
 
+    /**
+     * Creates a PUT handler with lifecycle hooks.
+     *
+     * @param runtime runtime services used by the handler
+     * @param lifecycleHooks lifecycle hooks for write processing
+     */
     public RestApiPutHandler(
             final ThingifierApiRuntime runtime,
             final ThingifierApiLifecycleHookRegistry lifecycleHooks) {
@@ -37,16 +59,40 @@ public class RestApiPutHandler {
                 lifecycleHooks == null ? new ThingifierApiLifecycleHookRegistry() : lifecycleHooks;
     }
 
+    /**
+     * Handles a PUT request using a body parser and raw headers.
+     *
+     * @param url generated API path
+     * @param args parsed body source
+     * @param requestHeaders request headers used to resolve context
+     * @return API response for the PUT
+     */
     public ApiResponse handle(
             final String url, final BodyParser args, final HttpHeadersBlock requestHeaders) {
         return handle(url, args.bodyFields(), runtime.contextFrom(requestHeaders));
     }
 
+    /**
+     * Handles a PUT request using a body parser and explicit request context.
+     *
+     * @param url generated API path
+     * @param args parsed body source
+     * @param context request context containing the active store
+     * @return API response for the PUT
+     */
     public ApiResponse handle(
             final String url, final BodyParser args, final ThingifierRequestContext context) {
         return handle(url, args.bodyFields(), context);
     }
 
+    /**
+     * Handles a PUT request without lifecycle hook state.
+     *
+     * @param url generated API path
+     * @param bodyFields parsed request body fields
+     * @param context request context containing the active store
+     * @return API response for the PUT
+     */
     public ApiResponse handle(
             final String url,
             final ApiBodyFields bodyFields,
@@ -54,6 +100,15 @@ public class RestApiPutHandler {
         return handle(url, bodyFields, context, null);
     }
 
+    /**
+     * Handles a PUT request with optional lifecycle hook state.
+     *
+     * @param url generated API path
+     * @param bodyFields parsed request body fields
+     * @param context request context containing the active store
+     * @param lifecycle lifecycle context, or null for direct processing
+     * @return API response for the PUT
+     */
     public ApiResponse handle(
             final String url,
             final ApiBodyFields bodyFields,

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPutHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPutHandler.java
@@ -2,30 +2,39 @@ package uk.co.compendiumdev.thingifier.api.restapihandlers;
 
 import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.DefaultThingifierApiRuntime;
-import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingCommandResultApiMapper;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingWriteRequestMapper;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingWriteRequestMapping;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierApiRuntime;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.WriteMethodPolicy;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRouteMapper;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleContext;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleHookRegistry;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.BodyParser;
 import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
-import uk.co.compendiumdev.thingifier.application.ThingCommandResult;
 
 public class RestApiPutHandler {
     private final ThingifierApiRuntime runtime;
+    private final ThingifierApiLifecycleHookRegistry lifecycleHooks;
 
     public RestApiPutHandler(final Thingifier aThingifier) {
         this(new DefaultThingifierApiRuntime(aThingifier));
     }
 
     public RestApiPutHandler(final ThingifierApiRuntime runtime) {
+        this(runtime, new ThingifierApiLifecycleHookRegistry());
+    }
+
+    public RestApiPutHandler(
+            final ThingifierApiRuntime runtime,
+            final ThingifierApiLifecycleHookRegistry lifecycleHooks) {
         this.runtime = runtime;
+        this.lifecycleHooks =
+                lifecycleHooks == null ? new ThingifierApiLifecycleHookRegistry() : lifecycleHooks;
     }
 
     public ApiResponse handle(
@@ -42,6 +51,14 @@ public class RestApiPutHandler {
             final String url,
             final ApiBodyFields bodyFields,
             final ThingifierRequestContext context) {
+        return handle(url, bodyFields, context, null);
+    }
+
+    public ApiResponse handle(
+            final String url,
+            final ApiBodyFields bodyFields,
+            final ThingifierRequestContext context,
+            final ThingifierApiLifecycleContext lifecycle) {
         ThingRoute route = new ThingRouteMapper(runtime.schema()).map(url);
         ApiResponse policyResponse =
                 new WriteMethodPolicy(runtime)
@@ -54,13 +71,16 @@ public class RestApiPutHandler {
                 new ThingWriteRequestMapper(
                                 runtime.schema(), runtime.apiConfig().writeMethods().entities())
                         .mapPut(route, bodyFields);
-        ThingCommandResultApiMapper apiMapper =
-                new ThingCommandResultApiMapper(runtime.apiConfig());
-        if (mapping.isError()) {
-            return apiMapper.map(mapping.getError());
-        }
-
-        ThingCommandResult result = runtime.commandService(context).execute(mapping.getCommand());
-        return apiMapper.map(mapping, result);
+        return LifecycleWriteSupport.execute(
+                runtime,
+                lifecycleHooks,
+                lifecycle,
+                mapping,
+                context,
+                () ->
+                        new ThingWriteRequestMapper(
+                                        runtime.schema(),
+                                        runtime.apiConfig().writeMethods().entities())
+                                .mapPut(route, lifecycle.bodyFields()));
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandler.java
@@ -11,6 +11,8 @@ import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.Relationshi
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.RelationshipInstanceRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRouteMapper;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleContext;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleHookRegistry;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.api.ermodelconversion.JsonThing;
 import uk.co.compendiumdev.thingifier.api.http.ApiRequestEnvelope;
@@ -26,9 +28,18 @@ import uk.co.compendiumdev.thingifier.core.query.RepositoryQueryResult;
 public final class RestApiQueryHandler {
 
     private final ThingifierApiRuntime runtime;
+    private final ThingifierApiLifecycleHookRegistry lifecycleHooks;
 
     public RestApiQueryHandler(final ThingifierApiRuntime runtime) {
+        this(runtime, new ThingifierApiLifecycleHookRegistry());
+    }
+
+    public RestApiQueryHandler(
+            final ThingifierApiRuntime runtime,
+            final ThingifierApiLifecycleHookRegistry lifecycleHooks) {
         this.runtime = runtime;
+        this.lifecycleHooks =
+                lifecycleHooks == null ? new ThingifierApiLifecycleHookRegistry() : lifecycleHooks;
     }
 
     public ApiResponse handle(
@@ -45,6 +56,16 @@ public final class RestApiQueryHandler {
             final ApiRequestEnvelope.QueryBodyFormat queryBodyFormat,
             final String queryBody,
             final ThingifierRequestContext context) {
+        return handle(url, queryParams, queryBodyFormat, queryBody, context, null);
+    }
+
+    public ApiResponse handle(
+            final String url,
+            final QueryFilterParams queryParams,
+            final ApiRequestEnvelope.QueryBodyFormat queryBodyFormat,
+            final String queryBody,
+            final ThingifierRequestContext context,
+            final ThingifierApiLifecycleContext lifecycle) {
         ThingReadResultApiMapper apiMapper = new ThingReadResultApiMapper(runtime.apiConfig());
         ThingRoute route = new ThingRouteMapper(runtime.schema()).map(url);
 
@@ -62,12 +83,88 @@ public final class RestApiQueryHandler {
                             404, String.format("Could not find an instance with %s", url)));
         }
 
+        QueryMapping mapping = mapQuery(route, queryParams, queryBodyFormat, queryBody, apiMapper);
+        if (mapping.response != null) {
+            return mapping.response;
+        }
+
+        if (lifecycle == null) {
+            return executeMappedQuery(url, mapping, queryBodyFormat, queryBody, context, apiMapper);
+        }
+
+        lifecycle.useMappedReadQuery(mapping.mapping.getQuery());
+        lifecycleHooks.runBeforeValidationHooks(lifecycle);
+        if (lifecycle.shouldShortCircuit()) {
+            return lifecycle.apiResponse();
+        }
+
+        if (shouldRemapQuery(lifecycle)) {
+            QueryMapping remappedMapping =
+                    mapQuery(
+                            route,
+                            lifecycle.queryParams(),
+                            lifecycle.queryBodyFormat(),
+                            lifecycle.rawBody(),
+                            apiMapper);
+            if (remappedMapping.response != null) {
+                return remappedMapping.response;
+            }
+            lifecycle.useMappedReadQuery(remappedMapping.mapping.getQuery());
+        }
+
+        lifecycleHooks.runAfterValidationHooks(lifecycle);
+        if (lifecycle.shouldShortCircuit()) {
+            return lifecycle.apiResponse();
+        }
+
+        lifecycleHooks.runBeforeActionHooks(lifecycle);
+        if (lifecycle.shouldShortCircuit()) {
+            return lifecycle.apiResponse();
+        }
+
+        RepositoryQueryResult queryResults =
+                runtime.queryService().execute(lifecycle.readQuery(), context.store(), false);
+        lifecycle.replaceReadQueryResult(queryResults);
+
+        ApiResponse response =
+                responseForQuery(
+                        url,
+                        lifecycle.queryBodyFormat(),
+                        lifecycle.rawBody(),
+                        queryResults,
+                        context,
+                        apiMapper);
+        lifecycle.useApiResponse(response);
+        lifecycleHooks.runAfterActionHooks(lifecycle);
+
+        RepositoryQueryResult finalResult =
+                lifecycle.readQueryResult() == null ? queryResults : lifecycle.readQueryResult();
+        if (finalResult != queryResults && !lifecycle.apiResponseWasReplaced()) {
+            lifecycle.useApiResponse(
+                    responseForQuery(
+                            url,
+                            lifecycle.queryBodyFormat(),
+                            lifecycle.rawBody(),
+                            finalResult,
+                            context,
+                            apiMapper));
+        }
+        return lifecycle.apiResponse();
+    }
+
+    private QueryMapping mapQuery(
+            final ThingRoute route,
+            final QueryFilterParams queryParams,
+            final ApiRequestEnvelope.QueryBodyFormat queryBodyFormat,
+            final String queryBody,
+            final ThingReadResultApiMapper apiMapper) {
         QueryFilterParams requestedQueryParams = queryParams;
         if (queryBodyFormat == ApiRequestEnvelope.QueryBodyFormat.STRUCTURED_JSON) {
             StructuredJsonQueryCompiler.Result structuredQuery =
                     StructuredJsonQueryCompiler.compile(queryBody, resultEntityFor(route));
             if (structuredQuery.isError()) {
-                return advertiseQuery(apiMapper.map(structuredQuery.error()));
+                return QueryMapping.response(
+                        advertiseQuery(apiMapper.map(structuredQuery.error())));
             }
             requestedQueryParams = combine(queryParams, structuredQuery.queryParams());
         }
@@ -75,18 +172,37 @@ public final class RestApiQueryHandler {
         EffectiveQueryParams effectiveQueryParams =
                 EffectiveQueryParams.forQuery(runtime.apiConfig(), route, requestedQueryParams);
         if (effectiveQueryParams.isError()) {
-            return apiMapper.map(effectiveQueryParams.error());
+            return QueryMapping.response(apiMapper.map(effectiveQueryParams.error()));
         }
 
         ThingReadRequestMapping mapping =
                 new ThingReadRequestMapper(runtime.schema())
                         .map(route, effectiveQueryParams.queryParams());
         if (mapping.isError()) {
-            return apiMapper.map(mapping.getError());
+            return QueryMapping.response(apiMapper.map(mapping.getError()));
         }
+        return QueryMapping.mapping(mapping);
+    }
 
+    private ApiResponse executeMappedQuery(
+            final String url,
+            final QueryMapping mapping,
+            final ApiRequestEnvelope.QueryBodyFormat queryBodyFormat,
+            final String queryBody,
+            final ThingifierRequestContext context,
+            final ThingReadResultApiMapper apiMapper) {
         RepositoryQueryResult queryResults =
-                runtime.queryService().execute(mapping.getQuery(), context.store(), false);
+                runtime.queryService().execute(mapping.mapping.getQuery(), context.store(), false);
+        return responseForQuery(url, queryBodyFormat, queryBody, queryResults, context, apiMapper);
+    }
+
+    private ApiResponse responseForQuery(
+            final String url,
+            final ApiRequestEnvelope.QueryBodyFormat queryBodyFormat,
+            final String queryBody,
+            final RepositoryQueryResult queryResults,
+            final ThingifierRequestContext context,
+            final ThingReadResultApiMapper apiMapper) {
         ApiResponse response = apiMapper.map(url, queryResults);
         if (response.isErrorResponse()) {
             return advertiseQuery(response);
@@ -100,6 +216,13 @@ public final class RestApiQueryHandler {
         }
 
         return advertiseQuery(response);
+    }
+
+    private boolean shouldRemapQuery(final ThingifierApiLifecycleContext lifecycle) {
+        return (lifecycle.queryParamsWereReplaced()
+                        || lifecycle.rawBodyWasReplaced()
+                        || lifecycle.queryBodyFormatWasReplaced())
+                && !lifecycle.readQueryWasReplaced();
     }
 
     private ApiResponse methodNotAllowed(final String allowHeader) {
@@ -164,5 +287,24 @@ public final class RestApiQueryHandler {
         return response.setHeader(
                 ThingifierHttpApi.ACCEPT_QUERY_HEADER,
                 ThingifierHttpApi.SUPPORTED_QUERY_CONTENT_TYPES);
+    }
+
+    private static final class QueryMapping {
+
+        private final ThingReadRequestMapping mapping;
+        private final ApiResponse response;
+
+        private QueryMapping(final ThingReadRequestMapping mapping, final ApiResponse response) {
+            this.mapping = mapping;
+            this.response = response;
+        }
+
+        private static QueryMapping mapping(final ThingReadRequestMapping mapping) {
+            return new QueryMapping(mapping, null);
+        }
+
+        private static QueryMapping response(final ApiResponse response) {
+            return new QueryMapping(null, response);
+        }
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandler.java
@@ -239,8 +239,12 @@ public final class RestApiQueryHandler {
 
         final EntityDefinition entity = response.getTypeOfThingReturned();
         return runtime.apiSpec()
-                .ruleFor(RoutingVerb.QUERY, url, runtime.apiConfig().getApiEndPointPrefix())
-                .map(rule -> rule.responseEntityViewFor(response.getStatusCode()))
+                .responseEntityViewFor(
+                        RoutingVerb.QUERY,
+                        url,
+                        runtime.apiConfig().getApiEndPointPrefix(),
+                        entity,
+                        response.getStatusCode())
                 .filter(entity::hasViewNamed)
                 .map(entity::getViewNamed)
                 .orElse(null);

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandler.java
@@ -25,15 +25,33 @@ import uk.co.compendiumdev.thingifier.core.domain.definitions.relationship.Relat
 import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
 import uk.co.compendiumdev.thingifier.core.query.RepositoryQueryResult;
 
+/**
+ * Handles Thingifier QUERY operations for collection and relationship collection routes.
+ *
+ * <p>QUERY supports URL-encoded filters, structured JSON queries, and JSONPath filtering. The
+ * handler also participates in lifecycle hooks so callers can inspect or replace the mapped read
+ * query before it reaches the query service.
+ */
 public final class RestApiQueryHandler {
 
     private final ThingifierApiRuntime runtime;
     private final ThingifierApiLifecycleHookRegistry lifecycleHooks;
 
+    /**
+     * Creates a query handler with no lifecycle hooks.
+     *
+     * @param runtime runtime services used to map and execute queries
+     */
     public RestApiQueryHandler(final ThingifierApiRuntime runtime) {
         this(runtime, new ThingifierApiLifecycleHookRegistry());
     }
 
+    /**
+     * Creates a query handler with lifecycle hooks.
+     *
+     * @param runtime runtime services used to map and execute queries
+     * @param lifecycleHooks lifecycle hooks for validation and action phases
+     */
     public RestApiQueryHandler(
             final ThingifierApiRuntime runtime,
             final ThingifierApiLifecycleHookRegistry lifecycleHooks) {
@@ -42,6 +60,14 @@ public final class RestApiQueryHandler {
                 lifecycleHooks == null ? new ThingifierApiLifecycleHookRegistry() : lifecycleHooks;
     }
 
+    /**
+     * Handles a URL-encoded query using direct-call arguments.
+     *
+     * @param url generated API path
+     * @param queryParams query filters to apply
+     * @param context request context containing the active store
+     * @return API response for the query
+     */
     public ApiResponse handle(
             final String url,
             final QueryFilterParams queryParams,
@@ -50,6 +76,16 @@ public final class RestApiQueryHandler {
                 url, queryParams, ApiRequestEnvelope.QueryBodyFormat.URL_ENCODED, "", context);
     }
 
+    /**
+     * Handles a query without lifecycle hook state.
+     *
+     * @param url generated API path
+     * @param queryParams URI query filters
+     * @param queryBodyFormat body format selected from content type
+     * @param queryBody raw query body
+     * @param context request context containing the active store
+     * @return API response for the query
+     */
     public ApiResponse handle(
             final String url,
             final QueryFilterParams queryParams,
@@ -59,6 +95,21 @@ public final class RestApiQueryHandler {
         return handle(url, queryParams, queryBodyFormat, queryBody, context, null);
     }
 
+    /**
+     * Handles a query with optional lifecycle hook state.
+     *
+     * <p>When lifecycle state is present, hooks can replace query params, raw body, query format,
+     * or the mapped read query before execution, then inspect or replace the query result
+     * afterwards.
+     *
+     * @param url generated API path
+     * @param queryParams URI query filters
+     * @param queryBodyFormat body format selected from content type
+     * @param queryBody raw query body
+     * @param context request context containing the active store
+     * @param lifecycle lifecycle context, or null for direct processing
+     * @return API response for the query
+     */
     public ApiResponse handle(
             final String url,
             final QueryFilterParams queryParams,
@@ -152,6 +203,19 @@ public final class RestApiQueryHandler {
         return lifecycle.apiResponse();
     }
 
+    /**
+     * Maps request query data into a Thingifier read request.
+     *
+     * <p>Structured JSON query bodies are compiled into query params before normal effective-query
+     * processing so the rest of the mapper pipeline can remain shared.
+     *
+     * @param route mapped generated route
+     * @param queryParams URI or merged query filters
+     * @param queryBodyFormat body format selected from content type
+     * @param queryBody raw query body
+     * @param apiMapper mapper used to convert mapping errors to API responses
+     * @return query mapping or early API response
+     */
     private QueryMapping mapQuery(
             final ThingRoute route,
             final QueryFilterParams queryParams,
@@ -184,6 +248,17 @@ public final class RestApiQueryHandler {
         return QueryMapping.mapping(mapping);
     }
 
+    /**
+     * Executes a mapped query when no lifecycle hook can replace it.
+     *
+     * @param url generated API path
+     * @param mapping mapped read request
+     * @param queryBodyFormat body format selected from content type
+     * @param queryBody raw query body
+     * @param context request context containing the active store
+     * @param apiMapper mapper used to convert query results to API responses
+     * @return API response for the executed query
+     */
     private ApiResponse executeMappedQuery(
             final String url,
             final QueryMapping mapping,
@@ -196,6 +271,20 @@ public final class RestApiQueryHandler {
         return responseForQuery(url, queryBodyFormat, queryBody, queryResults, context, apiMapper);
     }
 
+    /**
+     * Converts query results to an API response and applies query response features.
+     *
+     * <p>JSONPath filtering happens after entity response view selection so JSONPath sees the
+     * public response shape rather than fields hidden by configured views.
+     *
+     * @param url generated API path
+     * @param queryBodyFormat body format selected from content type
+     * @param queryBody raw query body
+     * @param queryResults repository query result
+     * @param context request context containing the active store
+     * @param apiMapper mapper used to convert query results to API responses
+     * @return API response with QUERY advertising headers
+     */
     private ApiResponse responseForQuery(
             final String url,
             final ApiRequestEnvelope.QueryBodyFormat queryBodyFormat,
@@ -218,6 +307,12 @@ public final class RestApiQueryHandler {
         return advertiseQuery(response);
     }
 
+    /**
+     * Reports whether hook mutations require query remapping.
+     *
+     * @param lifecycle lifecycle context after before-validation hooks
+     * @return true when request data changed but the mapped read query was not explicitly replaced
+     */
     private boolean shouldRemapQuery(final ThingifierApiLifecycleContext lifecycle) {
         return (lifecycle.queryParamsWereReplaced()
                         || lifecycle.rawBodyWasReplaced()
@@ -225,10 +320,23 @@ public final class RestApiQueryHandler {
                 && !lifecycle.readQueryWasReplaced();
     }
 
+    /**
+     * Creates the standard 405 response for routes where QUERY is not meaningful.
+     *
+     * @param allowHeader value to expose in the Allow header
+     * @return method-not-allowed response
+     */
     private ApiResponse methodNotAllowed(final String allowHeader) {
         return ApiResponse.error(405, "Method Not Allowed").setHeader("Allow", allowHeader);
     }
 
+    /**
+     * Resolves the response view that should be applied before JSONPath filtering.
+     *
+     * @param url generated API path
+     * @param response mapped query response
+     * @return entity view to apply during filtering, or null
+     */
     private EntityViewDefinition responseViewFor(final String url, final ApiResponse response) {
         if (response == null
                 || response.isErrorResponse()
@@ -250,6 +358,13 @@ public final class RestApiQueryHandler {
                 .orElse(null);
     }
 
+    /**
+     * Combines two query parameter sets while preserving both sources.
+     *
+     * @param first first query parameter set
+     * @param second second query parameter set
+     * @return combined query parameters
+     */
     private QueryFilterParams combine(
             final QueryFilterParams first, final QueryFilterParams second) {
         QueryFilterParams combined = new QueryFilterParams();
@@ -258,6 +373,12 @@ public final class RestApiQueryHandler {
         return combined;
     }
 
+    /**
+     * Resolves the entity type that a QUERY route returns.
+     *
+     * @param route mapped collection or relationship collection route
+     * @return result entity definition, or null when the route cannot be resolved
+     */
     private EntityDefinition resultEntityFor(final ThingRoute route) {
         if (route instanceof CollectionRoute) {
             return runtime.schema()
@@ -287,6 +408,12 @@ public final class RestApiQueryHandler {
         return null;
     }
 
+    /**
+     * Adds supported QUERY media type information to the response.
+     *
+     * @param response response to update
+     * @return same response with Accept-Query header set
+     */
     private ApiResponse advertiseQuery(final ApiResponse response) {
         return response.setHeader(
                 ThingifierHttpApi.ACCEPT_QUERY_HEADER,
@@ -298,15 +425,33 @@ public final class RestApiQueryHandler {
         private final ThingReadRequestMapping mapping;
         private final ApiResponse response;
 
+        /**
+         * Creates a query mapping value that holds either a mapped request or an early response.
+         *
+         * @param mapping mapped read request, or null when response is populated
+         * @param response early API response, or null when mapping is populated
+         */
         private QueryMapping(final ThingReadRequestMapping mapping, final ApiResponse response) {
             this.mapping = mapping;
             this.response = response;
         }
 
+        /**
+         * Creates a successful query mapping.
+         *
+         * @param mapping mapped read request
+         * @return query mapping wrapper
+         */
         private static QueryMapping mapping(final ThingReadRequestMapping mapping) {
             return new QueryMapping(mapping, null);
         }
 
+        /**
+         * Creates a query mapping result that should immediately return a response.
+         *
+         * @param response API response to return
+         * @return query mapping wrapper containing the response
+         */
         private static QueryMapping response(final ApiResponse response) {
             return new QueryMapping(null, response);
         }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/SecuritySchemeNames.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/SecuritySchemeNames.java
@@ -1,0 +1,29 @@
+package uk.co.compendiumdev.thingifier.api.security;
+
+/**
+ * Normalizes and validates public Thingifier API security scheme names.
+ *
+ * <p>OpenAPI security scheme names are map keys, so accepting blank names would create confusing
+ * documentation and runtime lookup behaviour.
+ */
+public final class SecuritySchemeNames {
+
+    /** Default OpenAPI scheme name used by the historical no-argument bearer marker. */
+    public static final String DEFAULT_BEARER_AUTH_SCHEME = "bearerAuth";
+
+    private SecuritySchemeNames() {}
+
+    /**
+     * Validates and trims a security scheme name.
+     *
+     * @param schemeName caller supplied scheme name
+     * @return trimmed scheme name
+     * @throws IllegalArgumentException when the scheme name is null or blank
+     */
+    public static String requireValid(final String schemeName) {
+        if (schemeName == null || schemeName.trim().isEmpty()) {
+            throw new IllegalArgumentException("security scheme name is required");
+        }
+        return schemeName.trim();
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthenticationContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthenticationContext.java
@@ -1,0 +1,202 @@
+package uk.co.compendiumdev.thingifier.api.security;
+
+import java.util.Map;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
+import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
+import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
+
+/**
+ * Request details supplied to a Thingifier API authenticator.
+ *
+ * <p>The context gives authentication code enough information to resolve a token against the active
+ * store/session without exposing mutable request-processing internals.
+ */
+public final class ThingifierApiAuthenticationContext {
+
+    private final String schemeName;
+    private final RoutingVerb verb;
+    private final String path;
+    private final Map<String, String> pathParameters;
+    private final ThingRoute route;
+    private final HttpHeadersBlock headers;
+    private final ThingifierRequestContext requestContext;
+    private final String bearerToken;
+    private final EntityDefinition targetEntity;
+    private final String targetIdentifier;
+    private final EntityDefinition parentEntity;
+    private final String parentIdentifier;
+    private final String relationshipName;
+    private final String childIdentifier;
+
+    /**
+     * Creates an immutable authentication context.
+     *
+     * @param details reusable route and request details
+     * @param bearerToken parsed bearer token from the Authorization header
+     */
+    public ThingifierApiAuthenticationContext(
+            final ThingifierApiRouteAuthDetails details, final String bearerToken) {
+        this.schemeName = details.schemeName();
+        this.verb = details.verb();
+        this.path = details.path();
+        this.pathParameters = details.pathParameters();
+        this.route = details.route();
+        this.headers = details.headers();
+        this.requestContext = details.requestContext();
+        this.bearerToken = bearerToken == null ? "" : bearerToken;
+        this.targetEntity = details.targetEntity();
+        this.targetIdentifier = details.targetIdentifier();
+        this.parentEntity = details.parentEntity();
+        this.parentIdentifier = details.parentIdentifier();
+        this.relationshipName = details.relationshipName();
+        this.childIdentifier = details.childIdentifier();
+    }
+
+    /**
+     * Returns the security scheme name that selected the authenticator.
+     *
+     * @return security scheme name
+     */
+    public String schemeName() {
+        return schemeName;
+    }
+
+    /**
+     * Returns the generated API verb being processed.
+     *
+     * @return routing verb
+     */
+    public RoutingVerb verb() {
+        return verb;
+    }
+
+    /**
+     * Returns the generated API path for the request.
+     *
+     * @return request path
+     */
+    public String path() {
+        return path;
+    }
+
+    /**
+     * Returns named path parameters extracted from the matched API spec pattern.
+     *
+     * @return immutable path-parameter map
+     */
+    public Map<String, String> pathParameters() {
+        return pathParameters;
+    }
+
+    /**
+     * Returns one named path parameter.
+     *
+     * @param name parameter name
+     * @return parameter value, or an empty string when it was not present
+     */
+    public String pathParameter(final String name) {
+        return pathParameters.getOrDefault(name, "");
+    }
+
+    /**
+     * Returns the mapped generated route.
+     *
+     * @return route abstraction
+     */
+    public ThingRoute route() {
+        return route;
+    }
+
+    /**
+     * Returns request headers.
+     *
+     * @return request header block
+     */
+    public HttpHeadersBlock headers() {
+        return headers;
+    }
+
+    /**
+     * Returns the active request context.
+     *
+     * @return request context with store/session information
+     */
+    public ThingifierRequestContext requestContext() {
+        return requestContext;
+    }
+
+    /**
+     * Returns the active Thingifier store.
+     *
+     * @return request store
+     */
+    public ThingStore store() {
+        return requestContext.store();
+    }
+
+    /**
+     * Returns the parsed bearer token.
+     *
+     * @return bearer token without the Authorization scheme prefix
+     */
+    public String bearerToken() {
+        return bearerToken;
+    }
+
+    /**
+     * Returns the target entity for entity or relationship routes.
+     *
+     * @return target entity, or null when no entity route matched
+     */
+    public EntityDefinition targetEntity() {
+        return targetEntity;
+    }
+
+    /**
+     * Returns the target identifier for instance routes.
+     *
+     * @return target identifier, or null for collection routes
+     */
+    public String targetIdentifier() {
+        return targetIdentifier;
+    }
+
+    /**
+     * Returns the parent entity for relationship routes.
+     *
+     * @return parent entity, or null for entity routes
+     */
+    public EntityDefinition parentEntity() {
+        return parentEntity;
+    }
+
+    /**
+     * Returns the parent identifier for relationship routes.
+     *
+     * @return parent identifier, or null for entity routes
+     */
+    public String parentIdentifier() {
+        return parentIdentifier;
+    }
+
+    /**
+     * Returns the relationship name for relationship routes.
+     *
+     * @return relationship name, or null for entity routes
+     */
+    public String relationshipName() {
+        return relationshipName;
+    }
+
+    /**
+     * Returns the child identifier for relationship instance routes.
+     *
+     * @return child identifier, or null when the route has no child
+     */
+    public String childIdentifier() {
+        return childIdentifier;
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthenticationResult.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthenticationResult.java
@@ -1,0 +1,104 @@
+package uk.co.compendiumdev.thingifier.api.security;
+
+import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
+
+/**
+ * Result returned by an application authenticator.
+ *
+ * <p>The result either supplies a principal for later authorization or an API response explaining
+ * why the credentials cannot be accepted. Thingifier supplies the standard missing and malformed
+ * bearer-token responses before invoking authenticators.
+ */
+public final class ThingifierApiAuthenticationResult {
+
+    private final boolean authenticated;
+    private final Object principal;
+    private final ApiResponse rejectionResponse;
+
+    private ThingifierApiAuthenticationResult(
+            final boolean authenticated,
+            final Object principal,
+            final ApiResponse rejectionResponse) {
+        this.authenticated = authenticated;
+        this.principal = principal;
+        this.rejectionResponse = rejectionResponse;
+    }
+
+    /**
+     * Creates a successful authentication result.
+     *
+     * @param principal application principal, token record, user id, or other caller-owned object
+     * @return successful authentication result
+     */
+    public static ThingifierApiAuthenticationResult authenticated(final Object principal) {
+        return new ThingifierApiAuthenticationResult(true, principal, null);
+    }
+
+    /**
+     * Creates a successful authentication result without a principal object.
+     *
+     * @return successful authentication result
+     */
+    public static ThingifierApiAuthenticationResult authenticated() {
+        return authenticated(null);
+    }
+
+    /**
+     * Creates a 401 authentication rejection with a message.
+     *
+     * @param message message to render in the error body
+     * @return rejected authentication result
+     */
+    public static ThingifierApiAuthenticationResult rejected(final String message) {
+        return rejected(401, message);
+    }
+
+    /**
+     * Creates an authentication rejection with a status and message.
+     *
+     * @param status status code to return
+     * @param message message to render in the error body
+     * @return rejected authentication result
+     */
+    public static ThingifierApiAuthenticationResult rejected(
+            final int status, final String message) {
+        return rejected(ApiResponse.error(status, message));
+    }
+
+    /**
+     * Creates an authentication rejection with a complete response.
+     *
+     * @param response response to return instead of continuing request processing
+     * @return rejected authentication result
+     */
+    public static ThingifierApiAuthenticationResult rejected(final ApiResponse response) {
+        return new ThingifierApiAuthenticationResult(false, null, response);
+    }
+
+    /**
+     * Reports whether the request was authenticated.
+     *
+     * @return true when a principal may be trusted by authorizers
+     */
+    public boolean isAuthenticated() {
+        return authenticated;
+    }
+
+    /**
+     * Returns the application principal supplied by the authenticator.
+     *
+     * @return principal object, or null when the authenticator did not need one
+     */
+    public Object principal() {
+        return principal;
+    }
+
+    /**
+     * Returns the rejection response for a failed authentication.
+     *
+     * @return API response to return, or null when authentication succeeded
+     */
+    public ApiResponse rejectionResponse() {
+        return rejectionResponse;
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthenticator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthenticator.java
@@ -1,0 +1,20 @@
+package uk.co.compendiumdev.thingifier.api.security;
+
+/**
+ * Authenticates credentials supplied to a protected Thingifier API route.
+ *
+ * <p>Thingifier owns the generic HTTP bearer flow and calls this interface only after a bearer
+ * token has been found in the {@code Authorization} header. Applications keep their token lookup,
+ * expiry, and principal creation logic outside the library by implementing this callback.
+ */
+@FunctionalInterface
+public interface ThingifierApiAuthenticator {
+
+    /**
+     * Authenticates the bearer token for the configured security scheme.
+     *
+     * @param context request and route details for the authentication decision
+     * @return authentication result describing the authenticated principal or rejection response
+     */
+    ThingifierApiAuthenticationResult authenticate(ThingifierApiAuthenticationContext context);
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthorizationContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthorizationContext.java
@@ -1,0 +1,198 @@
+package uk.co.compendiumdev.thingifier.api.security;
+
+import java.util.Map;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
+import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
+import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
+
+/**
+ * Request details supplied to a Thingifier API authorizer.
+ *
+ * <p>The authorization context wraps the authentication context and adds the principal returned by
+ * the authenticator. Authorizers can inspect route identifiers, path parameters, and the active
+ * store to decide whether the authenticated principal can use this specific route.
+ */
+public final class ThingifierApiAuthorizationContext {
+
+    private final ThingifierApiAuthenticationContext authenticationContext;
+    private final Object principal;
+
+    /**
+     * Creates an authorization context from an authentication context and principal.
+     *
+     * @param authenticationContext request details used during authentication
+     * @param principal application principal returned by the authenticator
+     */
+    public ThingifierApiAuthorizationContext(
+            final ThingifierApiAuthenticationContext authenticationContext,
+            final Object principal) {
+        this.authenticationContext = authenticationContext;
+        this.principal = principal;
+    }
+
+    /**
+     * Returns the authentication context that produced this authorization context.
+     *
+     * @return authentication context
+     */
+    public ThingifierApiAuthenticationContext authenticationContext() {
+        return authenticationContext;
+    }
+
+    /**
+     * Returns the authenticated application principal.
+     *
+     * @return principal object, or null when the authenticator did not provide one
+     */
+    public Object principal() {
+        return principal;
+    }
+
+    /**
+     * Returns the security scheme name that selected the authenticator.
+     *
+     * @return security scheme name
+     */
+    public String schemeName() {
+        return authenticationContext.schemeName();
+    }
+
+    /**
+     * Returns the generated API verb being processed.
+     *
+     * @return routing verb
+     */
+    public RoutingVerb verb() {
+        return authenticationContext.verb();
+    }
+
+    /**
+     * Returns the generated API path for the request.
+     *
+     * @return request path
+     */
+    public String path() {
+        return authenticationContext.path();
+    }
+
+    /**
+     * Returns named path parameters extracted from the matched API spec pattern.
+     *
+     * @return immutable path-parameter map
+     */
+    public Map<String, String> pathParameters() {
+        return authenticationContext.pathParameters();
+    }
+
+    /**
+     * Returns one named path parameter.
+     *
+     * @param name parameter name
+     * @return parameter value, or an empty string when it was not present
+     */
+    public String pathParameter(final String name) {
+        return authenticationContext.pathParameter(name);
+    }
+
+    /**
+     * Returns the mapped generated route.
+     *
+     * @return route abstraction
+     */
+    public ThingRoute route() {
+        return authenticationContext.route();
+    }
+
+    /**
+     * Returns request headers.
+     *
+     * @return request header block
+     */
+    public HttpHeadersBlock headers() {
+        return authenticationContext.headers();
+    }
+
+    /**
+     * Returns the active request context.
+     *
+     * @return request context with store/session information
+     */
+    public ThingifierRequestContext requestContext() {
+        return authenticationContext.requestContext();
+    }
+
+    /**
+     * Returns the active Thingifier store.
+     *
+     * @return request store
+     */
+    public ThingStore store() {
+        return authenticationContext.store();
+    }
+
+    /**
+     * Returns the parsed bearer token.
+     *
+     * @return bearer token without the Authorization scheme prefix
+     */
+    public String bearerToken() {
+        return authenticationContext.bearerToken();
+    }
+
+    /**
+     * Returns the target entity for entity or relationship routes.
+     *
+     * @return target entity, or null when no entity route matched
+     */
+    public EntityDefinition targetEntity() {
+        return authenticationContext.targetEntity();
+    }
+
+    /**
+     * Returns the target identifier for instance routes.
+     *
+     * @return target identifier, or null for collection routes
+     */
+    public String targetIdentifier() {
+        return authenticationContext.targetIdentifier();
+    }
+
+    /**
+     * Returns the parent entity for relationship routes.
+     *
+     * @return parent entity, or null for entity routes
+     */
+    public EntityDefinition parentEntity() {
+        return authenticationContext.parentEntity();
+    }
+
+    /**
+     * Returns the parent identifier for relationship routes.
+     *
+     * @return parent identifier, or null for entity routes
+     */
+    public String parentIdentifier() {
+        return authenticationContext.parentIdentifier();
+    }
+
+    /**
+     * Returns the relationship name for relationship routes.
+     *
+     * @return relationship name, or null for entity routes
+     */
+    public String relationshipName() {
+        return authenticationContext.relationshipName();
+    }
+
+    /**
+     * Returns the child identifier for relationship instance routes.
+     *
+     * @return child identifier, or null when the route has no child
+     */
+    public String childIdentifier() {
+        return authenticationContext.childIdentifier();
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthorizationResult.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthorizationResult.java
@@ -1,0 +1,79 @@
+package uk.co.compendiumdev.thingifier.api.security;
+
+import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
+
+/**
+ * Result returned by an application authorizer.
+ *
+ * <p>Authorizers can allow a request, return the standard forbidden response, or provide a
+ * route/domain-specific response such as 404 when the protected parent resource does not exist.
+ */
+public final class ThingifierApiAuthorizationResult {
+
+    private final boolean authorized;
+    private final ApiResponse rejectionResponse;
+
+    private ThingifierApiAuthorizationResult(
+            final boolean authorized, final ApiResponse rejectionResponse) {
+        this.authorized = authorized;
+        this.rejectionResponse = rejectionResponse;
+    }
+
+    /**
+     * Creates a successful authorization result.
+     *
+     * @return successful authorization result
+     */
+    public static ThingifierApiAuthorizationResult authorized() {
+        return new ThingifierApiAuthorizationResult(true, null);
+    }
+
+    /**
+     * Creates a 403 Forbidden authorization rejection.
+     *
+     * @return forbidden authorization result
+     */
+    public static ThingifierApiAuthorizationResult forbidden() {
+        return rejected(403, "Forbidden");
+    }
+
+    /**
+     * Creates an authorization rejection with a status and message.
+     *
+     * @param status status code to return
+     * @param message message to render in the error body
+     * @return rejected authorization result
+     */
+    public static ThingifierApiAuthorizationResult rejected(
+            final int status, final String message) {
+        return rejected(ApiResponse.error(status, message));
+    }
+
+    /**
+     * Creates an authorization rejection with a complete response.
+     *
+     * @param response response to return instead of continuing request processing
+     * @return rejected authorization result
+     */
+    public static ThingifierApiAuthorizationResult rejected(final ApiResponse response) {
+        return new ThingifierApiAuthorizationResult(false, response);
+    }
+
+    /**
+     * Reports whether the authenticated principal may use the route.
+     *
+     * @return true when request processing may continue
+     */
+    public boolean isAuthorized() {
+        return authorized;
+    }
+
+    /**
+     * Returns the response for a failed authorization.
+     *
+     * @return API response to return, or null when authorization succeeded
+     */
+    public ApiResponse rejectionResponse() {
+        return rejectionResponse;
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthorizer.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthorizer.java
@@ -1,0 +1,20 @@
+package uk.co.compendiumdev.thingifier.api.security;
+
+/**
+ * Authorizes an authenticated principal for one generated Thingifier API route.
+ *
+ * <p>Authenticators answer "who is this request?" while authorizers answer "may that principal do
+ * this route-specific action?". Keeping these separate lets applications enforce domain rules such
+ * as cart ownership without teaching Thingifier about the application domain.
+ */
+@FunctionalInterface
+public interface ThingifierApiAuthorizer {
+
+    /**
+     * Authorizes the authenticated principal for the current request.
+     *
+     * @param context request, route, and principal details for the authorization decision
+     * @return authorization result describing whether the request may continue
+     */
+    ThingifierApiAuthorizationResult authorize(ThingifierApiAuthorizationContext context);
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiRouteAuthDetails.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiRouteAuthDetails.java
@@ -1,0 +1,349 @@
+package uk.co.compendiumdev.thingifier.api.security;
+
+import java.util.Map;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
+import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
+import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+
+/**
+ * Immutable route details shared by authentication and authorization contexts.
+ *
+ * <p>The internal auth policy builds this once per request so both callbacks see the same route,
+ * path-parameter, entity, and store information.
+ */
+public final class ThingifierApiRouteAuthDetails {
+
+    private final String schemeName;
+    private final RoutingVerb verb;
+    private final String path;
+    private final Map<String, String> pathParameters;
+    private final ThingRoute route;
+    private final HttpHeadersBlock headers;
+    private final ThingifierRequestContext requestContext;
+    private final EntityDefinition targetEntity;
+    private final String targetIdentifier;
+    private final EntityDefinition parentEntity;
+    private final String parentIdentifier;
+    private final String relationshipName;
+    private final String childIdentifier;
+
+    /**
+     * Creates route auth details.
+     *
+     * @param builder populated details builder
+     */
+    private ThingifierApiRouteAuthDetails(final Builder builder) {
+        this.schemeName = builder.schemeName;
+        this.verb = builder.verb;
+        this.path = builder.path;
+        this.pathParameters = Map.copyOf(builder.pathParameters);
+        this.route = builder.route;
+        this.headers = builder.headers;
+        this.requestContext = builder.requestContext;
+        this.targetEntity = builder.targetEntity;
+        this.targetIdentifier = builder.targetIdentifier;
+        this.parentEntity = builder.parentEntity;
+        this.parentIdentifier = builder.parentIdentifier;
+        this.relationshipName = builder.relationshipName;
+        this.childIdentifier = builder.childIdentifier;
+    }
+
+    /**
+     * Starts a builder for route auth details.
+     *
+     * @return new details builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Returns the security scheme name.
+     *
+     * @return security scheme name
+     */
+    public String schemeName() {
+        return schemeName;
+    }
+
+    /**
+     * Returns the generated API verb.
+     *
+     * @return routing verb
+     */
+    public RoutingVerb verb() {
+        return verb;
+    }
+
+    /**
+     * Returns the generated API path.
+     *
+     * @return request path
+     */
+    public String path() {
+        return path;
+    }
+
+    /**
+     * Returns named path parameters.
+     *
+     * @return immutable path-parameter map
+     */
+    public Map<String, String> pathParameters() {
+        return pathParameters;
+    }
+
+    /**
+     * Returns the mapped generated route.
+     *
+     * @return route abstraction
+     */
+    public ThingRoute route() {
+        return route;
+    }
+
+    /**
+     * Returns request headers.
+     *
+     * @return request header block
+     */
+    public HttpHeadersBlock headers() {
+        return headers;
+    }
+
+    /**
+     * Returns the active request context.
+     *
+     * @return request context
+     */
+    public ThingifierRequestContext requestContext() {
+        return requestContext;
+    }
+
+    /**
+     * Returns the target entity.
+     *
+     * @return target entity, or null
+     */
+    public EntityDefinition targetEntity() {
+        return targetEntity;
+    }
+
+    /**
+     * Returns the target identifier.
+     *
+     * @return target identifier, or null
+     */
+    public String targetIdentifier() {
+        return targetIdentifier;
+    }
+
+    /**
+     * Returns the parent entity for relationship routes.
+     *
+     * @return parent entity, or null
+     */
+    public EntityDefinition parentEntity() {
+        return parentEntity;
+    }
+
+    /**
+     * Returns the parent identifier for relationship routes.
+     *
+     * @return parent identifier, or null
+     */
+    public String parentIdentifier() {
+        return parentIdentifier;
+    }
+
+    /**
+     * Returns the relationship name.
+     *
+     * @return relationship name, or null
+     */
+    public String relationshipName() {
+        return relationshipName;
+    }
+
+    /**
+     * Returns the child identifier for relationship instance routes.
+     *
+     * @return child identifier, or null
+     */
+    public String childIdentifier() {
+        return childIdentifier;
+    }
+
+    /** Mutable builder for {@link ThingifierApiRouteAuthDetails}. */
+    public static final class Builder {
+        private String schemeName;
+        private RoutingVerb verb;
+        private String path;
+        private Map<String, String> pathParameters = Map.of();
+        private ThingRoute route;
+        private HttpHeadersBlock headers;
+        private ThingifierRequestContext requestContext;
+        private EntityDefinition targetEntity;
+        private String targetIdentifier;
+        private EntityDefinition parentEntity;
+        private String parentIdentifier;
+        private String relationshipName;
+        private String childIdentifier;
+
+        private Builder() {}
+
+        /**
+         * Sets the security scheme name.
+         *
+         * @param schemeName security scheme name
+         * @return this builder
+         */
+        public Builder schemeName(final String schemeName) {
+            this.schemeName = schemeName;
+            return this;
+        }
+
+        /**
+         * Sets the generated API verb.
+         *
+         * @param verb routing verb
+         * @return this builder
+         */
+        public Builder verb(final RoutingVerb verb) {
+            this.verb = verb;
+            return this;
+        }
+
+        /**
+         * Sets the generated API path.
+         *
+         * @param path request path
+         * @return this builder
+         */
+        public Builder path(final String path) {
+            this.path = path;
+            return this;
+        }
+
+        /**
+         * Sets named path parameters.
+         *
+         * @param pathParameters path-parameter map
+         * @return this builder
+         */
+        public Builder pathParameters(final Map<String, String> pathParameters) {
+            this.pathParameters = pathParameters == null ? Map.of() : pathParameters;
+            return this;
+        }
+
+        /**
+         * Sets the mapped generated route.
+         *
+         * @param route route abstraction
+         * @return this builder
+         */
+        public Builder route(final ThingRoute route) {
+            this.route = route;
+            return this;
+        }
+
+        /**
+         * Sets request headers.
+         *
+         * @param headers request header block
+         * @return this builder
+         */
+        public Builder headers(final HttpHeadersBlock headers) {
+            this.headers = headers;
+            return this;
+        }
+
+        /**
+         * Sets the active request context.
+         *
+         * @param requestContext request context
+         * @return this builder
+         */
+        public Builder requestContext(final ThingifierRequestContext requestContext) {
+            this.requestContext = requestContext;
+            return this;
+        }
+
+        /**
+         * Sets the target entity.
+         *
+         * @param targetEntity target entity
+         * @return this builder
+         */
+        public Builder targetEntity(final EntityDefinition targetEntity) {
+            this.targetEntity = targetEntity;
+            return this;
+        }
+
+        /**
+         * Sets the target identifier.
+         *
+         * @param targetIdentifier target identifier
+         * @return this builder
+         */
+        public Builder targetIdentifier(final String targetIdentifier) {
+            this.targetIdentifier = targetIdentifier;
+            return this;
+        }
+
+        /**
+         * Sets the parent entity for relationship routes.
+         *
+         * @param parentEntity parent entity
+         * @return this builder
+         */
+        public Builder parentEntity(final EntityDefinition parentEntity) {
+            this.parentEntity = parentEntity;
+            return this;
+        }
+
+        /**
+         * Sets the parent identifier for relationship routes.
+         *
+         * @param parentIdentifier parent identifier
+         * @return this builder
+         */
+        public Builder parentIdentifier(final String parentIdentifier) {
+            this.parentIdentifier = parentIdentifier;
+            return this;
+        }
+
+        /**
+         * Sets the relationship name.
+         *
+         * @param relationshipName relationship name
+         * @return this builder
+         */
+        public Builder relationshipName(final String relationshipName) {
+            this.relationshipName = relationshipName;
+            return this;
+        }
+
+        /**
+         * Sets the child identifier for relationship instance routes.
+         *
+         * @param childIdentifier child identifier
+         * @return this builder
+         */
+        public Builder childIdentifier(final String childIdentifier) {
+            this.childIdentifier = childIdentifier;
+            return this;
+        }
+
+        /**
+         * Builds immutable route auth details.
+         *
+         * @return route auth details
+         */
+        public ThingifierApiRouteAuthDetails build() {
+            return new ThingifierApiRouteAuthDetails(this);
+        }
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiSecuritySpec.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiSecuritySpec.java
@@ -1,0 +1,52 @@
+package uk.co.compendiumdev.thingifier.api.security;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Declares named security schemes used by a Thingifier API specification.
+ *
+ * <p>The security spec is intentionally small at the moment. It lets API authors give bearer
+ * schemes meaningful names, such as {@code cartToken}, so generated OpenAPI documents and runtime
+ * enforcement can refer to the same policy without hard-coding application behaviour in Thingifier.
+ */
+public final class ThingifierApiSecuritySpec {
+
+    private final Set<String> bearerSchemes;
+
+    /** Creates an empty security declaration set. */
+    public ThingifierApiSecuritySpec() {
+        bearerSchemes = new LinkedHashSet<>();
+    }
+
+    /**
+     * Declares a named bearer authentication scheme.
+     *
+     * @param schemeName name to use in API spec route rules and OpenAPI security schemes
+     * @return this security spec so declarations can be chained
+     */
+    public ThingifierApiSecuritySpec bearer(final String schemeName) {
+        bearerSchemes.add(SecuritySchemeNames.requireValid(schemeName));
+        return this;
+    }
+
+    /**
+     * Reports whether the named bearer scheme has been declared.
+     *
+     * @param schemeName security scheme name
+     * @return true when a matching bearer scheme is known
+     */
+    public boolean hasBearer(final String schemeName) {
+        return bearerSchemes.contains(SecuritySchemeNames.requireValid(schemeName));
+    }
+
+    /**
+     * Returns all declared bearer scheme names in declaration order.
+     *
+     * @return immutable set of bearer scheme names
+     */
+    public Set<String> bearerSchemes() {
+        return Collections.unmodifiableSet(bearerSchemes);
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ApiRoutePathMatcher.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ApiRoutePathMatcher.java
@@ -1,12 +1,30 @@
 package uk.co.compendiumdev.thingifier.api.spec;
 
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
+/**
+ * Compares API spec route patterns and request paths using Thingifier route parameter rules.
+ *
+ * <p>API spec users can write either {@code :id} or {@code {id}} parameters. This matcher treats
+ * both forms as wildcards for route matching and can also extract named parameter values for policy
+ * callbacks such as route authorization.
+ */
 public final class ApiRoutePathMatcher {
 
+    /** Utility class; callers use the static matching helpers. */
     private ApiRoutePathMatcher() {}
 
+    /**
+     * Reports whether a rule path and candidate path describe the same generated route.
+     *
+     * @param rulePath configured route pattern
+     * @param candidatePath generated route path or request path
+     * @param apiPathPrefix configured API prefix to ignore when matching
+     * @return true when the paths have the same shape
+     */
     public static boolean pathsMatch(
             final String rulePath, final String candidatePath, final String apiPathPrefix) {
         final List<String> ruleSegments = segments(rulePath, apiPathPrefix);
@@ -27,16 +45,68 @@ public final class ApiRoutePathMatcher {
         return true;
     }
 
-    private static List<String> segments(final String path, final String apiPathPrefix) {
-        final String normalized = removePrefix(normalize(path), normalize(apiPathPrefix));
-        if (normalized.isEmpty()) {
-            return List.of();
+    /**
+     * Extracts named parameter values from a matching rule path and candidate path.
+     *
+     * <p>Only parameter names from the rule path are returned. If the paths do not have the same
+     * number of segments, an empty map is returned because there is no safe one-to-one binding.
+     *
+     * @param rulePath configured route pattern
+     * @param candidatePath generated route path or request path
+     * @param apiPathPrefix configured API prefix to ignore when matching
+     * @return immutable map of parameter names to candidate segment values
+     */
+    public static Map<String, String> pathParameters(
+            final String rulePath, final String candidatePath, final String apiPathPrefix) {
+        final List<String> ruleSegments = rawSegments(rulePath, apiPathPrefix);
+        final List<String> candidateSegments = rawSegments(candidatePath, apiPathPrefix);
+        if (ruleSegments.size() != candidateSegments.size()) {
+            return Map.of();
         }
-        return Arrays.stream(normalized.split("/"))
+
+        final Map<String, String> parameters = new LinkedHashMap<>();
+        for (int index = 0; index < ruleSegments.size(); index++) {
+            final int parameterIndex = index;
+            parameterName(ruleSegments.get(index))
+                    .ifPresent(name -> parameters.put(name, candidateSegments.get(parameterIndex)));
+        }
+        return Map.copyOf(parameters);
+    }
+
+    /**
+     * Splits a normalized path into comparable route segments.
+     *
+     * @param path route path or pattern
+     * @param apiPathPrefix configured API prefix
+     * @return route segments with parameter segments normalized to wildcards
+     */
+    private static List<String> segments(final String path, final String apiPathPrefix) {
+        return rawSegments(path, apiPathPrefix).stream()
                 .map(ApiRoutePathMatcher::normalizeParameterSegment)
                 .toList();
     }
 
+    /**
+     * Splits a normalized path into raw route segments.
+     *
+     * @param path route path or pattern
+     * @param apiPathPrefix configured API prefix
+     * @return route segments with parameter names preserved
+     */
+    private static List<String> rawSegments(final String path, final String apiPathPrefix) {
+        final String normalized = removePrefix(normalize(path), normalize(apiPathPrefix));
+        if (normalized.isEmpty()) {
+            return List.of();
+        }
+        return Arrays.stream(normalized.split("/")).toList();
+    }
+
+    /**
+     * Normalizes slash usage in a path.
+     *
+     * @param path path or path pattern
+     * @return path without leading or trailing slashes
+     */
     private static String normalize(final String path) {
         String normalized = path == null ? "" : path.trim();
         while (normalized.startsWith("/")) {
@@ -48,6 +118,13 @@ public final class ApiRoutePathMatcher {
         return normalized;
     }
 
+    /**
+     * Removes the configured API prefix when it is present.
+     *
+     * @param path normalized path
+     * @param apiPathPrefix normalized API prefix
+     * @return path without the prefix
+     */
     private static String removePrefix(final String path, final String apiPathPrefix) {
         if (apiPathPrefix == null || apiPathPrefix.isEmpty()) {
             return path;
@@ -61,6 +138,12 @@ public final class ApiRoutePathMatcher {
         return path;
     }
 
+    /**
+     * Converts supported parameter syntaxes to a wildcard token.
+     *
+     * @param segment path segment
+     * @return wildcard token for parameter segments, otherwise the original segment
+     */
     private static String normalizeParameterSegment(final String segment) {
         if (segment.startsWith(":")) {
             return "*";
@@ -71,6 +154,28 @@ public final class ApiRoutePathMatcher {
         return segment;
     }
 
+    /**
+     * Extracts the parameter name from a path segment.
+     *
+     * @param segment path pattern segment
+     * @return parameter name when the segment uses a supported parameter syntax
+     */
+    private static java.util.Optional<String> parameterName(final String segment) {
+        if (segment.startsWith(":") && segment.length() > 1) {
+            return java.util.Optional.of(segment.substring(1));
+        }
+        if (segment.startsWith("{") && segment.endsWith("}") && segment.length() > 2) {
+            return java.util.Optional.of(segment.substring(1, segment.length() - 1));
+        }
+        return java.util.Optional.empty();
+    }
+
+    /**
+     * Reports whether a comparable segment is a route wildcard.
+     *
+     * @param segment comparable route segment
+     * @return true when the segment is a wildcard
+     */
     private static boolean isWildcard(final String segment) {
         return "*".equals(segment);
     }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiEntityRule.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiEntityRule.java
@@ -2,6 +2,14 @@ package uk.co.compendiumdev.thingifier.api.spec;
 
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 
+/**
+ * Configures API-wide defaults for one Thingifier entity.
+ *
+ * <p>Entity rules exist so a generated API can describe a stable public shape once for an entity
+ * instead of repeating the same request and response view settings on every generated route.
+ * Route-level configuration still has higher precedence when a particular endpoint needs a
+ * different representation.
+ */
 public final class ThingifierApiEntityRule {
 
     private final String entityName;
@@ -14,42 +22,107 @@ public final class ThingifierApiEntityRule {
         this.defaultResponseView = null;
     }
 
+    /**
+     * Returns the entity name this rule was configured for.
+     *
+     * <p>The name may be singular or plural; matching is intentionally case-insensitive so callers
+     * can configure rules using the names they already use in route paths.
+     *
+     * @return the normalized rule target as supplied by the caller, after trimming
+     */
     public String entityName() {
         return entityName;
     }
 
+    /**
+     * Sets the default view used to validate write request bodies for this entity.
+     *
+     * <p>This lets the API reject fields which are part of the internal model but not accepted by
+     * the public API. A route-specific request view overrides this default.
+     *
+     * @param viewName entity view name to apply to write input
+     * @return this rule so entity API configuration can be chained
+     */
     public ThingifierApiEntityRule defaultRequestView(final String viewName) {
         defaultRequestView = requiredName("View name", viewName);
         return this;
     }
 
+    /**
+     * Sets the default view used when rendering successful responses for this entity.
+     *
+     * <p>The default applies to collection, instance, relationship, direct API, and HTTP API
+     * responses unless the matching route declares a response view for the status code.
+     *
+     * @param viewName entity view name to apply to successful response bodies
+     * @return this rule so entity API configuration can be chained
+     */
     public ThingifierApiEntityRule defaultResponseView(final String viewName) {
         defaultResponseView = requiredName("View name", viewName);
         return this;
     }
 
+    /**
+     * Sets the same default view for write validation and response rendering.
+     *
+     * <p>This is the compact form for entities where the external input and output surface are the
+     * same. Use the request or response specific methods when the public API accepts and returns
+     * different fields.
+     *
+     * @param viewName entity view name to use for both request and response defaults
+     * @return this rule so entity API configuration can be chained
+     */
     public ThingifierApiEntityRule defaultEntityView(final String viewName) {
         defaultRequestView(viewName);
         defaultResponseView(viewName);
         return this;
     }
 
+    /**
+     * Reports whether this entity has a request-body view default.
+     *
+     * @return true when write input should be checked against a configured entity view
+     */
     public boolean hasDefaultRequestView() {
         return defaultRequestView != null;
     }
 
+    /**
+     * Returns the configured default request view.
+     *
+     * @return the request view name, or null when no request default has been configured
+     */
     public String defaultRequestView() {
         return defaultRequestView;
     }
 
+    /**
+     * Reports whether this entity has a response-body view default.
+     *
+     * @return true when successful responses should be rendered through a configured entity view
+     */
     public boolean hasDefaultResponseView() {
         return defaultResponseView != null;
     }
 
+    /**
+     * Returns the configured default response view.
+     *
+     * @return the response view name, or null when no response default has been configured
+     */
     public String defaultResponseView() {
         return defaultResponseView;
     }
 
+    /**
+     * Matches this rule to an entity definition by singular or plural name.
+     *
+     * <p>The API spec accepts either spelling because callers often think in route paths, while the
+     * model stores both names on the entity definition.
+     *
+     * @param entity entity definition being resolved for a route or response
+     * @return true when the rule targets the supplied entity
+     */
     boolean matches(final EntityDefinition entity) {
         if (entity == null) {
             return false;
@@ -58,10 +131,26 @@ public final class ThingifierApiEntityRule {
                 || normalized(entityName).equals(normalized(entity.getPlural()));
     }
 
+    /**
+     * Matches this rule to a caller-supplied entity name.
+     *
+     * <p>This is used when adding rules so repeated calls to {@code entity("todos")} update the
+     * existing rule instead of creating competing defaults for the same entity.
+     *
+     * @param name singular or plural entity name to compare
+     * @return true when the supplied name refers to the same configured entity
+     */
     boolean sameEntityName(final String name) {
         return normalized(entityName).equals(normalized(name));
     }
 
+    /**
+     * Normalizes and validates a required API-spec name.
+     *
+     * @param label name used in the exception message
+     * @param name candidate name from the caller
+     * @return trimmed name when present
+     */
     private String requiredName(final String label, final String name) {
         final String normalized = name == null ? "" : name.trim();
         if (normalized.isEmpty()) {
@@ -70,6 +159,12 @@ public final class ThingifierApiEntityRule {
         return normalized;
     }
 
+    /**
+     * Converts optional API-spec names into the comparison form used by rule matching.
+     *
+     * @param name candidate name, possibly null
+     * @return trimmed lower-case name, or an empty string for null
+     */
     private String normalized(final String name) {
         return name == null ? "" : name.trim().toLowerCase();
     }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiEntityRule.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiEntityRule.java
@@ -1,0 +1,76 @@
+package uk.co.compendiumdev.thingifier.api.spec;
+
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+
+public final class ThingifierApiEntityRule {
+
+    private final String entityName;
+    private String defaultRequestView;
+    private String defaultResponseView;
+
+    ThingifierApiEntityRule(final String entityName) {
+        this.entityName = requiredName("Entity name", entityName);
+        this.defaultRequestView = null;
+        this.defaultResponseView = null;
+    }
+
+    public String entityName() {
+        return entityName;
+    }
+
+    public ThingifierApiEntityRule defaultRequestView(final String viewName) {
+        defaultRequestView = requiredName("View name", viewName);
+        return this;
+    }
+
+    public ThingifierApiEntityRule defaultResponseView(final String viewName) {
+        defaultResponseView = requiredName("View name", viewName);
+        return this;
+    }
+
+    public ThingifierApiEntityRule defaultEntityView(final String viewName) {
+        defaultRequestView(viewName);
+        defaultResponseView(viewName);
+        return this;
+    }
+
+    public boolean hasDefaultRequestView() {
+        return defaultRequestView != null;
+    }
+
+    public String defaultRequestView() {
+        return defaultRequestView;
+    }
+
+    public boolean hasDefaultResponseView() {
+        return defaultResponseView != null;
+    }
+
+    public String defaultResponseView() {
+        return defaultResponseView;
+    }
+
+    boolean matches(final EntityDefinition entity) {
+        if (entity == null) {
+            return false;
+        }
+        return normalized(entityName).equals(normalized(entity.getName()))
+                || normalized(entityName).equals(normalized(entity.getPlural()));
+    }
+
+    boolean sameEntityName(final String name) {
+        return normalized(entityName).equals(normalized(name));
+    }
+
+    private String requiredName(final String label, final String name) {
+        final String normalized = name == null ? "" : name.trim();
+        if (normalized.isEmpty()) {
+            throw new IllegalArgumentException(label + " is required");
+        }
+        return normalized;
+    }
+
+    private String normalized(final String name) {
+        return name == null ? "" : name.trim().toLowerCase();
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiPathRule.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiPathRule.java
@@ -1,0 +1,27 @@
+package uk.co.compendiumdev.thingifier.api.spec;
+
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
+
+public final class ThingifierApiPathRule {
+
+    private final ThingifierApiSpec apiSpec;
+    private final String pathPattern;
+
+    ThingifierApiPathRule(final ThingifierApiSpec apiSpec, final String pathPattern) {
+        this.apiSpec = apiSpec;
+        this.pathPattern = pathPattern;
+    }
+
+    public ThingifierApiPathRule methodNotAllowed(final RoutingVerb... verbs) {
+        if (verbs == null || verbs.length == 0) {
+            throw new IllegalArgumentException("methodNotAllowed requires at least one verb");
+        }
+        for (RoutingVerb verb : verbs) {
+            if (verb == null) {
+                throw new IllegalArgumentException("methodNotAllowed requires non-null verbs");
+            }
+            apiSpec.routeFor(verb, pathPattern).methodNotAllowed();
+        }
+        return this;
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiPathRule.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiPathRule.java
@@ -2,6 +2,13 @@ package uk.co.compendiumdev.thingifier.api.spec;
 
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 
+/**
+ * Configures all route rules for a single path pattern.
+ *
+ * <p>This builder is a convenience layer over the one-verb route rules. It is useful when the
+ * public API decision is path-oriented, such as declaring several generated methods unavailable for
+ * the same endpoint.
+ */
 public final class ThingifierApiPathRule {
 
     private final ThingifierApiSpec apiSpec;
@@ -12,6 +19,16 @@ public final class ThingifierApiPathRule {
         this.pathPattern = pathPattern;
     }
 
+    /**
+     * Marks one or more generated methods on this path as HTTP 405 Method Not Allowed.
+     *
+     * <p>The route is still visible and routable so OPTIONS and generated documentation can explain
+     * the public surface. Use {@link ThingifierApiRouteRule#disable()} when the route should behave
+     * as absent instead.
+     *
+     * @param verbs generated methods to reject with 405
+     * @return this path rule so more path-level configuration can be chained
+     */
     public ThingifierApiPathRule methodNotAllowed(final RoutingVerb... verbs) {
         if (verbs == null || verbs.length == 0) {
             throw new IllegalArgumentException("methodNotAllowed requires at least one verb");

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiRouteRule.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiRouteRule.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingDefinition;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingStatus;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.apiconfig.EntityPatchUpdateStyle;
 import uk.co.compendiumdev.thingifier.apiconfig.EntityWriteOperation;
@@ -17,6 +18,7 @@ public final class ThingifierApiRouteRule {
     private final String pathPattern;
     private boolean hidden;
     private boolean disabled;
+    private boolean methodNotAllowed;
     private boolean usesBasicAuth;
     private boolean usesBearerAuth;
     private String documentation;
@@ -33,6 +35,7 @@ public final class ThingifierApiRouteRule {
         this.pathPattern = pathPattern == null ? "" : pathPattern;
         this.hidden = false;
         this.disabled = false;
+        this.methodNotAllowed = false;
         this.usesBasicAuth = false;
         this.usesBearerAuth = false;
         this.documentation = null;
@@ -67,12 +70,21 @@ public final class ThingifierApiRouteRule {
         return this;
     }
 
+    public ThingifierApiRouteRule methodNotAllowed() {
+        methodNotAllowed = true;
+        return this;
+    }
+
     public boolean isHidden() {
         return hidden;
     }
 
     public boolean isDisabled() {
         return disabled;
+    }
+
+    public boolean isMethodNotAllowed() {
+        return methodNotAllowed;
     }
 
     public ThingifierApiRouteRule secureWithBasicAuth() {
@@ -192,6 +204,9 @@ public final class ThingifierApiRouteRule {
         }
         if (disabled) {
             route.disable();
+        }
+        if (methodNotAllowed && !disabled) {
+            route.replaceStatus(RoutingStatus.returnValue(405));
         }
         if (usesBasicAuth) {
             route.secureWithBasicAuth();

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiRouteRule.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiRouteRule.java
@@ -12,6 +12,13 @@ import uk.co.compendiumdev.thingifier.apiconfig.EntityPatchUpdateStyle;
 import uk.co.compendiumdev.thingifier.apiconfig.EntityWriteOperation;
 import uk.co.compendiumdev.thingifier.apiconfig.RelationshipWriteOperation;
 
+/**
+ * Configures the generated API behaviour for one verb and path pattern.
+ *
+ * <p>Route rules are deliberately narrow overrides for generated Thingifier routes. They let a
+ * model keep its generated route set while shaping the public API with documentation, visibility,
+ * authentication, allowed write semantics, and entity views.
+ */
 public final class ThingifierApiRouteRule {
 
     private final RoutingVerb verb;
@@ -48,113 +55,267 @@ public final class ThingifierApiRouteRule {
         this.relationshipWriteOperations = null;
     }
 
+    /**
+     * Returns the HTTP-style verb this rule applies to.
+     *
+     * @return the configured routing verb
+     */
     public RoutingVerb verb() {
         return verb;
     }
 
+    /**
+     * Returns the route path pattern this rule applies to.
+     *
+     * <p>Patterns use the same parameter forms as generated routes, including {@code {id}} and
+     * {@code :id}.
+     *
+     * @return configured route path pattern
+     */
     public String pathPattern() {
         return pathPattern;
     }
 
+    /**
+     * Hides the generated route from API documentation while leaving runtime behaviour available.
+     *
+     * @return this rule so route API configuration can be chained
+     */
     public ThingifierApiRouteRule hide() {
         hidden = true;
         return this;
     }
 
+    /**
+     * Hides the generated route from API documentation.
+     *
+     * <p>This alias keeps older configuration readable while making the intent explicit.
+     *
+     * @return this rule so route API configuration can be chained
+     */
     public ThingifierApiRouteRule hideFromDocs() {
         return hide();
     }
 
+    /**
+     * Disables the generated route so it behaves like it is not part of the API.
+     *
+     * <p>Disabled routes are hidden from documentation and return the existing not-found style
+     * response instead of a 405.
+     *
+     * @return this rule so route API configuration can be chained
+     */
     public ThingifierApiRouteRule disable() {
         disabled = true;
         return this;
     }
 
+    /**
+     * Marks the generated route as present but unavailable for this method.
+     *
+     * <p>This is for public API surface decisions where clients should receive HTTP 405 Method Not
+     * Allowed and an Allow header rather than a not-found response.
+     *
+     * @return this rule so route API configuration can be chained
+     */
     public ThingifierApiRouteRule methodNotAllowed() {
         methodNotAllowed = true;
         return this;
     }
 
+    /**
+     * Reports whether this route should be hidden from documentation.
+     *
+     * @return true when the route is documentation-hidden
+     */
     public boolean isHidden() {
         return hidden;
     }
 
+    /**
+     * Reports whether this route should behave as disabled.
+     *
+     * @return true when the route should be treated as absent at runtime
+     */
     public boolean isDisabled() {
         return disabled;
     }
 
+    /**
+     * Reports whether this route should return 405 Method Not Allowed.
+     *
+     * @return true when the method is publicly unavailable but still a known route
+     */
     public boolean isMethodNotAllowed() {
         return methodNotAllowed;
     }
 
+    /**
+     * Marks the route as requiring Basic authentication in generated documentation.
+     *
+     * @return this rule so route API configuration can be chained
+     */
     public ThingifierApiRouteRule secureWithBasicAuth() {
         usesBasicAuth = true;
         return this;
     }
 
+    /**
+     * Marks the route as requiring Bearer authentication in generated documentation.
+     *
+     * @return this rule so route API configuration can be chained
+     */
     public ThingifierApiRouteRule secureWithBearerAuth() {
         usesBearerAuth = true;
         return this;
     }
 
+    /**
+     * Adds route-specific documentation text to the generated API definition.
+     *
+     * @param documentation documentation text to append to the route definition
+     * @return this rule so route API configuration can be chained
+     */
     public ThingifierApiRouteRule addDocumentation(final String documentation) {
         this.documentation = documentation;
         return this;
     }
 
+    /**
+     * Overrides the named request payload schema advertised for this route.
+     *
+     * @param requestPayload object schema name to use as the request payload
+     * @return this rule so route API configuration can be chained
+     */
     public ThingifierApiRouteRule requestPayload(final String requestPayload) {
         this.requestPayload = requestPayload;
         return this;
     }
 
+    /**
+     * Sets the entity view used to validate accepted request fields for this route.
+     *
+     * <p>Route-specific request views override entity-level defaults because endpoint contracts can
+     * be narrower or broader than the normal entity contract.
+     *
+     * @param viewName entity view name used for request validation
+     * @return this rule so route API configuration can be chained
+     */
     public ThingifierApiRouteRule requestEntityView(final String viewName) {
         this.requestEntityView = viewName;
         return this;
     }
 
+    /**
+     * Sets the response entity view for a specific successful or error status code.
+     *
+     * @param statusCode status code whose response payload should use the view
+     * @param viewName entity view name used when rendering the response body
+     * @return this rule so route API configuration can be chained
+     */
     public ThingifierApiRouteRule responseEntityView(final int statusCode, final String viewName) {
         this.responseEntityViews.put(statusCode, viewName);
         return this;
     }
 
+    /**
+     * Restricts which entity write operations this generated route may perform.
+     *
+     * <p>The route may still be generated; the runtime chooses 405 when the concrete write
+     * operation is outside this set.
+     *
+     * @param operations allowed create or update operations for the route
+     * @return this rule so route API configuration can be chained
+     */
     public ThingifierApiRouteRule entityWriteOperations(final EntityWriteOperation... operations) {
         this.entityWriteOperations = entityOperations(operations);
         return this;
     }
 
+    /**
+     * Alias for {@link #entityWriteOperations(EntityWriteOperation...)}.
+     *
+     * @param operations allowed create or update operations for the route
+     * @return this rule so route API configuration can be chained
+     */
     public ThingifierApiRouteRule entityCan(final EntityWriteOperation... operations) {
         return entityWriteOperations(operations);
     }
 
+    /**
+     * Restricts which patch document styles this generated entity route accepts.
+     *
+     * @param updateStyles accepted patch formats for the route
+     * @return this rule so route API configuration can be chained
+     */
     public ThingifierApiRouteRule entityPatchCan(final EntityPatchUpdateStyle... updateStyles) {
         this.entityPatchUpdateStyles = patchStyles(updateStyles);
         return this;
     }
 
+    /**
+     * Restricts which relationship write operations this generated route may perform.
+     *
+     * @param operations allowed relationship operations for the route
+     * @return this rule so route API configuration can be chained
+     */
     public ThingifierApiRouteRule relationshipWriteOperations(
             final RelationshipWriteOperation... operations) {
         this.relationshipWriteOperations = relationshipOperations(operations);
         return this;
     }
 
+    /**
+     * Alias for {@link #relationshipWriteOperations(RelationshipWriteOperation...)}.
+     *
+     * @param operations allowed relationship operations for the route
+     * @return this rule so route API configuration can be chained
+     */
     public ThingifierApiRouteRule relationshipCan(final RelationshipWriteOperation... operations) {
         return relationshipWriteOperations(operations);
     }
 
+    /**
+     * Uses the same entity view for request validation and successful responses on this route.
+     *
+     * <p>This route-level view overrides entity defaults and is kept for concise route contracts.
+     *
+     * @param viewName entity view name for route input and output
+     * @return this rule so route API configuration can be chained
+     */
     public ThingifierApiRouteRule entityView(final String viewName) {
         this.requestEntityView = viewName;
         this.defaultEntityView = viewName;
         return this;
     }
 
+    /**
+     * Reports whether this route has an explicit request entity view.
+     *
+     * @return true when request input should use the configured route view
+     */
     public boolean hasRequestEntityView() {
         return requestEntityView != null;
     }
 
+    /**
+     * Returns the explicit request entity view configured for this route.
+     *
+     * @return request entity view name, or null when the route has none
+     */
     public String getRequestEntityView() {
         return requestEntityView;
     }
 
+    /**
+     * Resolves the response entity view for the supplied status code.
+     *
+     * <p>Status-specific views win first. The route default applies only to 2xx responses so error
+     * bodies are not accidentally shaped like normal entity resources.
+     *
+     * @param statusCode API response status code
+     * @return entity view name, or null when this route does not define one for the status
+     */
     public String responseEntityViewFor(final int statusCode) {
         if (responseEntityViews.containsKey(statusCode)) {
             return responseEntityViews.get(statusCode);
@@ -165,10 +326,21 @@ public final class ThingifierApiRouteRule {
         return null;
     }
 
+    /**
+     * Reports whether this route overrides entity write operation policy.
+     *
+     * @return true when entity write operations were explicitly configured
+     */
     public boolean hasEntityWriteOperations() {
         return entityWriteOperations != null;
     }
 
+    /**
+     * Returns the entity write operations allowed by this route.
+     *
+     * @return immutable set of allowed entity write operations, or an empty set when none are
+     *     allowed
+     */
     public Set<EntityWriteOperation> entityWriteOperations() {
         if (entityWriteOperations == null || entityWriteOperations.isEmpty()) {
             return Set.of();
@@ -176,10 +348,20 @@ public final class ThingifierApiRouteRule {
         return Collections.unmodifiableSet(EnumSet.copyOf(entityWriteOperations));
     }
 
+    /**
+     * Reports whether this route overrides PATCH update style policy.
+     *
+     * @return true when PATCH styles were explicitly configured
+     */
     public boolean hasEntityPatchUpdateStyles() {
         return entityPatchUpdateStyles != null;
     }
 
+    /**
+     * Returns the PATCH update styles allowed by this route.
+     *
+     * @return immutable set of accepted PATCH styles, or an empty set when none are allowed
+     */
     public Set<EntityPatchUpdateStyle> entityPatchUpdateStyles() {
         if (entityPatchUpdateStyles == null || entityPatchUpdateStyles.isEmpty()) {
             return Set.of();
@@ -187,10 +369,21 @@ public final class ThingifierApiRouteRule {
         return Collections.unmodifiableSet(EnumSet.copyOf(entityPatchUpdateStyles));
     }
 
+    /**
+     * Reports whether this route overrides relationship write operation policy.
+     *
+     * @return true when relationship write operations were explicitly configured
+     */
     public boolean hasRelationshipWriteOperations() {
         return relationshipWriteOperations != null;
     }
 
+    /**
+     * Returns the relationship write operations allowed by this route.
+     *
+     * @return immutable set of allowed relationship write operations, or an empty set when none are
+     *     allowed
+     */
     public Set<RelationshipWriteOperation> relationshipWriteOperations() {
         if (relationshipWriteOperations == null || relationshipWriteOperations.isEmpty()) {
             return Set.of();
@@ -198,6 +391,14 @@ public final class ThingifierApiRouteRule {
         return Collections.unmodifiableSet(EnumSet.copyOf(relationshipWriteOperations));
     }
 
+    /**
+     * Applies this API-spec rule to a generated route definition.
+     *
+     * <p>Documentation route metadata is updated here, while runtime policy is resolved separately
+     * by the HTTP and direct API handlers so both execution paths remain consistent.
+     *
+     * @param route generated routing definition to update
+     */
     void applyTo(final RoutingDefinition route) {
         if (hidden) {
             route.hideFromDocumentation();
@@ -242,6 +443,12 @@ public final class ThingifierApiRouteRule {
         }
     }
 
+    /**
+     * Captures the configured entity write operations in an enum set.
+     *
+     * @param operations caller supplied operations, possibly null
+     * @return mutable enum set stored by this rule
+     */
     private EnumSet<EntityWriteOperation> entityOperations(
             final EntityWriteOperation... operations) {
         EnumSet<EntityWriteOperation> selected = EnumSet.noneOf(EntityWriteOperation.class);
@@ -251,6 +458,12 @@ public final class ThingifierApiRouteRule {
         return selected;
     }
 
+    /**
+     * Captures the configured patch styles in an enum set.
+     *
+     * @param styles caller supplied patch styles, possibly null
+     * @return mutable enum set stored by this rule
+     */
     private EnumSet<EntityPatchUpdateStyle> patchStyles(final EntityPatchUpdateStyle... styles) {
         EnumSet<EntityPatchUpdateStyle> selected = EnumSet.noneOf(EntityPatchUpdateStyle.class);
         if (styles != null) {
@@ -259,6 +472,12 @@ public final class ThingifierApiRouteRule {
         return selected;
     }
 
+    /**
+     * Captures the configured relationship write operations in an enum set.
+     *
+     * @param operations caller supplied operations, possibly null
+     * @return mutable enum set stored by this rule
+     */
     private EnumSet<RelationshipWriteOperation> relationshipOperations(
             final RelationshipWriteOperation... operations) {
         EnumSet<RelationshipWriteOperation> selected =

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiRouteRule.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiRouteRule.java
@@ -3,11 +3,14 @@ package uk.co.compendiumdev.thingifier.api.spec;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingDefinition;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingStatus;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
+import uk.co.compendiumdev.thingifier.api.security.SecuritySchemeNames;
+import uk.co.compendiumdev.thingifier.api.security.ThingifierApiAuthorizer;
 import uk.co.compendiumdev.thingifier.apiconfig.EntityPatchUpdateStyle;
 import uk.co.compendiumdev.thingifier.apiconfig.EntityWriteOperation;
 import uk.co.compendiumdev.thingifier.apiconfig.RelationshipWriteOperation;
@@ -28,6 +31,9 @@ public final class ThingifierApiRouteRule {
     private boolean methodNotAllowed;
     private boolean usesBasicAuth;
     private boolean usesBearerAuth;
+    private String bearerAuthSchemeName;
+    private String enforcedBearerAuthSchemeName;
+    private final List<ThingifierApiAuthorizer> authorizers;
     private String documentation;
     private String requestPayload;
     private String requestEntityView;
@@ -45,6 +51,9 @@ public final class ThingifierApiRouteRule {
         this.methodNotAllowed = false;
         this.usesBasicAuth = false;
         this.usesBearerAuth = false;
+        this.bearerAuthSchemeName = SecuritySchemeNames.DEFAULT_BEARER_AUTH_SCHEME;
+        this.enforcedBearerAuthSchemeName = null;
+        this.authorizers = new java.util.ArrayList<>();
         this.documentation = null;
         this.requestPayload = null;
         this.requestEntityView = null;
@@ -163,11 +172,98 @@ public final class ThingifierApiRouteRule {
     /**
      * Marks the route as requiring Bearer authentication in generated documentation.
      *
+     * <p>This historical form is documentation-only. Use {@link #secureWithBearerAuth(String)} when
+     * Thingifier should also enforce a named bearer policy at runtime.
+     *
      * @return this rule so route API configuration can be chained
      */
+    @Deprecated
     public ThingifierApiRouteRule secureWithBearerAuth() {
         usesBearerAuth = true;
+        bearerAuthSchemeName = SecuritySchemeNames.DEFAULT_BEARER_AUTH_SCHEME;
         return this;
+    }
+
+    /**
+     * Marks the route as requiring a named Bearer authentication scheme and runtime enforcement.
+     *
+     * <p>The scheme name is used in generated documentation, authenticator lookup, and the
+     * authenticated-principal slot on the request context. Applications supply the authenticator
+     * through {@link ThingifierApiSpec#authenticator(String,
+     * uk.co.compendiumdev.thingifier.api.security.ThingifierApiAuthenticator)}.
+     *
+     * @param schemeName named bearer scheme, for example {@code cartToken}
+     * @return this rule so route API configuration can be chained
+     */
+    public ThingifierApiRouteRule secureWithBearerAuth(final String schemeName) {
+        final String normalizedSchemeName = SecuritySchemeNames.requireValid(schemeName);
+        usesBearerAuth = true;
+        bearerAuthSchemeName = normalizedSchemeName;
+        enforcedBearerAuthSchemeName = normalizedSchemeName;
+        return this;
+    }
+
+    /**
+     * Adds a route-specific authorization callback.
+     *
+     * <p>Authorizers run only after the named authenticator accepts the bearer token. Multiple
+     * authorizers are evaluated in registration order and the first rejection stops the request.
+     *
+     * @param authorizer authorization callback
+     * @return this rule so route API configuration can be chained
+     * @throws IllegalArgumentException when the authorizer is null
+     */
+    public ThingifierApiRouteRule authorizeWith(final ThingifierApiAuthorizer authorizer) {
+        if (authorizer == null) {
+            throw new IllegalArgumentException("authorizer is required");
+        }
+        authorizers.add(authorizer);
+        return this;
+    }
+
+    /**
+     * Reports whether this route is documented as bearer secured.
+     *
+     * @return true when bearer auth should appear in generated documentation
+     */
+    public boolean isSecuredByBearerAuth() {
+        return usesBearerAuth;
+    }
+
+    /**
+     * Returns the bearer scheme name used in generated documentation.
+     *
+     * @return bearer auth scheme name
+     */
+    public String bearerAuthSchemeName() {
+        return bearerAuthSchemeName;
+    }
+
+    /**
+     * Reports whether this route should enforce bearer auth at runtime.
+     *
+     * @return true when the route has a named bearer enforcement scheme
+     */
+    public boolean hasBearerAuthEnforcement() {
+        return enforcedBearerAuthSchemeName != null;
+    }
+
+    /**
+     * Returns the bearer scheme name used for runtime enforcement.
+     *
+     * @return bearer enforcement scheme name, or null for documentation-only bearer routes
+     */
+    public String bearerAuthEnforcementSchemeName() {
+        return enforcedBearerAuthSchemeName;
+    }
+
+    /**
+     * Returns route-specific authorizers in registration order.
+     *
+     * @return immutable authorizer list
+     */
+    public List<ThingifierApiAuthorizer> authorizers() {
+        return List.copyOf(authorizers);
     }
 
     /**
@@ -413,7 +509,7 @@ public final class ThingifierApiRouteRule {
             route.secureWithBasicAuth();
         }
         if (usesBearerAuth) {
-            route.secureWithBearerAuth();
+            route.secureWithBearerAuth(bearerAuthSchemeName);
         }
         if (documentation != null) {
             route.addDocumentation(documentation);

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpec.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpec.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import uk.co.compendiumdev.thingifier.api.docgen.ApiRoutingDefinition;
@@ -12,16 +13,19 @@ import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.apiconfig.EntityPatchUpdateStyle;
 import uk.co.compendiumdev.thingifier.apiconfig.EntityWriteOperation;
 import uk.co.compendiumdev.thingifier.apiconfig.RelationshipWriteOperation;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 
 public final class ThingifierApiSpec {
 
     private final List<ThingifierApiRouteRule> routeRules;
+    private final List<ThingifierApiEntityRule> entityRules;
     private final List<EntityWritePolicyRule> entityWritePolicyRules;
     private final List<EntityPatchPolicyRule> entityPatchPolicyRules;
     private final List<RelationshipWritePolicyRule> relationshipWritePolicyRules;
 
     public ThingifierApiSpec() {
         routeRules = new ArrayList<>();
+        entityRules = new ArrayList<>();
         entityWritePolicyRules = new ArrayList<>();
         entityPatchPolicyRules = new ArrayList<>();
         relationshipWritePolicyRules = new ArrayList<>();
@@ -39,6 +43,19 @@ public final class ThingifierApiSpec {
 
     public ThingifierApiPathRule route(final String pathPattern) {
         return new ThingifierApiPathRule(this, pathPattern);
+    }
+
+    public ThingifierApiEntityRule entity(final String entityName) {
+        return entityRules.stream()
+                .filter(rule -> rule.sameEntityName(entityName))
+                .findFirst()
+                .orElseGet(
+                        () -> {
+                            final ThingifierApiEntityRule rule =
+                                    new ThingifierApiEntityRule(entityName);
+                            entityRules.add(rule);
+                            return rule;
+                        });
     }
 
     public ThingifierApiSpec hideEntityRoutes(final String entityPath) {
@@ -103,6 +120,7 @@ public final class ThingifierApiSpec {
         for (RoutingDefinition route : routingDefinition.definitions()) {
             ruleFor(route.verb(), route.url(), apiPathPrefix)
                     .ifPresent(rule -> rule.applyTo(route));
+            applyEntityDefaultsTo(route, routingDefinition);
         }
         routingDefinition.updateOptionsAllowHeaders();
     }
@@ -140,6 +158,56 @@ public final class ThingifierApiSpec {
                         rule ->
                                 ApiRoutePathMatcher.pathsMatch(
                                         rule.pathPattern(), path, apiPathPrefix))
+                .findFirst();
+    }
+
+    public Optional<String> requestEntityViewFor(
+            final RoutingVerb verb,
+            final String path,
+            final String apiPathPrefix,
+            final EntityDefinition entity) {
+        final Optional<String> routeView =
+                ruleFor(verb, path, apiPathPrefix)
+                        .filter(ThingifierApiRouteRule::hasRequestEntityView)
+                        .map(ThingifierApiRouteRule::getRequestEntityView);
+        if (routeView.isPresent()) {
+            return routeView;
+        }
+        return defaultRequestEntityViewFor(entity);
+    }
+
+    public Optional<String> responseEntityViewFor(
+            final RoutingVerb verb,
+            final String path,
+            final String apiPathPrefix,
+            final EntityDefinition entity,
+            final int statusCode) {
+        final Optional<String> routeView =
+                ruleFor(verb, path, apiPathPrefix)
+                        .map(rule -> rule.responseEntityViewFor(statusCode))
+                        .filter(Objects::nonNull);
+        if (routeView.isPresent()) {
+            return routeView;
+        }
+        if (statusCode < 200 || statusCode >= 300) {
+            return Optional.empty();
+        }
+        return defaultResponseEntityViewFor(entity);
+    }
+
+    public Optional<String> defaultRequestEntityViewFor(final EntityDefinition entity) {
+        return entityRules.stream()
+                .filter(rule -> rule.matches(entity))
+                .filter(ThingifierApiEntityRule::hasDefaultRequestView)
+                .map(ThingifierApiEntityRule::defaultRequestView)
+                .findFirst();
+    }
+
+    public Optional<String> defaultResponseEntityViewFor(final EntityDefinition entity) {
+        return entityRules.stream()
+                .filter(rule -> rule.matches(entity))
+                .filter(ThingifierApiEntityRule::hasDefaultResponseView)
+                .map(ThingifierApiEntityRule::defaultResponseView)
                 .findFirst();
     }
 
@@ -269,6 +337,29 @@ public final class ThingifierApiSpec {
                 verb == RoutingVerb.DELETE ? relationshipPath + "/{relatedId}" : relationshipPath;
         relationshipWritePolicyRules.add(
                 new RelationshipWritePolicyRule(verb, path, relationshipOperations(operations)));
+    }
+
+    private void applyEntityDefaultsTo(
+            final RoutingDefinition route, final ApiRoutingDefinition routingDefinition) {
+        if (!route.hasRequestEntityView() && route.hasRequestPayload()) {
+            routingDefinition
+                    .objectSchemaNamed(route.getRequestPayload())
+                    .flatMap(this::defaultRequestEntityViewFor)
+                    .ifPresent(route::requestEntityView);
+        }
+
+        for (Integer statusCode : route.returnPayloadStatusCodes()) {
+            if (route.hasResponseEntityViewFor(statusCode)) {
+                continue;
+            }
+            if (statusCode < 200 || statusCode >= 300) {
+                continue;
+            }
+            routingDefinition
+                    .objectSchemaNamed(route.getReturnPayloadFor(statusCode))
+                    .flatMap(this::defaultResponseEntityViewFor)
+                    .ifPresent(viewName -> route.responseEntityView(statusCode, viewName));
+        }
     }
 
     private Set<EntityWriteOperation> entityOperations(final EntityWriteOperation... operations) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpec.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpec.java
@@ -3,13 +3,18 @@ package uk.co.compendiumdev.thingifier.api.spec;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import uk.co.compendiumdev.thingifier.api.docgen.ApiRoutingDefinition;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingDefinition;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
+import uk.co.compendiumdev.thingifier.api.security.SecuritySchemeNames;
+import uk.co.compendiumdev.thingifier.api.security.ThingifierApiAuthenticator;
+import uk.co.compendiumdev.thingifier.api.security.ThingifierApiSecuritySpec;
 import uk.co.compendiumdev.thingifier.apiconfig.EntityPatchUpdateStyle;
 import uk.co.compendiumdev.thingifier.apiconfig.EntityWriteOperation;
 import uk.co.compendiumdev.thingifier.apiconfig.RelationshipWriteOperation;
@@ -30,6 +35,8 @@ public final class ThingifierApiSpec {
     private final List<EntityWritePolicyRule> entityWritePolicyRules;
     private final List<EntityPatchPolicyRule> entityPatchPolicyRules;
     private final List<RelationshipWritePolicyRule> relationshipWritePolicyRules;
+    private final ThingifierApiSecuritySpec securitySpec;
+    private final Map<String, ThingifierApiAuthenticator> authenticators;
 
     public ThingifierApiSpec() {
         routeRules = new ArrayList<>();
@@ -37,6 +44,8 @@ public final class ThingifierApiSpec {
         entityWritePolicyRules = new ArrayList<>();
         entityPatchPolicyRules = new ArrayList<>();
         relationshipWritePolicyRules = new ArrayList<>();
+        securitySpec = new ThingifierApiSecuritySpec();
+        authenticators = new HashMap<>();
     }
 
     /**
@@ -81,6 +90,41 @@ public final class ThingifierApiSpec {
      */
     public ThingifierApiPathRule route(final String pathPattern) {
         return new ThingifierApiPathRule(this, pathPattern);
+    }
+
+    /**
+     * Returns the security declaration builder for this API.
+     *
+     * <p>Security declarations give named schemes a stable place in the API contract. Route rules
+     * still decide which endpoints use each scheme.
+     *
+     * @return security declaration builder
+     */
+    public ThingifierApiSecuritySpec security() {
+        return securitySpec;
+    }
+
+    /**
+     * Registers an authenticator for a named security scheme.
+     *
+     * <p>Registering an authenticator makes a named scheme enforceable at runtime. The scheme is
+     * also declared as a bearer scheme for generated documentation because enforcement without a
+     * published security scheme would mislead API consumers.
+     *
+     * @param schemeName named bearer scheme
+     * @param authenticator callback used to authenticate bearer tokens for the scheme
+     * @return this spec so API configuration can be chained
+     * @throws IllegalArgumentException when the scheme name is blank or the authenticator is null
+     */
+    public ThingifierApiSpec authenticator(
+            final String schemeName, final ThingifierApiAuthenticator authenticator) {
+        final String normalizedSchemeName = SecuritySchemeNames.requireValid(schemeName);
+        if (authenticator == null) {
+            throw new IllegalArgumentException("authenticator is required");
+        }
+        securitySpec.bearer(normalizedSchemeName);
+        authenticators.put(normalizedSchemeName, authenticator);
+        return this;
     }
 
     /**
@@ -331,6 +375,17 @@ public final class ThingifierApiSpec {
                                 ApiRoutePathMatcher.pathsMatch(
                                         rule.pathPattern(), path, apiPathPrefix))
                 .findFirst();
+    }
+
+    /**
+     * Finds the authenticator registered for a named security scheme.
+     *
+     * @param schemeName named bearer scheme
+     * @return authenticator when configured
+     */
+    public Optional<ThingifierApiAuthenticator> authenticatorFor(final String schemeName) {
+        return Optional.ofNullable(
+                authenticators.get(SecuritySchemeNames.requireValid(schemeName)));
     }
 
     /**

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpec.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpec.java
@@ -37,6 +37,10 @@ public final class ThingifierApiSpec {
         return route(RoutingVerb.valueOf(verb.trim().toUpperCase()), pathPattern);
     }
 
+    public ThingifierApiPathRule route(final String pathPattern) {
+        return new ThingifierApiPathRule(this, pathPattern);
+    }
+
     public ThingifierApiSpec hideEntityRoutes(final String entityPath) {
         configureEntityRoutes(entityPath, false);
         return this;
@@ -116,6 +120,13 @@ public final class ThingifierApiSpec {
                 .orElse(false);
     }
 
+    public boolean isMethodNotAllowed(
+            final RoutingVerb verb, final String path, final String apiPathPrefix) {
+        return ruleFor(verb, path, apiPathPrefix)
+                .map(ThingifierApiRouteRule::isMethodNotAllowed)
+                .orElse(false);
+    }
+
     public Optional<ThingifierApiRouteRule> ruleFor(
             final String verb, final String path, final String apiPathPrefix) {
         return ruleFor(RoutingVerb.valueOf(verb.trim().toUpperCase()), path, apiPathPrefix);
@@ -130,6 +141,14 @@ public final class ThingifierApiSpec {
                                 ApiRoutePathMatcher.pathsMatch(
                                         rule.pathPattern(), path, apiPathPrefix))
                 .findFirst();
+    }
+
+    ThingifierApiRouteRule routeFor(final RoutingVerb verb, final String pathPattern) {
+        return routeRules.stream()
+                .filter(rule -> rule.verb() == verb)
+                .filter(rule -> samePathPattern(rule.pathPattern(), pathPattern))
+                .findFirst()
+                .orElseGet(() -> route(verb, pathPattern));
     }
 
     public Optional<Set<EntityWriteOperation>> entityWriteOperationsFor(
@@ -297,6 +316,10 @@ public final class ThingifierApiSpec {
             normalized = normalized.substring(0, normalized.length() - 1);
         }
         return normalized;
+    }
+
+    private boolean samePathPattern(final String first, final String second) {
+        return normalize(first).equals(normalize(second));
     }
 
     private static final class EntityWritePolicyRule {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpec.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpec.java
@@ -15,6 +15,14 @@ import uk.co.compendiumdev.thingifier.apiconfig.EntityWriteOperation;
 import uk.co.compendiumdev.thingifier.apiconfig.RelationshipWriteOperation;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 
+/**
+ * Declarative configuration for the generated Thingifier API surface.
+ *
+ * <p>The spec records small policy rules which are applied to generated documentation and checked
+ * by runtime handlers. It is the preferred place for API-shape decisions such as hiding generated
+ * routes, declaring a method unavailable, limiting write operations, or choosing default entity
+ * views.
+ */
 public final class ThingifierApiSpec {
 
     private final List<ThingifierApiRouteRule> routeRules;
@@ -31,20 +39,60 @@ public final class ThingifierApiSpec {
         relationshipWritePolicyRules = new ArrayList<>();
     }
 
+    /**
+     * Creates a rule for one generated route method and path.
+     *
+     * <p>Use this form when a rule depends on the HTTP-style verb, such as making only POST on a
+     * generated route method-not-allowed or applying a response view to one method.
+     *
+     * @param verb generated routing verb to configure
+     * @param pathPattern generated route path pattern
+     * @return mutable rule for the supplied verb and path
+     */
     public ThingifierApiRouteRule route(final RoutingVerb verb, final String pathPattern) {
         final ThingifierApiRouteRule rule = new ThingifierApiRouteRule(verb, pathPattern);
         routeRules.add(rule);
         return rule;
     }
 
+    /**
+     * Creates a route rule using a string verb.
+     *
+     * <p>This keeps configuration convenient for callers that receive verbs from text-based
+     * configuration. The verb is trimmed and matched case-insensitively against {@link
+     * RoutingVerb}.
+     *
+     * @param verb routing verb name
+     * @param pathPattern generated route path pattern
+     * @return mutable rule for the supplied verb and path
+     */
     public ThingifierApiRouteRule route(final String verb, final String pathPattern) {
         return route(RoutingVerb.valueOf(verb.trim().toUpperCase()), pathPattern);
     }
 
+    /**
+     * Creates a path-level rule builder for configuring multiple verbs at the same endpoint.
+     *
+     * <p>This is useful for API surface rules which are naturally path based, for example declaring
+     * both POST and PUT on {@code /carts} as method-not-allowed.
+     *
+     * @param pathPattern generated route path pattern
+     * @return path rule facade backed by verb-specific route rules
+     */
     public ThingifierApiPathRule route(final String pathPattern) {
         return new ThingifierApiPathRule(this, pathPattern);
     }
 
+    /**
+     * Returns the reusable entity-level rule for a model entity.
+     *
+     * <p>Entity rules let a caller declare default request and response views once, with
+     * route-specific rules still able to override the default for endpoints that need a different
+     * contract.
+     *
+     * @param entityName singular or plural entity name
+     * @return existing or newly-created entity rule for the supplied name
+     */
     public ThingifierApiEntityRule entity(final String entityName) {
         return entityRules.stream()
                 .filter(rule -> rule.sameEntityName(entityName))
@@ -58,46 +106,110 @@ public final class ThingifierApiSpec {
                         });
     }
 
+    /**
+     * Hides all generated collection and instance routes for an entity from documentation.
+     *
+     * <p>The routes remain callable. Use this when the API is intentionally available but should
+     * not be advertised as part of the public contract.
+     *
+     * @param entityPath entity path segment, with or without slashes
+     * @return this spec so API configuration can be chained
+     */
     public ThingifierApiSpec hideEntityRoutes(final String entityPath) {
         configureEntityRoutes(entityPath, false);
         return this;
     }
 
+    /**
+     * Disables all generated collection and instance routes for an entity.
+     *
+     * <p>Disabled routes are treated as absent at runtime and are hidden from generated
+     * documentation.
+     *
+     * @param entityPath entity path segment, with or without slashes
+     * @return this spec so API configuration can be chained
+     */
     public ThingifierApiSpec disableEntityRoutes(final String entityPath) {
         configureEntityRoutes(entityPath, true);
         return this;
     }
 
+    /**
+     * Hides all generated relationship routes for a parent entity and relationship name.
+     *
+     * @param parentEntityPath parent entity path segment, with or without slashes
+     * @param relationshipName generated relationship route segment
+     * @return this spec so API configuration can be chained
+     */
     public ThingifierApiSpec hideRelationshipRoutes(
             final String parentEntityPath, final String relationshipName) {
         configureRelationshipRoutes(parentEntityPath, relationshipName, false);
         return this;
     }
 
+    /**
+     * Disables all generated relationship routes for a parent entity and relationship name.
+     *
+     * @param parentEntityPath parent entity path segment, with or without slashes
+     * @param relationshipName generated relationship route segment
+     * @return this spec so API configuration can be chained
+     */
     public ThingifierApiSpec disableRelationshipRoutes(
             final String parentEntityPath, final String relationshipName) {
         configureRelationshipRoutes(parentEntityPath, relationshipName, true);
         return this;
     }
 
+    /**
+     * Configures which create/update semantics POST may perform for an entity path.
+     *
+     * <p>The policy applies to the generated collection and instance forms where POST can map to a
+     * concrete write operation.
+     *
+     * @param entityPath entity path segment, with or without slashes
+     * @param operations allowed write operations for POST
+     * @return this spec so API configuration can be chained
+     */
     public ThingifierApiSpec entityPostCan(
             final String entityPath, final EntityWriteOperation... operations) {
         configureEntityWritePolicy(RoutingVerb.POST, entityPath, operations);
         return this;
     }
 
+    /**
+     * Configures which create/update semantics PUT may perform for an entity path.
+     *
+     * @param entityPath entity path segment, with or without slashes
+     * @param operations allowed write operations for PUT
+     * @return this spec so API configuration can be chained
+     */
     public ThingifierApiSpec entityPutCan(
             final String entityPath, final EntityWriteOperation... operations) {
         configureEntityWritePolicy(RoutingVerb.PUT, entityPath, operations);
         return this;
     }
 
+    /**
+     * Configures which PATCH document styles may update an entity path.
+     *
+     * @param entityPath entity path segment, with or without slashes
+     * @param updateStyles accepted PATCH styles
+     * @return this spec so API configuration can be chained
+     */
     public ThingifierApiSpec entityPatchCan(
             final String entityPath, final EntityPatchUpdateStyle... updateStyles) {
         configureEntityPatchPolicy(entityPath, updateStyles);
         return this;
     }
 
+    /**
+     * Configures which relationship operations POST may perform.
+     *
+     * @param parentEntityPath parent entity path segment, with or without slashes
+     * @param relationshipName generated relationship route segment
+     * @param operations allowed relationship operations for POST
+     * @return this spec so API configuration can be chained
+     */
     public ThingifierApiSpec relationshipPostCan(
             final String parentEntityPath,
             final String relationshipName,
@@ -107,6 +219,14 @@ public final class ThingifierApiSpec {
         return this;
     }
 
+    /**
+     * Configures which relationship operations DELETE may perform.
+     *
+     * @param parentEntityPath parent entity path segment, with or without slashes
+     * @param relationshipName generated relationship route segment
+     * @param operations allowed relationship operations for DELETE
+     * @return this spec so API configuration can be chained
+     */
     public ThingifierApiSpec relationshipDeleteCan(
             final String parentEntityPath,
             final String relationshipName,
@@ -116,6 +236,15 @@ public final class ThingifierApiSpec {
         return this;
     }
 
+    /**
+     * Applies this spec to generated route documentation metadata.
+     *
+     * <p>Runtime handlers also consult the spec directly. This method keeps generated route
+     * definitions, advertised payloads, and OPTIONS Allow headers aligned with the same policy.
+     *
+     * @param routingDefinition generated route definition set to update
+     * @param apiPathPrefix configured API prefix used when matching paths
+     */
     public void applyTo(final ApiRoutingDefinition routingDefinition, final String apiPathPrefix) {
         for (RoutingDefinition route : routingDefinition.definitions()) {
             ruleFor(route.verb(), route.url(), apiPathPrefix)
@@ -125,12 +254,28 @@ public final class ThingifierApiSpec {
         routingDefinition.updateOptionsAllowHeaders();
     }
 
+    /**
+     * Reports whether a route is disabled for a string verb.
+     *
+     * @param verb routing verb name
+     * @param path request or generated route path
+     * @param apiPathPrefix configured API prefix used when matching paths
+     * @return true when a matching route rule disables the route
+     */
     public boolean isDisabled(final String verb, final String path, final String apiPathPrefix) {
         return ruleFor(verb, path, apiPathPrefix)
                 .map(ThingifierApiRouteRule::isDisabled)
                 .orElse(false);
     }
 
+    /**
+     * Reports whether a route is disabled for a routing verb.
+     *
+     * @param verb routing verb
+     * @param path request or generated route path
+     * @param apiPathPrefix configured API prefix used when matching paths
+     * @return true when a matching route rule disables the route
+     */
     public boolean isDisabled(
             final RoutingVerb verb, final String path, final String apiPathPrefix) {
         return ruleFor(verb, path, apiPathPrefix)
@@ -138,6 +283,14 @@ public final class ThingifierApiSpec {
                 .orElse(false);
     }
 
+    /**
+     * Reports whether a route should return 405 Method Not Allowed.
+     *
+     * @param verb routing verb
+     * @param path request or generated route path
+     * @param apiPathPrefix configured API prefix used when matching paths
+     * @return true when a matching route rule marks the method unavailable
+     */
     public boolean isMethodNotAllowed(
             final RoutingVerb verb, final String path, final String apiPathPrefix) {
         return ruleFor(verb, path, apiPathPrefix)
@@ -145,11 +298,30 @@ public final class ThingifierApiSpec {
                 .orElse(false);
     }
 
+    /**
+     * Finds the first route rule matching a string verb and path.
+     *
+     * @param verb routing verb name
+     * @param path request or generated route path
+     * @param apiPathPrefix configured API prefix used when matching paths
+     * @return matching route rule when configured
+     */
     public Optional<ThingifierApiRouteRule> ruleFor(
             final String verb, final String path, final String apiPathPrefix) {
         return ruleFor(RoutingVerb.valueOf(verb.trim().toUpperCase()), path, apiPathPrefix);
     }
 
+    /**
+     * Finds the first route rule matching a routing verb and path.
+     *
+     * <p>Path matching uses the same generated-route parameter behavior as runtime routing so
+     * callers can configure rules using either concrete request paths or parameterized patterns.
+     *
+     * @param verb routing verb
+     * @param path request or generated route path
+     * @param apiPathPrefix configured API prefix used when matching paths
+     * @return matching route rule when configured
+     */
     public Optional<ThingifierApiRouteRule> ruleFor(
             final RoutingVerb verb, final String path, final String apiPathPrefix) {
         return routeRules.stream()
@@ -161,6 +333,18 @@ public final class ThingifierApiSpec {
                 .findFirst();
     }
 
+    /**
+     * Resolves the request entity view for a route and entity.
+     *
+     * <p>Route-specific request views take precedence over entity defaults. Returning empty means
+     * input should use the normal generated Thingifier validation rules.
+     *
+     * @param verb routing verb
+     * @param path request path
+     * @param apiPathPrefix configured API prefix used when matching paths
+     * @param entity entity receiving request fields
+     * @return configured request entity view name when one applies
+     */
     public Optional<String> requestEntityViewFor(
             final RoutingVerb verb,
             final String path,
@@ -176,6 +360,19 @@ public final class ThingifierApiSpec {
         return defaultRequestEntityViewFor(entity);
     }
 
+    /**
+     * Resolves the response entity view for a route, entity, and status code.
+     *
+     * <p>Route status-specific views take precedence over entity defaults. Entity defaults only
+     * apply to successful responses so error payloads keep their error shape.
+     *
+     * @param verb routing verb
+     * @param path request path
+     * @param apiPathPrefix configured API prefix used when matching paths
+     * @param entity entity being rendered
+     * @param statusCode response status code
+     * @return configured response entity view name when one applies
+     */
     public Optional<String> responseEntityViewFor(
             final RoutingVerb verb,
             final String path,
@@ -195,6 +392,12 @@ public final class ThingifierApiSpec {
         return defaultResponseEntityViewFor(entity);
     }
 
+    /**
+     * Finds the entity-level default request view for an entity.
+     *
+     * @param entity entity receiving request fields
+     * @return default request view name when configured
+     */
     public Optional<String> defaultRequestEntityViewFor(final EntityDefinition entity) {
         return entityRules.stream()
                 .filter(rule -> rule.matches(entity))
@@ -203,6 +406,12 @@ public final class ThingifierApiSpec {
                 .findFirst();
     }
 
+    /**
+     * Finds the entity-level default response view for an entity.
+     *
+     * @param entity entity being rendered
+     * @return default response view name when configured
+     */
     public Optional<String> defaultResponseEntityViewFor(final EntityDefinition entity) {
         return entityRules.stream()
                 .filter(rule -> rule.matches(entity))
@@ -211,6 +420,16 @@ public final class ThingifierApiSpec {
                 .findFirst();
     }
 
+    /**
+     * Returns an exact verb/path route rule, creating it when it does not already exist.
+     *
+     * <p>Path-level builders use this so declarations such as method-not-allowed compose with any
+     * existing one-verb configuration for the same path.
+     *
+     * @param verb generated routing verb
+     * @param pathPattern generated route path pattern
+     * @return existing or newly-created route rule
+     */
     ThingifierApiRouteRule routeFor(final RoutingVerb verb, final String pathPattern) {
         return routeRules.stream()
                 .filter(rule -> rule.verb() == verb)
@@ -219,6 +438,16 @@ public final class ThingifierApiSpec {
                 .orElseGet(() -> route(verb, pathPattern));
     }
 
+    /**
+     * Resolves entity write operation policy for a route.
+     *
+     * <p>One-route rules take precedence over path-level entity policies.
+     *
+     * @param verb routing verb
+     * @param path request path
+     * @param apiPathPrefix configured API prefix used when matching paths
+     * @return allowed operations when the spec overrides generated defaults
+     */
     public Optional<Set<EntityWriteOperation>> entityWriteOperationsFor(
             final RoutingVerb verb, final String path, final String apiPathPrefix) {
         Optional<ThingifierApiRouteRule> routeRule =
@@ -238,6 +467,13 @@ public final class ThingifierApiSpec {
                 .findFirst();
     }
 
+    /**
+     * Resolves PATCH update style policy for an entity route.
+     *
+     * @param path request path
+     * @param apiPathPrefix configured API prefix used when matching paths
+     * @return accepted PATCH styles when the spec overrides generated defaults
+     */
     public Optional<Set<EntityPatchUpdateStyle>> entityPatchUpdateStylesFor(
             final String path, final String apiPathPrefix) {
         Optional<ThingifierApiRouteRule> routeRule =
@@ -256,6 +492,16 @@ public final class ThingifierApiSpec {
                 .findFirst();
     }
 
+    /**
+     * Resolves relationship write operation policy for a route.
+     *
+     * <p>One-route rules take precedence over path-level relationship policies.
+     *
+     * @param verb routing verb
+     * @param path request path
+     * @param apiPathPrefix configured API prefix used when matching paths
+     * @return allowed operations when the spec overrides generated defaults
+     */
     public Optional<Set<RelationshipWriteOperation>> relationshipWriteOperationsFor(
             final RoutingVerb verb, final String path, final String apiPathPrefix) {
         Optional<ThingifierApiRouteRule> routeRule =
@@ -275,6 +521,12 @@ public final class ThingifierApiSpec {
                 .findFirst();
     }
 
+    /**
+     * Adds hide or disable rules for the standard collection and instance routes of an entity.
+     *
+     * @param entityPath entity path segment
+     * @param disable true to disable routes, false to only hide them from docs
+     */
     private void configureEntityRoutes(final String entityPath, final boolean disable) {
         final String collectionPath = "/" + normalize(entityPath);
         final String instancePath = collectionPath + "/{id}";
@@ -284,6 +536,13 @@ public final class ThingifierApiSpec {
         }
     }
 
+    /**
+     * Adds hide or disable rules for the standard relationship collection and instance routes.
+     *
+     * @param parentEntityPath parent entity path segment
+     * @param relationshipName generated relationship route segment
+     * @param disable true to disable routes, false to only hide them from docs
+     */
     private void configureRelationshipRoutes(
             final String parentEntityPath, final String relationshipName, final boolean disable) {
         final String relationshipPath =
@@ -295,6 +554,13 @@ public final class ThingifierApiSpec {
         }
     }
 
+    /**
+     * Creates a verb/path rule and applies either disabled or hidden state.
+     *
+     * @param verb routing verb to configure
+     * @param pathPattern generated route path pattern
+     * @param disable true to disable the route, false to only hide it from docs
+     */
     private void configureRoute(
             final RoutingVerb verb, final String pathPattern, final boolean disable) {
         final ThingifierApiRouteRule rule = route(verb, pathPattern);
@@ -305,6 +571,13 @@ public final class ThingifierApiSpec {
         }
     }
 
+    /**
+     * Records entity write operation policy for generated collection and instance paths.
+     *
+     * @param verb POST or PUT
+     * @param entityPath entity path segment
+     * @param operations allowed write operations
+     */
     private void configureEntityWritePolicy(
             final RoutingVerb verb,
             final String entityPath,
@@ -319,6 +592,12 @@ public final class ThingifierApiSpec {
                 new EntityWritePolicyRule(verb, instancePath, entityOperations(operations)));
     }
 
+    /**
+     * Records PATCH update style policy for generated instance paths.
+     *
+     * @param entityPath entity path segment
+     * @param updateStyles accepted PATCH styles
+     */
     private void configureEntityPatchPolicy(
             final String entityPath, final EntityPatchUpdateStyle... updateStyles) {
         final String instancePath = "/" + normalize(entityPath) + "/{id}";
@@ -326,6 +605,14 @@ public final class ThingifierApiSpec {
                 new EntityPatchPolicyRule(instancePath, entityPatchStyles(updateStyles)));
     }
 
+    /**
+     * Records relationship write operation policy for generated relationship paths.
+     *
+     * @param verb POST or DELETE
+     * @param parentEntityPath parent entity path segment
+     * @param relationshipName generated relationship route segment
+     * @param operations allowed relationship operations
+     */
     private void configureRelationshipWritePolicy(
             final RoutingVerb verb,
             final String parentEntityPath,
@@ -339,6 +626,15 @@ public final class ThingifierApiSpec {
                 new RelationshipWritePolicyRule(verb, path, relationshipOperations(operations)));
     }
 
+    /**
+     * Applies entity-level default views to generated route payload metadata.
+     *
+     * <p>Route-level request or response views remain unchanged so explicit endpoint contracts keep
+     * precedence over entity defaults.
+     *
+     * @param route generated route metadata to update
+     * @param routingDefinition route definition set containing payload schemas
+     */
     private void applyEntityDefaultsTo(
             final RoutingDefinition route, final ApiRoutingDefinition routingDefinition) {
         if (!route.hasRequestEntityView() && route.hasRequestPayload()) {
@@ -362,6 +658,12 @@ public final class ThingifierApiSpec {
         }
     }
 
+    /**
+     * Converts caller supplied entity write operations into an immutable policy set.
+     *
+     * @param operations configured write operations, possibly null
+     * @return immutable operation set, or an empty set when no operations are configured
+     */
     private Set<EntityWriteOperation> entityOperations(final EntityWriteOperation... operations) {
         EnumSet<EntityWriteOperation> selected = EnumSet.noneOf(EntityWriteOperation.class);
         if (operations != null) {
@@ -373,6 +675,12 @@ public final class ThingifierApiSpec {
         return Collections.unmodifiableSet(EnumSet.copyOf(selected));
     }
 
+    /**
+     * Converts caller supplied PATCH styles into an immutable policy set.
+     *
+     * @param updateStyles configured PATCH styles, possibly null
+     * @return immutable style set, or an empty set when no styles are configured
+     */
     private Set<EntityPatchUpdateStyle> entityPatchStyles(
             final EntityPatchUpdateStyle... updateStyles) {
         EnumSet<EntityPatchUpdateStyle> selected = EnumSet.noneOf(EntityPatchUpdateStyle.class);
@@ -385,6 +693,12 @@ public final class ThingifierApiSpec {
         return Collections.unmodifiableSet(EnumSet.copyOf(selected));
     }
 
+    /**
+     * Converts caller supplied relationship operations into an immutable policy set.
+     *
+     * @param operations configured relationship operations, possibly null
+     * @return immutable operation set, or an empty set when no operations are configured
+     */
     private Set<RelationshipWriteOperation> relationshipOperations(
             final RelationshipWriteOperation... operations) {
         EnumSet<RelationshipWriteOperation> selected =
@@ -398,6 +712,12 @@ public final class ThingifierApiSpec {
         return Collections.unmodifiableSet(EnumSet.copyOf(selected));
     }
 
+    /**
+     * Normalizes path segments so equivalent API spec inputs match generated route patterns.
+     *
+     * @param path path or path segment, with optional leading/trailing slashes
+     * @return path without leading or trailing slash characters
+     */
     private String normalize(final String path) {
         String normalized = path == null ? "" : path.trim();
         while (normalized.startsWith("/")) {
@@ -409,6 +729,13 @@ public final class ThingifierApiSpec {
         return normalized;
     }
 
+    /**
+     * Compares generated path patterns using the same slash-tolerant normalization.
+     *
+     * @param first first path pattern
+     * @param second second path pattern
+     * @return true when the patterns are equivalent after normalization
+     */
     private boolean samePathPattern(final String first, final String second) {
         return normalize(first).equals(normalize(second));
     }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/apiconfig/RelationshipWriteOperation.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/apiconfig/RelationshipWriteOperation.java
@@ -1,7 +1,23 @@
 package uk.co.compendiumdev.thingifier.apiconfig;
 
+/**
+ * Describes the relationship write operations that a generated API route may accept.
+ *
+ * <p>These values are used by {@code ThingifierApiConfig} and route-level API spec rules to keep
+ * generated documentation, direct API calls, and HTTP handling aligned. Relationship POST defaults
+ * to creating new children or connecting existing ones; updating an already connected child is
+ * explicit opt-in.
+ */
 public enum RelationshipWriteOperation {
+    /** Create a new target entity and connect it to the relationship source. */
     CREATE_AND_CONNECT,
+
+    /** Connect an existing target entity without changing the target's fields. */
     CONNECT_EXISTING,
+
+    /** Partially update an existing target entity that is already connected. */
+    UPDATE_CONNECTED,
+
+    /** Remove the connection between source and target entities. */
     DISCONNECT
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/AmendThingHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/AmendThingHandler.java
@@ -12,6 +12,12 @@ import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstanceDraft;
 import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
 import uk.co.compendiumdev.thingifier.core.repository.ThingStoreWriteException;
 
+/**
+ * Validates and applies commands that amend or replace entity instances.
+ *
+ * <p>The handler supports partial field amendment and full replacement while keeping validation
+ * separate from mutation for lifecycle hook processing.
+ */
 final class AmendThingHandler {
 
     private final ThingStore store;
@@ -21,6 +27,16 @@ final class AmendThingHandler {
     private final CreateThingHandler createHandler;
     private final RelationshipConnectionService relationships;
 
+    /**
+     * Creates the amend/replacement handler.
+     *
+     * @param store store to mutate
+     * @param definitions resolver for model definitions and instances
+     * @param validation write validation policy
+     * @param drafts factory for create-on-replace drafts
+     * @param createHandler handler used when replacement creates a missing instance
+     * @param relationships service used to reconnect relationship references
+     */
     AmendThingHandler(
             final ThingStore store,
             final ThingDefinitionResolver definitions,
@@ -36,6 +52,12 @@ final class AmendThingHandler {
         this.relationships = relationships;
     }
 
+    /**
+     * Validates and applies an amend command in one call.
+     *
+     * @param command amend command to handle
+     * @return validation error or successful amend result
+     */
     ThingCommandResult handle(final AmendThingCommand command) {
         ThingCommandResult validationResult = validate(command);
         if (validationResult != null) {
@@ -44,6 +66,12 @@ final class AmendThingHandler {
         return apply(command);
     }
 
+    /**
+     * Validates an amend command without mutating the store.
+     *
+     * @param command amend command to validate
+     * @return validation error, or null when validation succeeds
+     */
     ThingCommandResult validate(final AmendThingCommand command) {
         EntityDefinition entity = definitions.entityNamed(command.getEntityName());
         ThingCommandResult typeValidation =
@@ -62,6 +90,12 @@ final class AmendThingHandler {
         return null;
     }
 
+    /**
+     * Applies an amend command after validation.
+     *
+     * @param command validated amend command
+     * @return command result containing the updated instance or an error
+     */
     ThingCommandResult apply(final AmendThingCommand command) {
         EntityDefinition entity = definitions.entityNamed(command.getEntityName());
         EntityInstance instance = definitions.resolveInstance(entity, command.getIdentifier());
@@ -89,6 +123,12 @@ final class AmendThingHandler {
         }
     }
 
+    /**
+     * Validates and applies a replace command in one call.
+     *
+     * @param command replace command to handle
+     * @return validation error or successful replace/create result
+     */
     ThingCommandResult handle(final ReplaceThingCommand command) {
         ThingCommandResult validationResult = validate(command);
         if (validationResult != null) {
@@ -97,6 +137,14 @@ final class AmendThingHandler {
         return apply(command);
     }
 
+    /**
+     * Validates a replace command without mutating the store.
+     *
+     * <p>When the target does not exist, validation checks whether the replacement may create it.
+     *
+     * @param command replace command to validate
+     * @return validation error, or null when validation succeeds
+     */
     ThingCommandResult validate(final ReplaceThingCommand command) {
         EntityDefinition entity = definitions.entityNamed(command.getEntityName());
         if (entity == null) {
@@ -137,6 +185,15 @@ final class AmendThingHandler {
         return null;
     }
 
+    /**
+     * Applies a replace command after validation.
+     *
+     * <p>Existing instances are fully replaced; missing instances are created when replacement
+     * create policy allows it.
+     *
+     * @param command validated replace command
+     * @return command result containing the updated or created instance
+     */
     ThingCommandResult apply(final ReplaceThingCommand command) {
         EntityDefinition entity = definitions.entityNamed(command.getEntityName());
         if (entity == null) {
@@ -179,6 +236,16 @@ final class AmendThingHandler {
         }
     }
 
+    /**
+     * Applies field and relationship changes to an existing instance.
+     *
+     * @param instance existing instance to update
+     * @param draft draft values to write
+     * @param replaceExistingFields true to replace fields, false to patch them
+     * @param replaceExistingRelationships true to disconnect relationships before reconnecting
+     * @param relationshipReferences relationships to connect after the field update
+     * @return command result containing the updated instance or an error
+     */
     private ThingCommandResult amend(
             final EntityInstance instance,
             final EntityInstanceDraft draft,
@@ -217,6 +284,14 @@ final class AmendThingHandler {
         }
     }
 
+    /**
+     * Ensures replacement values include the primary key when the identifier came from the URI.
+     *
+     * @param entity entity definition being replaced
+     * @param identifier URI identifier
+     * @param fieldValues normalized field values from the request body
+     * @return field values with primary key added when needed
+     */
     private List<NamedValue> fieldValuesWithIdentifierIfMissing(
             final EntityDefinition entity,
             final String identifier,

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/AmendThingHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/AmendThingHandler.java
@@ -87,6 +87,12 @@ final class AmendThingHandler {
                     ApplicationError.instanceNotFound(
                             command.getEntityName(), command.getIdentifier()));
         }
+        ThingCommandResult relationshipValidation =
+                relationships.validateRelationshipReferences(
+                        entity, command.getRelationships(), false);
+        if (relationshipValidation != null) {
+            return relationshipValidation;
+        }
         return null;
     }
 
@@ -157,6 +163,13 @@ final class AmendThingHandler {
                         entity, command.getBodyFields());
         if (typeValidation != null) {
             return typeValidation;
+        }
+
+        ThingCommandResult relationshipValidation =
+                relationships.validateRelationshipReferences(
+                        entity, command.getRelationships(), false);
+        if (relationshipValidation != null) {
+            return relationshipValidation;
         }
 
         List<NamedValue> fieldValues =

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/AmendThingHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/AmendThingHandler.java
@@ -37,6 +37,14 @@ final class AmendThingHandler {
     }
 
     ThingCommandResult handle(final AmendThingCommand command) {
+        ThingCommandResult validationResult = validate(command);
+        if (validationResult != null) {
+            return validationResult;
+        }
+        return apply(command);
+    }
+
+    ThingCommandResult validate(final AmendThingCommand command) {
         EntityDefinition entity = definitions.entityNamed(command.getEntityName());
         ThingCommandResult typeValidation =
                 validation.validateDeclaredFieldTypesIgnoringProtected(
@@ -51,7 +59,17 @@ final class AmendThingHandler {
                     ApplicationError.instanceNotFound(
                             command.getEntityName(), command.getIdentifier()));
         }
+        return null;
+    }
 
+    ThingCommandResult apply(final AmendThingCommand command) {
+        EntityDefinition entity = definitions.entityNamed(command.getEntityName());
+        EntityInstance instance = definitions.resolveInstance(entity, command.getIdentifier());
+        if (instance == null) {
+            return ThingCommandResult.error(
+                    ApplicationError.instanceNotFound(
+                            command.getEntityName(), command.getIdentifier()));
+        }
         try {
             List<NamedValue> fieldValues =
                     validation.normalizedFieldValues(
@@ -72,7 +90,20 @@ final class AmendThingHandler {
     }
 
     ThingCommandResult handle(final ReplaceThingCommand command) {
+        ThingCommandResult validationResult = validate(command);
+        if (validationResult != null) {
+            return validationResult;
+        }
+        return apply(command);
+    }
+
+    ThingCommandResult validate(final ReplaceThingCommand command) {
         EntityDefinition entity = definitions.entityNamed(command.getEntityName());
+        if (entity == null) {
+            return ThingCommandResult.error(
+                    ApplicationError.notFound(
+                            String.format("Could not find entity %s", command.getEntityName())));
+        }
         ThingCommandResult typeValidation =
                 validation.validateDeclaredFieldTypesIgnoringProtected(
                         entity, command.getBodyFields());
@@ -80,6 +111,39 @@ final class AmendThingHandler {
             return typeValidation;
         }
 
+        List<NamedValue> fieldValues =
+                validation.normalizedFieldValues(
+                        entity, command.getFieldValues(), command.getBodyFields());
+        EntityInstance instance = definitions.resolveInstance(entity, command.getIdentifier());
+        if (instance != null) {
+            try {
+                List<NamedValue> replacementValues =
+                        fieldValuesWithIdentifierIfMissing(
+                                entity, command.getIdentifier(), fieldValues);
+                new EntityInstanceDraftBuilder(instance).setFieldValuesFrom(replacementValues);
+                return null;
+            } catch (ThingStoreWriteException e) {
+                throw e;
+            } catch (Exception e) {
+                return ThingCommandResult.error(ApplicationExceptionMessages.messageFrom(e));
+            }
+        }
+
+        ThingCommandResult creationAllowed =
+                validation.validateReplaceCreate(entity, command.getIdentifier(), fieldValues);
+        if (creationAllowed != null) {
+            return creationAllowed;
+        }
+        return null;
+    }
+
+    ThingCommandResult apply(final ReplaceThingCommand command) {
+        EntityDefinition entity = definitions.entityNamed(command.getEntityName());
+        if (entity == null) {
+            return ThingCommandResult.error(
+                    ApplicationError.notFound(
+                            String.format("Could not find entity %s", command.getEntityName())));
+        }
         List<NamedValue> fieldValues =
                 validation.normalizedFieldValues(
                         entity, command.getFieldValues(), command.getBodyFields());
@@ -99,13 +163,6 @@ final class AmendThingHandler {
                 return ThingCommandResult.error(ApplicationExceptionMessages.messageFrom(e));
             }
         }
-
-        ThingCommandResult creationAllowed =
-                validation.validateReplaceCreate(entity, command.getIdentifier(), fieldValues);
-        if (creationAllowed != null) {
-            return creationAllowed;
-        }
-
         try {
             EntityInstanceDraft draft =
                     drafts.createDraft(entity, command.getIdentifier(), fieldValues);

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/CreateThingHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/CreateThingHandler.java
@@ -92,6 +92,12 @@ final class CreateThingHandler {
         if (validationResult != null) {
             return validationResult;
         }
+        ThingCommandResult relationshipValidation =
+                relationships.validateRelationshipReferences(
+                        entity, command.getRelationships(), true);
+        if (relationshipValidation != null) {
+            return relationshipValidation;
+        }
         return null;
     }
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/CreateThingHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/CreateThingHandler.java
@@ -10,6 +10,12 @@ import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstanceDraft;
 import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
 import uk.co.compendiumdev.thingifier.core.repository.ThingStoreWriteException;
 
+/**
+ * Validates and applies commands that create entity instances.
+ *
+ * <p>The handler keeps validation separate from mutation so lifecycle hooks can inspect or replace
+ * validation results before the store is changed.
+ */
 final class CreateThingHandler {
 
     private final ThingStore store;
@@ -18,6 +24,15 @@ final class CreateThingHandler {
     private final ThingDraftFactory drafts;
     private final RelationshipConnectionService relationships;
 
+    /**
+     * Creates the entity creation handler.
+     *
+     * @param store store to mutate
+     * @param definitions resolver for model definitions and instances
+     * @param validation write validation policy
+     * @param drafts factory for validated entity drafts
+     * @param relationships service used to connect relationship references after creation
+     */
     CreateThingHandler(
             final ThingStore store,
             final ThingDefinitionResolver definitions,
@@ -31,6 +46,12 @@ final class CreateThingHandler {
         this.relationships = relationships;
     }
 
+    /**
+     * Validates and applies a create command in one call.
+     *
+     * @param command create command to handle
+     * @return validation error or successful create result
+     */
     ThingCommandResult handle(final CreateThingCommand command) {
         ThingCommandResult validationResult = validate(command);
         if (validationResult != null) {
@@ -39,6 +60,12 @@ final class CreateThingHandler {
         return apply(command);
     }
 
+    /**
+     * Validates a create command without mutating the store.
+     *
+     * @param command create command to validate
+     * @return validation error, or null when validation succeeds
+     */
     ThingCommandResult validate(final CreateThingCommand command) {
         EntityDefinition entity = definitions.entityNamed(command.getEntityName());
         if (entity == null) {
@@ -68,6 +95,12 @@ final class CreateThingHandler {
         return null;
     }
 
+    /**
+     * Applies a create command after validation.
+     *
+     * @param command validated create command
+     * @return command result containing the created instance or an error
+     */
     ThingCommandResult apply(final CreateThingCommand command) {
         EntityDefinition entity = definitions.entityNamed(command.getEntityName());
         if (entity == null) {
@@ -90,6 +123,14 @@ final class CreateThingHandler {
         }
     }
 
+    /**
+     * Persists a draft and connects any relationship references supplied with the create command.
+     *
+     * @param draft draft entity to persist
+     * @param relationshipReferences relationships to connect after creation
+     * @param validateFinalRelationships true when final relationship constraints should be checked
+     * @return command result containing the created instance or an error
+     */
     ThingCommandResult create(
             final EntityInstanceDraft draft,
             final List<RelationshipReference> relationshipReferences,

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/CreateThingHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/CreateThingHandler.java
@@ -32,6 +32,14 @@ final class CreateThingHandler {
     }
 
     ThingCommandResult handle(final CreateThingCommand command) {
+        ThingCommandResult validationResult = validate(command);
+        if (validationResult != null) {
+            return validationResult;
+        }
+        return apply(command);
+    }
+
+    ThingCommandResult validate(final CreateThingCommand command) {
         EntityDefinition entity = definitions.entityNamed(command.getEntityName());
         if (entity == null) {
             return ThingCommandResult.error(
@@ -57,8 +65,20 @@ final class CreateThingHandler {
         if (validationResult != null) {
             return validationResult;
         }
+        return null;
+    }
 
+    ThingCommandResult apply(final CreateThingCommand command) {
+        EntityDefinition entity = definitions.entityNamed(command.getEntityName());
+        if (entity == null) {
+            return ThingCommandResult.error(
+                    ApplicationError.notFound(
+                            String.format("Could not find entity %s", command.getEntityName())));
+        }
         try {
+            List<NamedValue> fieldValues =
+                    validation.normalizedFieldValues(
+                            entity, command.getFieldValues(), command.getBodyFields());
             EntityInstanceDraft draft =
                     drafts.createDraft(entity, command.getRequestedPrimaryKey(), fieldValues);
             return create(

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/DeleteThingHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/DeleteThingHandler.java
@@ -6,16 +6,33 @@ import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
 import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
 import uk.co.compendiumdev.thingifier.core.repository.ThingStoreWriteException;
 
+/**
+ * Validates and applies commands that delete entity instances.
+ *
+ * <p>Validation only proves the target exists; apply performs the actual store mutation.
+ */
 final class DeleteThingHandler {
 
     private final ThingStore store;
     private final ThingDefinitionResolver definitions;
 
+    /**
+     * Creates the delete handler.
+     *
+     * @param store store to mutate
+     * @param definitions resolver for model definitions and instances
+     */
     DeleteThingHandler(final ThingStore store, final ThingDefinitionResolver definitions) {
         this.store = store;
         this.definitions = definitions;
     }
 
+    /**
+     * Validates and applies a delete command in one call.
+     *
+     * @param command delete command to handle
+     * @return validation error or successful delete result
+     */
     ThingCommandResult handle(final DeleteThingCommand command) {
         ThingCommandResult validationResult = validate(command);
         if (validationResult != null) {
@@ -24,6 +41,12 @@ final class DeleteThingHandler {
         return apply(command);
     }
 
+    /**
+     * Validates a delete command without mutating the store.
+     *
+     * @param command delete command to validate
+     * @return validation error, or null when validation succeeds
+     */
     ThingCommandResult validate(final DeleteThingCommand command) {
         EntityDefinition entity = definitions.entityNamed(command.getEntityName());
         EntityInstance instance = definitions.resolveInstance(entity, command.getIdentifier());
@@ -35,6 +58,12 @@ final class DeleteThingHandler {
         return null;
     }
 
+    /**
+     * Applies a delete command after validation.
+     *
+     * @param command validated delete command
+     * @return successful command result or store error
+     */
     ThingCommandResult apply(final DeleteThingCommand command) {
         EntityDefinition entity = definitions.entityNamed(command.getEntityName());
         EntityInstance instance = definitions.resolveInstance(entity, command.getIdentifier());

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/DeleteThingHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/DeleteThingHandler.java
@@ -13,8 +13,8 @@ import uk.co.compendiumdev.thingifier.core.repository.ThingStoreWriteException;
  */
 final class DeleteThingHandler {
 
-    private final ThingStore store;
     private final ThingDefinitionResolver definitions;
+    private final RelationshipCascadeDeleteService cascadeDeletes;
 
     /**
      * Creates the delete handler.
@@ -23,8 +23,22 @@ final class DeleteThingHandler {
      * @param definitions resolver for model definitions and instances
      */
     DeleteThingHandler(final ThingStore store, final ThingDefinitionResolver definitions) {
-        this.store = store;
+        this(store, definitions, new RelationshipCascadeDeleteService(store));
+    }
+
+    /**
+     * Creates the delete handler with an explicit cascade delete service for focused tests.
+     *
+     * @param store store associated with the command service
+     * @param definitions resolver for model definitions and instances
+     * @param cascadeDeletes service that applies configured relationship ownership deletes
+     */
+    DeleteThingHandler(
+            final ThingStore store,
+            final ThingDefinitionResolver definitions,
+            final RelationshipCascadeDeleteService cascadeDeletes) {
         this.definitions = definitions;
+        this.cascadeDeletes = cascadeDeletes;
     }
 
     /**
@@ -73,7 +87,7 @@ final class DeleteThingHandler {
                             command.getEntityName(), command.getIdentifier()));
         }
         try {
-            store.entities().delete(instance);
+            cascadeDeletes.deleteInstance(instance);
             return ThingCommandResult.success();
         } catch (ThingStoreWriteException e) {
             throw e;

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/DeleteThingHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/DeleteThingHandler.java
@@ -17,6 +17,14 @@ final class DeleteThingHandler {
     }
 
     ThingCommandResult handle(final DeleteThingCommand command) {
+        ThingCommandResult validationResult = validate(command);
+        if (validationResult != null) {
+            return validationResult;
+        }
+        return apply(command);
+    }
+
+    ThingCommandResult validate(final DeleteThingCommand command) {
         EntityDefinition entity = definitions.entityNamed(command.getEntityName());
         EntityInstance instance = definitions.resolveInstance(entity, command.getIdentifier());
         if (instance == null) {
@@ -24,7 +32,17 @@ final class DeleteThingHandler {
                     ApplicationError.instanceNotFound(
                             command.getEntityName(), command.getIdentifier()));
         }
+        return null;
+    }
 
+    ThingCommandResult apply(final DeleteThingCommand command) {
+        EntityDefinition entity = definitions.entityNamed(command.getEntityName());
+        EntityInstance instance = definitions.resolveInstance(entity, command.getIdentifier());
+        if (instance == null) {
+            return ThingCommandResult.error(
+                    ApplicationError.instanceNotFound(
+                            command.getEntityName(), command.getIdentifier()));
+        }
         try {
             store.entities().delete(instance);
             return ThingCommandResult.success();

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/PatchThingDocumentHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/PatchThingDocumentHandler.java
@@ -21,12 +21,27 @@ import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.field.instance.NamedValue;
 import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
 
+/**
+ * Validates and applies JSON Patch and JSON Merge Patch document commands.
+ *
+ * <p>The handler turns a patch document into a replacement amend command. Keeping this conversion
+ * separate from mutation lets lifecycle hooks inspect validation before the patched document is
+ * applied to the store.
+ */
 final class PatchThingDocumentHandler {
 
     private final ThingDefinitionResolver definitions;
     private final AmendThingHandler amendHandler;
     private final JsonOutputConfig jsonOutput;
 
+    /**
+     * Creates the patch document handler.
+     *
+     * @param definitions resolver for model definitions and instances
+     * @param amendHandler handler used to validate and apply the replacement command
+     * @param jsonOutput JSON output configuration used to render the current instance before
+     *     patching
+     */
     PatchThingDocumentHandler(
             final ThingDefinitionResolver definitions,
             final AmendThingHandler amendHandler,
@@ -36,6 +51,12 @@ final class PatchThingDocumentHandler {
         this.jsonOutput = jsonOutput == null ? new JsonOutputConfig() : jsonOutput;
     }
 
+    /**
+     * Validates and applies a patch document command in one call.
+     *
+     * @param command patch document command to handle
+     * @return validation error or successful amend result
+     */
     ThingCommandResult handle(final PatchThingDocumentCommand command) {
         ThingCommandResult validationResult = validate(command);
         if (validationResult != null) {
@@ -44,6 +65,15 @@ final class PatchThingDocumentHandler {
         return apply(command);
     }
 
+    /**
+     * Validates a patch document without mutating the store.
+     *
+     * <p>Validation applies the patch to an in-memory representation and validates the equivalent
+     * replacement command.
+     *
+     * @param command patch document command to validate
+     * @return validation error, or null when validation succeeds
+     */
     ThingCommandResult validate(final PatchThingDocumentCommand command) {
         EntityDefinition entity = definitions.entityNamed(command.getEntityName());
         EntityInstance instance = definitions.resolveInstance(entity, command.getIdentifier());
@@ -75,6 +105,12 @@ final class PatchThingDocumentHandler {
         return amendHandler.validate(replacementCommand(command, patchedDocument));
     }
 
+    /**
+     * Applies a patch document after validation.
+     *
+     * @param command validated patch document command
+     * @return command result from applying the equivalent amend command
+     */
     ThingCommandResult apply(final PatchThingDocumentCommand command) {
         EntityDefinition entity = definitions.entityNamed(command.getEntityName());
         EntityInstance instance = definitions.resolveInstance(entity, command.getIdentifier());
@@ -106,6 +142,12 @@ final class PatchThingDocumentHandler {
         return amendHandler.apply(replacementCommand(command, patchedDocument));
     }
 
+    /**
+     * Parses the raw patch document into JSON.
+     *
+     * @param command patch document command
+     * @return parsed document, or null when parsing fails
+     */
     private JsonNode parsePatchDocument(final PatchThingDocumentCommand command) {
         try {
             return JsonBodyValueConverter.readTree(command.getRawDocument());
@@ -114,6 +156,12 @@ final class PatchThingDocumentHandler {
         }
     }
 
+    /**
+     * Creates the style-specific malformed patch error.
+     *
+     * @param command patch document command
+     * @return command result containing the malformed document error
+     */
     private ThingCommandResult malformedPatch(final PatchThingDocumentCommand command) {
         if (command.getStyle()
                 == PatchThingDocumentCommand.DocumentStyle.JSON_MERGE_PATCH_RFC7396) {
@@ -124,6 +172,13 @@ final class PatchThingDocumentHandler {
                 ApplicationError.badRequest("Malformed JSON Patch document"));
     }
 
+    /**
+     * Validates the top-level shape required by the selected patch document style.
+     *
+     * @param command patch document command
+     * @param patchDocument parsed patch document
+     * @return validation error, or null when the shape is valid
+     */
     private ThingCommandResult validateDocumentShape(
             final PatchThingDocumentCommand command, final JsonNode patchDocument) {
         if (command.getStyle()
@@ -144,6 +199,14 @@ final class PatchThingDocumentHandler {
         return null;
     }
 
+    /**
+     * Applies the parsed patch document to the current instance JSON.
+     *
+     * @param command patch document command
+     * @param instance current entity instance
+     * @param patchDocument parsed patch document
+     * @return patched JSON document, or null when JSON Patch application fails
+     */
     private JsonNode patchedDocument(
             final PatchThingDocumentCommand command,
             final EntityInstance instance,
@@ -161,6 +224,13 @@ final class PatchThingDocumentHandler {
         }
     }
 
+    /**
+     * Applies RFC 7396 merge patch semantics to a JSON target.
+     *
+     * @param target current JSON target
+     * @param patch merge patch document
+     * @return merged JSON document
+     */
     private JsonNode applyMergePatch(final JsonNode target, final JsonNode patch) {
         if (!patch.isObject()) {
             return patch;
@@ -182,6 +252,12 @@ final class PatchThingDocumentHandler {
         return result;
     }
 
+    /**
+     * Renders an entity instance as JSON so patch documents can be applied in memory.
+     *
+     * @param instance current entity instance
+     * @return JSON representation of the instance
+     */
     private JsonNode jsonFor(final EntityInstance instance) {
         try {
             return JsonBodyValueConverter.readTree(
@@ -191,6 +267,13 @@ final class PatchThingDocumentHandler {
         }
     }
 
+    /**
+     * Builds the amend command represented by a successfully patched document.
+     *
+     * @param command original patch document command
+     * @param patchedDocument patched JSON object
+     * @return amend command replacing fields from the patched document
+     */
     private AmendThingCommand replacementCommand(
             final PatchThingDocumentCommand command, final JsonNode patchedDocument) {
         ApiBodyFields bodyFields =
@@ -205,6 +288,12 @@ final class PatchThingDocumentHandler {
                 List.of());
     }
 
+    /**
+     * Converts parsed body fields into command named values.
+     *
+     * @param bodyFields parsed body fields
+     * @return flattened named values
+     */
     private List<NamedValue> fieldValues(final ApiBodyFields bodyFields) {
         List<NamedValue> values = new ArrayList<>();
         for (Map.Entry<String, String> entry : bodyFields.asFlattenedStringMap()) {
@@ -213,6 +302,12 @@ final class PatchThingDocumentHandler {
         return values;
     }
 
+    /**
+     * Converts parsed body fields into typed command body field values.
+     *
+     * @param bodyFields parsed body fields
+     * @return top-level typed body values
+     */
     private List<BodyFieldValue> bodyFieldValues(final ApiBodyFields bodyFields) {
         List<BodyFieldValue> values = new ArrayList<>();
         for (ApiBodyField field : bodyFields.topLevelFields()) {
@@ -223,6 +318,12 @@ final class PatchThingDocumentHandler {
         return values;
     }
 
+    /**
+     * Maps parser source type names to command source type values.
+     *
+     * @param sourceType source type name from parsed body fields
+     * @return command source type
+     */
     private BodyFieldValue.SourceType sourceTypeFor(final String sourceType) {
         if ("STRING".equals(sourceType)) {
             return BodyFieldValue.SourceType.STRING;

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/PatchThingDocumentHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/PatchThingDocumentHandler.java
@@ -37,6 +37,14 @@ final class PatchThingDocumentHandler {
     }
 
     ThingCommandResult handle(final PatchThingDocumentCommand command) {
+        ThingCommandResult validationResult = validate(command);
+        if (validationResult != null) {
+            return validationResult;
+        }
+        return apply(command);
+    }
+
+    ThingCommandResult validate(final PatchThingDocumentCommand command) {
         EntityDefinition entity = definitions.entityNamed(command.getEntityName());
         EntityInstance instance = definitions.resolveInstance(entity, command.getIdentifier());
         if (instance == null) {
@@ -64,7 +72,38 @@ final class PatchThingDocumentHandler {
             return ThingCommandResult.error(ApplicationError.patchResultNotObject());
         }
 
-        return amendHandler.handle(replacementCommand(command, patchedDocument));
+        return amendHandler.validate(replacementCommand(command, patchedDocument));
+    }
+
+    ThingCommandResult apply(final PatchThingDocumentCommand command) {
+        EntityDefinition entity = definitions.entityNamed(command.getEntityName());
+        EntityInstance instance = definitions.resolveInstance(entity, command.getIdentifier());
+        if (instance == null) {
+            return ThingCommandResult.error(
+                    ApplicationError.instanceNotFound(
+                            command.getEntityName(), command.getIdentifier()));
+        }
+
+        JsonNode patchDocument = parsePatchDocument(command);
+        if (patchDocument == null) {
+            return malformedPatch(command);
+        }
+
+        ThingCommandResult shapeValidation = validateDocumentShape(command, patchDocument);
+        if (shapeValidation != null) {
+            return shapeValidation;
+        }
+
+        JsonNode patchedDocument = patchedDocument(command, instance, patchDocument);
+        if (patchedDocument == null) {
+            return ThingCommandResult.error(
+                    ApplicationError.conflict("JSON Patch could not be applied"));
+        }
+        if (!patchedDocument.isObject()) {
+            return ThingCommandResult.error(ApplicationError.patchResultNotObject());
+        }
+
+        return amendHandler.apply(replacementCommand(command, patchedDocument));
     }
 
     private JsonNode parsePatchDocument(final PatchThingDocumentCommand command) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/RelationshipCascadeDeleteService.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/RelationshipCascadeDeleteService.java
@@ -1,0 +1,78 @@
+package uk.co.compendiumdev.thingifier.application;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.relationship.RelationshipVectorDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
+import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
+
+final class RelationshipCascadeDeleteService {
+
+    private final ThingStore store;
+
+    RelationshipCascadeDeleteService(final ThingStore store) {
+        this.store = store;
+    }
+
+    void deleteInstance(final EntityInstance instance) {
+        deleteInstance(instance, new HashSet<>());
+    }
+
+    void deleteTargetAfterDisconnect(
+            final EntityInstance parent,
+            final String relationshipName,
+            final EntityInstance child) {
+        RelationshipVectorDefinition vector =
+                parent.getEntity().getNamedRelationshipTo(relationshipName, child.getEntity());
+        if (vector != null && vector.shouldDeleteTargetWhenDisconnected()) {
+            deleteInstance(child);
+        }
+    }
+
+    private void deleteInstance(final EntityInstance instance, final Set<String> alreadyDeleting) {
+        if (instance == null || !alreadyDeleting.add(instance.getInternalId())) {
+            return;
+        }
+        if (!isPersisted(instance)) {
+            return;
+        }
+
+        for (EntityInstance target : cascadeTargetsFor(instance)) {
+            deleteInstance(target, alreadyDeleting);
+        }
+
+        if (isPersisted(instance)) {
+            store.entities().delete(instance);
+        }
+    }
+
+    private List<EntityInstance> cascadeTargetsFor(final EntityInstance instance) {
+        List<EntityInstance> targets = new ArrayList<>();
+        for (RelationshipVectorDefinition relationship :
+                instance.getEntity().related().getRelationships()) {
+            if (relationship.shouldDeleteTargetsWhenSourceDeleted()) {
+                targets.addAll(store.relationships().listRelated(instance, relationship.getName()));
+            }
+        }
+        return targets;
+    }
+
+    private boolean isPersisted(final EntityInstance instance) {
+        if (instance.getPrimaryKeyValue() != null) {
+            EntityInstance found =
+                    store.entityQueries()
+                            .findByQueryIdentifier(
+                                    instance.getEntity(), instance.getPrimaryKeyValue());
+            return found != null && found.getInternalId().equals(instance.getInternalId());
+        }
+
+        for (EntityInstance candidate : store.entityQueries().list(instance.getEntity())) {
+            if (candidate.getInternalId().equals(instance.getInternalId())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/RelationshipCommandHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/RelationshipCommandHandler.java
@@ -5,6 +5,7 @@ import uk.co.compendiumdev.thingifier.application.command.ConnectExistingRelatio
 import uk.co.compendiumdev.thingifier.application.command.CreateAndConnectRelationshipCommand;
 import uk.co.compendiumdev.thingifier.application.command.DisconnectRelationshipCommand;
 import uk.co.compendiumdev.thingifier.application.command.RelateThingCommand;
+import uk.co.compendiumdev.thingifier.application.command.UpdateConnectedRelationshipCommand;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.field.instance.NamedValue;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.relationship.RelationshipVectorDefinition;
@@ -29,6 +30,7 @@ final class RelationshipCommandHandler {
     private final CreateThingHandler createHandler;
     private final RelationshipConnectionService relationships;
     private final RelationshipTargetResolver targets;
+    private final RelationshipCascadeDeleteService cascadeDeletes;
 
     /**
      * Creates the relationship command handler.
@@ -48,7 +50,8 @@ final class RelationshipCommandHandler {
             final ThingDraftFactory drafts,
             final CreateThingHandler createHandler,
             final RelationshipConnectionService relationships,
-            final RelationshipTargetResolver targets) {
+            final RelationshipTargetResolver targets,
+            final RelationshipCascadeDeleteService cascadeDeletes) {
         this.store = store;
         this.definitions = definitions;
         this.validation = validation;
@@ -56,6 +59,7 @@ final class RelationshipCommandHandler {
         this.createHandler = createHandler;
         this.relationships = relationships;
         this.targets = targets;
+        this.cascadeDeletes = cascadeDeletes;
     }
 
     /**
@@ -181,6 +185,12 @@ final class RelationshipCommandHandler {
         if (validationResult != null) {
             return validationResult;
         }
+        ThingCommandResult relationshipValidation =
+                relationships.validateRelationshipReferences(
+                        childEntity, command.getChildRelationships(), true);
+        if (relationshipValidation != null) {
+            return relationshipValidation;
+        }
         return null;
     }
 
@@ -282,6 +292,13 @@ final class RelationshipCommandHandler {
             return typeValidation;
         }
 
+        ThingCommandResult relationshipValidation =
+                relationships.validateRelationshipReferences(
+                        vector.getTo(), command.getBodyRelationships(), false);
+        if (relationshipValidation != null) {
+            return relationshipValidation;
+        }
+
         if (definitions.resolveInstance(parentEntity, command.getParentIdentifier()) == null) {
             return parentNotFound(command);
         }
@@ -367,6 +384,137 @@ final class RelationshipCommandHandler {
         return result;
     }
 
+    ThingCommandResult handle(final UpdateConnectedRelationshipCommand command) {
+        ThingCommandResult validationResult = validate(command);
+        if (validationResult != null) {
+            return validationResult;
+        }
+        return apply(command);
+    }
+
+    ThingCommandResult validate(final UpdateConnectedRelationshipCommand command) {
+        EntityDefinition parentEntity = definitions.entityNamed(command.getParentEntityName());
+        if (parentEntity == null) {
+            return parentNotFound(
+                    command.getParentEntityName(),
+                    command.getParentIdentifier(),
+                    command.getRelationshipName());
+        }
+
+        RelationshipVectorDefinition vector =
+                targets.firstRelationshipVector(parentEntity, command.getRelationshipName());
+        if (vector == null) {
+            return ThingCommandResult.error(
+                    String.format(
+                            "Could not find a relationship named %s for %s",
+                            command.getRelationshipName(), parentEntity.getName()));
+        }
+
+        ThingCommandResult typeValidation =
+                validation.validateDeclaredFieldTypesIgnoringProtected(
+                        vector.getTo(), command.getChildBodyFields());
+        if (typeValidation != null) {
+            return typeValidation;
+        }
+
+        List<NamedValue> childFieldValues =
+                validation.normalizedFieldValues(
+                        vector.getTo(),
+                        command.getChildFieldValues(),
+                        command.getChildBodyFields());
+
+        EntityInstance parent =
+                definitions.resolveInstance(parentEntity, command.getParentIdentifier());
+        if (parent == null) {
+            return parentNotFound(command);
+        }
+
+        RelationshipTargetResolver.RelatedItemResolution related =
+                targets.resolveRelatedItemFromReferenceFields(
+                        parent, command.getRelationshipName(), childFieldValues);
+        if (related.error() != null) {
+            return ThingCommandResult.error(related.error());
+        }
+
+        ThingCommandResult relationshipError =
+                relationships.relationshipErrorIfInvalid(
+                        parent, related.instance(), vector, command.getRelationshipName());
+        if (relationshipError != null) {
+            return relationshipError;
+        }
+
+        if (!targets.isRelated(parent, command.getRelationshipName(), related.instance())) {
+            return relationshipTargetNotFound(command, related.instance());
+        }
+
+        ThingCommandResult relationshipValidation =
+                relationships.validateRelationshipReferences(
+                        vector.getTo(), command.getChildRelationships(), false);
+        if (relationshipValidation != null) {
+            return relationshipValidation;
+        }
+
+        try {
+            new EntityInstanceDraftBuilder(related.instance()).setFieldValuesFrom(childFieldValues);
+            return null;
+        } catch (ThingStoreWriteException e) {
+            throw e;
+        } catch (Exception e) {
+            return ThingCommandResult.error(ApplicationExceptionMessages.messageFrom(e));
+        }
+    }
+
+    ThingCommandResult apply(final UpdateConnectedRelationshipCommand command) {
+        EntityDefinition parentEntity = definitions.entityNamed(command.getParentEntityName());
+        EntityInstance parent =
+                definitions.resolveInstance(parentEntity, command.getParentIdentifier());
+        if (parent == null) {
+            return parentNotFound(command);
+        }
+
+        RelationshipVectorDefinition vector =
+                targets.firstRelationshipVector(parentEntity, command.getRelationshipName());
+        if (vector == null) {
+            return ThingCommandResult.error(
+                    String.format(
+                            "Could not find a relationship named %s for %s",
+                            command.getRelationshipName(), parentEntity.getName()));
+        }
+
+        List<NamedValue> childFieldValues =
+                validation.normalizedFieldValues(
+                        vector.getTo(),
+                        command.getChildFieldValues(),
+                        command.getChildBodyFields());
+        RelationshipTargetResolver.RelatedItemResolution related =
+                targets.resolveRelatedItemFromReferenceFields(
+                        parent, command.getRelationshipName(), childFieldValues);
+        if (related.error() != null) {
+            return ThingCommandResult.error(related.error());
+        }
+        if (!targets.isRelated(parent, command.getRelationshipName(), related.instance())) {
+            return relationshipTargetNotFound(command, related.instance());
+        }
+
+        try {
+            EntityInstanceDraft draft =
+                    new EntityInstanceDraftBuilder(related.instance())
+                            .setFieldValuesFrom(childFieldValues);
+            EntityInstance updated = store.entities().patch(related.instance(), draft);
+            ThingCommandResult relationshipResult =
+                    relationships.connectRelationshipReferences(
+                            updated, command.getChildRelationships(), true, false);
+            if (relationshipResult.isError()) {
+                return relationshipResult;
+            }
+            return ThingCommandResult.success(updated);
+        } catch (ThingStoreWriteException e) {
+            throw e;
+        } catch (Exception e) {
+            return ThingCommandResult.error(ApplicationExceptionMessages.messageFrom(e));
+        }
+    }
+
     /**
      * Validates and applies a disconnect relationship command in one call.
      *
@@ -426,6 +574,8 @@ final class RelationshipCommandHandler {
         }
         try {
             store.relationships().removeBetween(parent, child, command.getRelationshipName());
+            cascadeDeletes.deleteTargetAfterDisconnect(
+                    parent, command.getRelationshipName(), child);
             return ThingCommandResult.success();
         } catch (ThingStoreWriteException e) {
             throw e;
@@ -467,6 +617,13 @@ final class RelationshipCommandHandler {
      * @return command result containing the parent error
      */
     private ThingCommandResult parentNotFound(final RelateThingCommand command) {
+        return parentNotFound(
+                command.getParentEntityName(),
+                command.getParentIdentifier(),
+                command.getRelationshipName());
+    }
+
+    private ThingCommandResult parentNotFound(final UpdateConnectedRelationshipCommand command) {
         return parentNotFound(
                 command.getParentEntityName(),
                 command.getParentIdentifier(),
@@ -516,5 +673,15 @@ final class RelationshipCommandHandler {
                         command.getParentIdentifier(),
                         command.getRelationshipName(),
                         command.getChildIdentifier()));
+    }
+
+    private ThingCommandResult relationshipTargetNotFound(
+            final UpdateConnectedRelationshipCommand command, final EntityInstance child) {
+        return ThingCommandResult.error(
+                ApplicationError.relationshipTargetNotFound(
+                        command.getParentEntityName(),
+                        command.getParentIdentifier(),
+                        command.getRelationshipName(),
+                        child.getPrimaryKeyValue()));
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/RelationshipCommandHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/RelationshipCommandHandler.java
@@ -41,6 +41,14 @@ final class RelationshipCommandHandler {
     }
 
     ThingCommandResult handle(final ConnectExistingRelationshipCommand command) {
+        ThingCommandResult validationResult = validate(command);
+        if (validationResult != null) {
+            return validationResult;
+        }
+        return apply(command);
+    }
+
+    ThingCommandResult validate(final ConnectExistingRelationshipCommand command) {
         EntityDefinition parentEntity = definitions.entityNamed(command.getParentEntityName());
         EntityInstance parent =
                 definitions.resolveInstance(parentEntity, command.getParentIdentifier());
@@ -68,12 +76,41 @@ final class RelationshipCommandHandler {
         if (relationshipError != null) {
             return relationshipError;
         }
+        return null;
+    }
 
+    ThingCommandResult apply(final ConnectExistingRelationshipCommand command) {
+        EntityDefinition parentEntity = definitions.entityNamed(command.getParentEntityName());
+        EntityInstance parent =
+                definitions.resolveInstance(parentEntity, command.getParentIdentifier());
+        if (parent == null) {
+            return parentNotFound(command);
+        }
+
+        RelationshipTargetResolver.RelatedItemResolution related =
+                targets.resolveRelatedItemFromReferenceFields(
+                        parent, command.getRelationshipName(), command.getChildReferenceFields());
+        if (related.error() != null) {
+            return ThingCommandResult.error(related.error());
+        }
+
+        RelationshipVectorDefinition relationshipToUse =
+                parent.getEntity()
+                        .getNamedRelationshipTo(
+                                command.getRelationshipName(), related.instance().getEntity());
         return relationships.connectRelationship(
                 parent, relationshipToUse.getName(), related.instance(), false);
     }
 
     ThingCommandResult handle(final CreateAndConnectRelationshipCommand command) {
+        ThingCommandResult validationResult = validate(command);
+        if (validationResult != null) {
+            return validationResult;
+        }
+        return apply(command);
+    }
+
+    ThingCommandResult validate(final CreateAndConnectRelationshipCommand command) {
         EntityDefinition parentEntity = definitions.entityNamed(command.getParentEntityName());
         EntityInstance parent =
                 definitions.resolveInstance(parentEntity, command.getParentIdentifier());
@@ -96,7 +133,21 @@ final class RelationshipCommandHandler {
         if (validationResult != null) {
             return validationResult;
         }
+        return null;
+    }
 
+    ThingCommandResult apply(final CreateAndConnectRelationshipCommand command) {
+        EntityDefinition parentEntity = definitions.entityNamed(command.getParentEntityName());
+        EntityInstance parent =
+                definitions.resolveInstance(parentEntity, command.getParentIdentifier());
+        if (parent == null) {
+            return parentNotFound(command);
+        }
+
+        EntityDefinition childEntity = definitions.entityNamed(command.getChildEntityName());
+        List<NamedValue> childFieldValues =
+                validation.normalizedFieldValues(
+                        childEntity, command.getChildFieldValues(), command.getChildBodyFields());
         try {
             EntityInstanceDraft childDraft = drafts.createDraft(childEntity, "", childFieldValues);
             ThingCommandResult createResult =
@@ -124,6 +175,14 @@ final class RelationshipCommandHandler {
     }
 
     ThingCommandResult handle(final RelateThingCommand command) {
+        ThingCommandResult validationResult = validate(command);
+        if (validationResult != null) {
+            return validationResult;
+        }
+        return apply(command);
+    }
+
+    ThingCommandResult validate(final RelateThingCommand command) {
         EntityDefinition parentEntity = definitions.entityNamed(command.getParentEntityName());
         if (parentEntity == null) {
             return parentNotFound(command);
@@ -154,6 +213,53 @@ final class RelationshipCommandHandler {
             return typeValidation;
         }
 
+        if (definitions.resolveInstance(parentEntity, command.getParentIdentifier()) == null) {
+            return parentNotFound(command);
+        }
+
+        if (referencesExistingRelatedItem) {
+            ConnectExistingRelationshipCommand connect =
+                    new ConnectExistingRelationshipCommand(
+                            command.getParentEntityName(),
+                            command.getParentIdentifier(),
+                            command.getRelationshipName(),
+                            bodyFieldValues);
+            return validate(connect);
+        }
+
+        CreateAndConnectRelationshipCommand create =
+                new CreateAndConnectRelationshipCommand(
+                        command.getParentEntityName(),
+                        command.getParentIdentifier(),
+                        command.getRelationshipName(),
+                        vector.getTo().getName(),
+                        bodyFieldValues,
+                        command.getBodyFields(),
+                        command.getBodyRelationships());
+        return validate(create);
+    }
+
+    ThingCommandResult apply(final RelateThingCommand command) {
+        EntityDefinition parentEntity = definitions.entityNamed(command.getParentEntityName());
+        if (parentEntity == null) {
+            return parentNotFound(command);
+        }
+
+        RelationshipVectorDefinition vector =
+                targets.firstRelationshipVector(parentEntity, command.getRelationshipName());
+        if (vector == null) {
+            return ThingCommandResult.error(
+                    String.format(
+                            "Could not find a relationship named %s for %s",
+                            command.getRelationshipName(), parentEntity.getName()));
+        }
+
+        List<NamedValue> bodyFieldValues =
+                validation.normalizedFieldValues(
+                        vector.getTo(), command.getBodyFieldValues(), command.getBodyFields());
+        boolean referencesExistingRelatedItem =
+                targets.bodyReferencesExistingRelatedItem(vector.getTo(), bodyFieldValues);
+
         EntityInstance parent =
                 definitions.resolveInstance(parentEntity, command.getParentIdentifier());
         if (parent == null) {
@@ -167,7 +273,7 @@ final class RelationshipCommandHandler {
                             command.getParentIdentifier(),
                             command.getRelationshipName(),
                             bodyFieldValues);
-            return handle(connect);
+            return apply(connect);
         }
 
         CreateAndConnectRelationshipCommand create =
@@ -179,7 +285,7 @@ final class RelationshipCommandHandler {
                         bodyFieldValues,
                         command.getBodyFields(),
                         command.getBodyRelationships());
-        ThingCommandResult result = handle(create);
+        ThingCommandResult result = apply(create);
         if (result.isSuccessful()) {
             return ThingCommandResult.created(result.getInstance());
         }
@@ -187,6 +293,14 @@ final class RelationshipCommandHandler {
     }
 
     ThingCommandResult handle(final DisconnectRelationshipCommand command) {
+        ThingCommandResult validationResult = validate(command);
+        if (validationResult != null) {
+            return validationResult;
+        }
+        return apply(command);
+    }
+
+    ThingCommandResult validate(final DisconnectRelationshipCommand command) {
         EntityDefinition parentEntity = definitions.entityNamed(command.getParentEntityName());
         EntityInstance parent =
                 definitions.resolveInstance(parentEntity, command.getParentIdentifier());
@@ -200,7 +314,23 @@ final class RelationshipCommandHandler {
         if (child == null) {
             return relationshipTargetNotFound(command);
         }
+        return null;
+    }
 
+    ThingCommandResult apply(final DisconnectRelationshipCommand command) {
+        EntityDefinition parentEntity = definitions.entityNamed(command.getParentEntityName());
+        EntityInstance parent =
+                definitions.resolveInstance(parentEntity, command.getParentIdentifier());
+        if (parent == null) {
+            return relationshipSourceNotFound(command);
+        }
+
+        EntityInstance child =
+                targets.relatedInstanceMatchingIdentifier(
+                        parent, command.getRelationshipName(), command.getChildIdentifier());
+        if (child == null) {
+            return relationshipTargetNotFound(command);
+        }
         try {
             store.relationships().removeBetween(parent, child, command.getRelationshipName());
             return ThingCommandResult.success();

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/RelationshipCommandHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/RelationshipCommandHandler.java
@@ -13,6 +13,13 @@ import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstanceDraft;
 import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
 import uk.co.compendiumdev.thingifier.core.repository.ThingStoreWriteException;
 
+/**
+ * Validates and applies relationship write commands.
+ *
+ * <p>Relationship writes can connect an existing child, create and connect a new child, infer the
+ * correct operation from a request body, or disconnect an existing relationship. Each command has a
+ * validation path separated from the mutation path for lifecycle hook processing.
+ */
 final class RelationshipCommandHandler {
 
     private final ThingStore store;
@@ -23,6 +30,17 @@ final class RelationshipCommandHandler {
     private final RelationshipConnectionService relationships;
     private final RelationshipTargetResolver targets;
 
+    /**
+     * Creates the relationship command handler.
+     *
+     * @param store store to mutate
+     * @param definitions resolver for model definitions and instances
+     * @param validation write validation policy
+     * @param drafts factory for child drafts
+     * @param createHandler handler used to persist newly related children
+     * @param relationships service used to connect relationship references
+     * @param targets resolver for relationship targets and references
+     */
     RelationshipCommandHandler(
             final ThingStore store,
             final ThingDefinitionResolver definitions,
@@ -40,6 +58,12 @@ final class RelationshipCommandHandler {
         this.targets = targets;
     }
 
+    /**
+     * Validates and applies a connect-existing relationship command in one call.
+     *
+     * @param command connect-existing command to handle
+     * @return validation error or successful relationship result
+     */
     ThingCommandResult handle(final ConnectExistingRelationshipCommand command) {
         ThingCommandResult validationResult = validate(command);
         if (validationResult != null) {
@@ -48,6 +72,12 @@ final class RelationshipCommandHandler {
         return apply(command);
     }
 
+    /**
+     * Validates that the parent and referenced related instance can be connected.
+     *
+     * @param command connect-existing command to validate
+     * @return validation error, or null when validation succeeds
+     */
     ThingCommandResult validate(final ConnectExistingRelationshipCommand command) {
         EntityDefinition parentEntity = definitions.entityNamed(command.getParentEntityName());
         EntityInstance parent =
@@ -79,6 +109,12 @@ final class RelationshipCommandHandler {
         return null;
     }
 
+    /**
+     * Applies a connect-existing relationship command after validation.
+     *
+     * @param command validated connect-existing command
+     * @return command result from connecting the relationship
+     */
     ThingCommandResult apply(final ConnectExistingRelationshipCommand command) {
         EntityDefinition parentEntity = definitions.entityNamed(command.getParentEntityName());
         EntityInstance parent =
@@ -102,6 +138,12 @@ final class RelationshipCommandHandler {
                 parent, relationshipToUse.getName(), related.instance(), false);
     }
 
+    /**
+     * Validates and applies a create-and-connect relationship command in one call.
+     *
+     * @param command create-and-connect command to handle
+     * @return validation error or successful creation/relationship result
+     */
     ThingCommandResult handle(final CreateAndConnectRelationshipCommand command) {
         ThingCommandResult validationResult = validate(command);
         if (validationResult != null) {
@@ -110,6 +152,12 @@ final class RelationshipCommandHandler {
         return apply(command);
     }
 
+    /**
+     * Validates that a new child can be created and connected to the parent.
+     *
+     * @param command create-and-connect command to validate
+     * @return validation error, or null when validation succeeds
+     */
     ThingCommandResult validate(final CreateAndConnectRelationshipCommand command) {
         EntityDefinition parentEntity = definitions.entityNamed(command.getParentEntityName());
         EntityInstance parent =
@@ -136,6 +184,12 @@ final class RelationshipCommandHandler {
         return null;
     }
 
+    /**
+     * Applies a create-and-connect command after validation.
+     *
+     * @param command validated create-and-connect command
+     * @return command result containing the created child or an error
+     */
     ThingCommandResult apply(final CreateAndConnectRelationshipCommand command) {
         EntityDefinition parentEntity = definitions.entityNamed(command.getParentEntityName());
         EntityInstance parent =
@@ -174,6 +228,12 @@ final class RelationshipCommandHandler {
         }
     }
 
+    /**
+     * Validates and applies a relate command in one call.
+     *
+     * @param command relate command to handle
+     * @return validation error or successful relationship result
+     */
     ThingCommandResult handle(final RelateThingCommand command) {
         ThingCommandResult validationResult = validate(command);
         if (validationResult != null) {
@@ -182,6 +242,15 @@ final class RelationshipCommandHandler {
         return apply(command);
     }
 
+    /**
+     * Validates a body-driven relationship command.
+     *
+     * <p>The command is resolved as connect-existing when the body references an existing child,
+     * otherwise it is validated as create-and-connect.
+     *
+     * @param command relate command to validate
+     * @return validation error, or null when validation succeeds
+     */
     ThingCommandResult validate(final RelateThingCommand command) {
         EntityDefinition parentEntity = definitions.entityNamed(command.getParentEntityName());
         if (parentEntity == null) {
@@ -239,6 +308,12 @@ final class RelationshipCommandHandler {
         return validate(create);
     }
 
+    /**
+     * Applies a body-driven relationship command after validation.
+     *
+     * @param command validated relate command
+     * @return command result from connect-existing or create-and-connect
+     */
     ThingCommandResult apply(final RelateThingCommand command) {
         EntityDefinition parentEntity = definitions.entityNamed(command.getParentEntityName());
         if (parentEntity == null) {
@@ -292,6 +367,12 @@ final class RelationshipCommandHandler {
         return result;
     }
 
+    /**
+     * Validates and applies a disconnect relationship command in one call.
+     *
+     * @param command disconnect command to handle
+     * @return validation error or successful disconnect result
+     */
     ThingCommandResult handle(final DisconnectRelationshipCommand command) {
         ThingCommandResult validationResult = validate(command);
         if (validationResult != null) {
@@ -300,6 +381,12 @@ final class RelationshipCommandHandler {
         return apply(command);
     }
 
+    /**
+     * Validates that the source and target instances are currently related.
+     *
+     * @param command disconnect command to validate
+     * @return validation error, or null when validation succeeds
+     */
     ThingCommandResult validate(final DisconnectRelationshipCommand command) {
         EntityDefinition parentEntity = definitions.entityNamed(command.getParentEntityName());
         EntityInstance parent =
@@ -317,6 +404,12 @@ final class RelationshipCommandHandler {
         return null;
     }
 
+    /**
+     * Applies a disconnect command after validation.
+     *
+     * @param command validated disconnect command
+     * @return successful command result or store error
+     */
     ThingCommandResult apply(final DisconnectRelationshipCommand command) {
         EntityDefinition parentEntity = definitions.entityNamed(command.getParentEntityName());
         EntityInstance parent =
@@ -341,6 +434,12 @@ final class RelationshipCommandHandler {
         }
     }
 
+    /**
+     * Builds a parent-not-found error for connect-existing commands.
+     *
+     * @param command command whose parent was missing
+     * @return command result containing the parent error
+     */
     private ThingCommandResult parentNotFound(final ConnectExistingRelationshipCommand command) {
         return parentNotFound(
                 command.getParentEntityName(),
@@ -348,6 +447,12 @@ final class RelationshipCommandHandler {
                 command.getRelationshipName());
     }
 
+    /**
+     * Builds a parent-not-found error for create-and-connect commands.
+     *
+     * @param command command whose parent was missing
+     * @return command result containing the parent error
+     */
     private ThingCommandResult parentNotFound(final CreateAndConnectRelationshipCommand command) {
         return parentNotFound(
                 command.getParentEntityName(),
@@ -355,6 +460,12 @@ final class RelationshipCommandHandler {
                 command.getRelationshipName());
     }
 
+    /**
+     * Builds a parent-not-found error for relate commands.
+     *
+     * @param command command whose parent was missing
+     * @return command result containing the parent error
+     */
     private ThingCommandResult parentNotFound(final RelateThingCommand command) {
         return parentNotFound(
                 command.getParentEntityName(),
@@ -362,12 +473,26 @@ final class RelationshipCommandHandler {
                 command.getRelationshipName());
     }
 
+    /**
+     * Builds the standard parent-not-found error.
+     *
+     * @param entityName parent entity name
+     * @param identifier parent identifier
+     * @param relationshipName relationship name
+     * @return command result containing the parent error
+     */
     private ThingCommandResult parentNotFound(
             final String entityName, final String identifier, final String relationshipName) {
         return ThingCommandResult.error(
                 ApplicationError.parentInstanceNotFound(entityName, identifier, relationshipName));
     }
 
+    /**
+     * Builds the standard missing relationship source error for disconnects.
+     *
+     * @param command disconnect command
+     * @return command result containing the source error
+     */
     private ThingCommandResult relationshipSourceNotFound(
             final DisconnectRelationshipCommand command) {
         return ThingCommandResult.error(
@@ -377,6 +502,12 @@ final class RelationshipCommandHandler {
                         command.getRelationshipName()));
     }
 
+    /**
+     * Builds the standard missing relationship target error for disconnects.
+     *
+     * @param command disconnect command
+     * @return command result containing the target error
+     */
     private ThingCommandResult relationshipTargetNotFound(
             final DisconnectRelationshipCommand command) {
         return ThingCommandResult.error(

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/RelationshipConnectionService.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/RelationshipConnectionService.java
@@ -1,8 +1,11 @@
 package uk.co.compendiumdev.thingifier.application;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import uk.co.compendiumdev.thingifier.application.command.RelationshipReference;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.relationship.RelationshipVectorDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
 import uk.co.compendiumdev.thingifier.core.reporting.ValidationReport;
@@ -70,8 +73,25 @@ final class RelationshipConnectionService {
             return ThingCommandResult.error(resolution.errors());
         }
 
+        disconnectFieldBoundRelationships(instance, references);
         return connectRelationships(
                 instance, resolution.relationships(), validateFinalRelationships);
+    }
+
+    ThingCommandResult validateRelationshipReferences(
+            final EntityDefinition sourceEntity,
+            final List<RelationshipReference> references,
+            final boolean prefixRelationshipErrors) {
+        RelationshipReferenceResolver.Resolution resolution =
+                relationshipResolver.resolve(sourceEntity, references);
+        if (!resolution.hasErrors()) {
+            return null;
+        }
+        if (prefixRelationshipErrors) {
+            return ThingCommandResult.error(
+                    "Invalid relationships: " + String.join(", ", resolution.errors()));
+        }
+        return ThingCommandResult.error(resolution.errors());
     }
 
     ThingCommandResult relationshipErrorIfInvalid(
@@ -136,6 +156,24 @@ final class RelationshipConnectionService {
             disconnectConnections(instance, connectedByCommand);
             return ThingCommandResult.error(
                     "Error creating relationships " + ApplicationExceptionMessages.messageFrom(e));
+        }
+    }
+
+    private void disconnectFieldBoundRelationships(
+            final EntityInstance instance, final List<RelationshipReference> references) {
+        Set<String> relationshipNames = new HashSet<>();
+        for (RelationshipReference reference : references) {
+            if (reference.isFieldBinding()) {
+                relationshipNames.add(reference.relationshipName());
+            }
+        }
+
+        for (String relationshipName : relationshipNames) {
+            List<EntityInstance> currentlyRelated =
+                    new ArrayList<>(store.relationships().listRelated(instance, relationshipName));
+            for (EntityInstance related : currentlyRelated) {
+                store.relationships().disconnectBetween(instance, related, relationshipName);
+            }
         }
     }
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/RelationshipReferenceResolver.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/RelationshipReferenceResolver.java
@@ -6,6 +6,8 @@ import java.util.List;
 import uk.co.compendiumdev.thingifier.application.command.RelationshipReference;
 import uk.co.compendiumdev.thingifier.application.schema.SchemaDefinitionResolver;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.Field;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldType;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.relationship.RelationshipVectorDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
 import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
@@ -22,11 +24,22 @@ final class RelationshipReferenceResolver {
 
     Resolution resolve(
             final EntityInstance instance, final List<RelationshipReference> references) {
+        return resolve(instance.getEntity(), references);
+    }
+
+    Resolution resolve(
+            final EntityDefinition sourceEntity, final List<RelationshipReference> references) {
         List<RelationshipConnection> relationships = new ArrayList<>();
         List<String> errors = new ArrayList<>();
 
         for (RelationshipReference reference : references) {
-            EntityInstance related = resolveRelationshipReference(instance, reference);
+            String configurationError = fieldBindingConfigurationError(sourceEntity, reference);
+            if (configurationError != null) {
+                errors.add(configurationError);
+                continue;
+            }
+
+            EntityInstance related = resolveRelationshipReference(sourceEntity, reference);
             if (related == null) {
                 errors.add(missingRelationshipReferenceMessage(reference));
             } else {
@@ -39,13 +52,13 @@ final class RelationshipReferenceResolver {
     }
 
     private EntityInstance resolveRelationshipReference(
-            final EntityInstance instance, final RelationshipReference reference) {
+            final EntityDefinition sourceEntity, final RelationshipReference reference) {
         if (reference.hasExplicitTargetEntity()) {
             return resolveExplicitRelationshipReference(reference);
         }
 
         for (RelationshipVectorDefinition vector :
-                instance.getEntity().related().getRelationships(reference.relationshipName())) {
+                sourceEntity.related().getRelationships(reference.relationshipName())) {
             EntityDefinition relatedEntity = vector.getTo();
             EntityInstance related =
                     store.entityQueries()
@@ -64,6 +77,52 @@ final class RelationshipReferenceResolver {
         }
 
         return null;
+    }
+
+    private String fieldBindingConfigurationError(
+            final EntityDefinition sourceEntity, final RelationshipReference reference) {
+        if (!reference.isFieldBinding()) {
+            return null;
+        }
+
+        EntityDefinition target = schema.entityNamed(reference.targetEntityName());
+        if (target == null) {
+            return "Reference target entity not found " + reference.targetEntityName();
+        }
+
+        Field targetField = target.getField(reference.referenceFieldName());
+        if (targetField == null) {
+            return String.format(
+                    "Reference target field not found %s.%s",
+                    target.getName(), reference.referenceFieldName());
+        }
+
+        if (!canUniquelyResolve(target, targetField)) {
+            return String.format(
+                    "Reference target field %s.%s must be unique, primary, or protected",
+                    target.getName(), targetField.getName());
+        }
+
+        RelationshipVectorDefinition relationship =
+                sourceEntity.getNamedRelationshipTo(reference.relationshipName(), target);
+        if (relationship == null) {
+            return String.format(
+                    "Relationship %s does not connect %s to %s",
+                    reference.relationshipName(), sourceEntity.getName(), target.getName());
+        }
+        return null;
+    }
+
+    private boolean canUniquelyResolve(final EntityDefinition target, final Field targetField) {
+        if (targetField.mustBeUnique()) {
+            return true;
+        }
+        if (target.hasPrimaryKeyField()
+                && target.getPrimaryKeyField().getName().equals(targetField.getName())) {
+            return true;
+        }
+        return targetField.getType() == FieldType.AUTO_INCREMENT
+                || targetField.getType() == FieldType.AUTO_GUID;
     }
 
     private EntityInstance resolveExplicitRelationshipReference(

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/RelationshipTargetResolver.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/RelationshipTargetResolver.java
@@ -104,6 +104,18 @@ final class RelationshipTargetResolver {
         return null;
     }
 
+    boolean isRelated(
+            final EntityInstance parent,
+            final String relationshipName,
+            final EntityInstance child) {
+        for (EntityInstance related : store.relationships().listRelated(parent, relationshipName)) {
+            if (related.getInternalId().equals(child.getInternalId())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private boolean matchesQueryIdentifier(final EntityInstance instance, final String identifier) {
         for (Field autoIncrementField :
                 instance.getEntity().getFieldsOfType(FieldType.AUTO_INCREMENT)) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/ThingCommandService.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/ThingCommandService.java
@@ -15,6 +15,13 @@ import uk.co.compendiumdev.thingifier.application.command.ThingWriteCommand;
 import uk.co.compendiumdev.thingifier.application.schema.SchemaDefinitionResolver;
 import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
 
+/**
+ * Coordinates validation and execution of Thingifier write commands.
+ *
+ * <p>The service exposes both the original one-step {@link #execute(ThingWriteCommand)} operation
+ * and the split {@link #validate(ThingWriteCommand)} / {@link #applyValidated(ThingWriteCommand)}
+ * operations needed by lifecycle hooks. All normal writes still run inside the transaction runner.
+ */
 public final class ThingCommandService {
 
     private final WriteTransactionRunner transactionRunner;
@@ -24,10 +31,23 @@ public final class ThingCommandService {
     private final DeleteThingHandler deleteHandler;
     private final RelationshipCommandHandler relationshipHandler;
 
+    /**
+     * Creates a command service with default type handling and JSON output configuration.
+     *
+     * @param store store to mutate
+     * @param schema schema resolver for entity and relationship definitions
+     */
     public ThingCommandService(final ThingStore store, final SchemaDefinitionResolver schema) {
         this(store, schema, false);
     }
 
+    /**
+     * Creates a command service with explicit declared-type enforcement.
+     *
+     * @param store store to mutate
+     * @param schema schema resolver for entity and relationship definitions
+     * @param enforceDeclaredTypes true when request values must match declared field types
+     */
     public ThingCommandService(
             final ThingStore store,
             final SchemaDefinitionResolver schema,
@@ -35,6 +55,14 @@ public final class ThingCommandService {
         this(store, schema, enforceDeclaredTypes, new JsonOutputConfig());
     }
 
+    /**
+     * Creates a command service with explicit validation and JSON rendering configuration.
+     *
+     * @param store store to mutate
+     * @param schema schema resolver for entity and relationship definitions
+     * @param enforceDeclaredTypes true when request values must match declared field types
+     * @param jsonOutput JSON rendering configuration used by patch document handling
+     */
     public ThingCommandService(
             final ThingStore store,
             final SchemaDefinitionResolver schema,
@@ -74,14 +102,35 @@ public final class ThingCommandService {
                         new RelationshipTargetResolver(store));
     }
 
+    /**
+     * Validates and applies a write command inside one transaction.
+     *
+     * @param command write command to execute
+     * @return command result from validation or application
+     */
     public ThingCommandResult execute(final ThingWriteCommand command) {
         return transactionRunner.run(() -> executeInsideTransaction(command));
     }
 
+    /**
+     * Runs a caller-supplied write operation inside the same transaction mechanism.
+     *
+     * <p>Lifecycle write support uses this so hooks, validation, and action execution share the
+     * original write transaction boundary.
+     *
+     * @param operation operation to run inside the transaction
+     * @return command result from the operation
+     */
     public ThingCommandResult runInTransaction(final Supplier<ThingCommandResult> operation) {
         return transactionRunner.run(operation);
     }
 
+    /**
+     * Validates a write command without mutating the store.
+     *
+     * @param command write command to validate
+     * @return validation error result, or null when validation succeeds
+     */
     public ThingCommandResult validate(final ThingWriteCommand command) {
         if (command instanceof CreateThingCommand) {
             return createHandler.validate((CreateThingCommand) command);
@@ -125,10 +174,25 @@ public final class ThingCommandService {
                                 "Unsupported command %s", command.getClass().getSimpleName())));
     }
 
+    /**
+     * Applies a command that has already passed validation.
+     *
+     * <p>Callers are responsible for only passing validated commands; the method exists so
+     * lifecycle hooks can run between validation and mutation.
+     *
+     * @param command validated write command to apply
+     * @return command result from applying the mutation
+     */
     public ThingCommandResult applyValidated(final ThingWriteCommand command) {
         return applyInsideTransaction(command);
     }
 
+    /**
+     * Runs the original validate-then-apply command flow inside a transaction.
+     *
+     * @param command write command to execute
+     * @return validation or apply result
+     */
     private ThingCommandResult executeInsideTransaction(final ThingWriteCommand command) {
         ThingCommandResult validationResult = validate(command);
         if (validationResult != null) {
@@ -137,6 +201,12 @@ public final class ThingCommandService {
         return applyInsideTransaction(command);
     }
 
+    /**
+     * Dispatches a validated write command to its concrete mutation handler.
+     *
+     * @param command validated write command
+     * @return command result from the matching handler
+     */
     private ThingCommandResult applyInsideTransaction(final ThingWriteCommand command) {
         if (command instanceof CreateThingCommand) {
             return createHandler.apply((CreateThingCommand) command);

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/ThingCommandService.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/ThingCommandService.java
@@ -1,5 +1,6 @@
 package uk.co.compendiumdev.thingifier.application;
 
+import java.util.function.Supplier;
 import uk.co.compendiumdev.thingifier.apiconfig.JsonOutputConfig;
 import uk.co.compendiumdev.thingifier.application.command.AmendThingCommand;
 import uk.co.compendiumdev.thingifier.application.command.ConnectExistingRelationshipCommand;
@@ -77,41 +78,100 @@ public final class ThingCommandService {
         return transactionRunner.run(() -> executeInsideTransaction(command));
     }
 
-    private ThingCommandResult executeInsideTransaction(final ThingWriteCommand command) {
+    public ThingCommandResult runInTransaction(final Supplier<ThingCommandResult> operation) {
+        return transactionRunner.run(operation);
+    }
+
+    public ThingCommandResult validate(final ThingWriteCommand command) {
         if (command instanceof CreateThingCommand) {
-            return createHandler.handle((CreateThingCommand) command);
+            return createHandler.validate((CreateThingCommand) command);
         }
 
         if (command instanceof AmendThingCommand) {
-            return amendHandler.handle((AmendThingCommand) command);
+            return amendHandler.validate((AmendThingCommand) command);
         }
 
         if (command instanceof DeleteThingCommand) {
-            return deleteHandler.handle((DeleteThingCommand) command);
+            return deleteHandler.validate((DeleteThingCommand) command);
         }
 
         if (command instanceof PatchThingDocumentCommand) {
-            return patchDocumentHandler.handle((PatchThingDocumentCommand) command);
+            return patchDocumentHandler.validate((PatchThingDocumentCommand) command);
         }
 
         if (command instanceof ReplaceThingCommand) {
-            return amendHandler.handle((ReplaceThingCommand) command);
+            return amendHandler.validate((ReplaceThingCommand) command);
         }
 
         if (command instanceof ConnectExistingRelationshipCommand) {
-            return relationshipHandler.handle((ConnectExistingRelationshipCommand) command);
+            return relationshipHandler.validate((ConnectExistingRelationshipCommand) command);
         }
 
         if (command instanceof CreateAndConnectRelationshipCommand) {
-            return relationshipHandler.handle((CreateAndConnectRelationshipCommand) command);
+            return relationshipHandler.validate((CreateAndConnectRelationshipCommand) command);
         }
 
         if (command instanceof RelateThingCommand) {
-            return relationshipHandler.handle((RelateThingCommand) command);
+            return relationshipHandler.validate((RelateThingCommand) command);
         }
 
         if (command instanceof DisconnectRelationshipCommand) {
-            return relationshipHandler.handle((DisconnectRelationshipCommand) command);
+            return relationshipHandler.validate((DisconnectRelationshipCommand) command);
+        }
+
+        return ThingCommandResult.error(
+                ApplicationError.unsupported(
+                        String.format(
+                                "Unsupported command %s", command.getClass().getSimpleName())));
+    }
+
+    public ThingCommandResult applyValidated(final ThingWriteCommand command) {
+        return applyInsideTransaction(command);
+    }
+
+    private ThingCommandResult executeInsideTransaction(final ThingWriteCommand command) {
+        ThingCommandResult validationResult = validate(command);
+        if (validationResult != null) {
+            return validationResult;
+        }
+        return applyInsideTransaction(command);
+    }
+
+    private ThingCommandResult applyInsideTransaction(final ThingWriteCommand command) {
+        if (command instanceof CreateThingCommand) {
+            return createHandler.apply((CreateThingCommand) command);
+        }
+
+        if (command instanceof AmendThingCommand) {
+            return amendHandler.apply((AmendThingCommand) command);
+        }
+
+        if (command instanceof DeleteThingCommand) {
+            return deleteHandler.apply((DeleteThingCommand) command);
+        }
+
+        if (command instanceof PatchThingDocumentCommand) {
+            return patchDocumentHandler.apply((PatchThingDocumentCommand) command);
+        }
+
+        if (command instanceof ReplaceThingCommand) {
+            return amendHandler.apply((ReplaceThingCommand) command);
+        }
+
+        if (command instanceof ConnectExistingRelationshipCommand) {
+            return relationshipHandler.apply((ConnectExistingRelationshipCommand) command);
+        }
+
+        if (command instanceof CreateAndConnectRelationshipCommand) {
+            return relationshipHandler.apply((CreateAndConnectRelationshipCommand) command);
+        }
+
+        if (command instanceof RelateThingCommand) {
+            return relationshipHandler.apply((RelateThingCommand) command);
+        }
+
+        if (command instanceof DisconnectRelationshipCommand) {
+            return relationshipHandler.apply((DisconnectRelationshipCommand) command);
         }
 
         return ThingCommandResult.error(

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/ThingCommandService.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/ThingCommandService.java
@@ -12,6 +12,7 @@ import uk.co.compendiumdev.thingifier.application.command.PatchThingDocumentComm
 import uk.co.compendiumdev.thingifier.application.command.RelateThingCommand;
 import uk.co.compendiumdev.thingifier.application.command.ReplaceThingCommand;
 import uk.co.compendiumdev.thingifier.application.command.ThingWriteCommand;
+import uk.co.compendiumdev.thingifier.application.command.UpdateConnectedRelationshipCommand;
 import uk.co.compendiumdev.thingifier.application.schema.SchemaDefinitionResolver;
 import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
 
@@ -74,6 +75,8 @@ public final class ThingCommandService {
                 new RelationshipReferenceResolver(store, schema);
         RelationshipConnectionService relationshipConnections =
                 new RelationshipConnectionService(store, relationshipResolver);
+        RelationshipCascadeDeleteService cascadeDeletes =
+                new RelationshipCascadeDeleteService(store);
         ThingDraftFactory drafts = new ThingDraftFactory(store);
 
         this.transactionRunner = new WriteTransactionRunner(store);
@@ -90,7 +93,7 @@ public final class ThingCommandService {
                         relationshipConnections);
         this.patchDocumentHandler =
                 new PatchThingDocumentHandler(definitions, amendHandler, jsonOutput);
-        this.deleteHandler = new DeleteThingHandler(store, definitions);
+        this.deleteHandler = new DeleteThingHandler(store, definitions, cascadeDeletes);
         this.relationshipHandler =
                 new RelationshipCommandHandler(
                         store,
@@ -99,7 +102,8 @@ public final class ThingCommandService {
                         drafts,
                         createHandler,
                         relationshipConnections,
-                        new RelationshipTargetResolver(store));
+                        new RelationshipTargetResolver(store),
+                        cascadeDeletes);
     }
 
     /**
@@ -162,6 +166,10 @@ public final class ThingCommandService {
 
         if (command instanceof RelateThingCommand) {
             return relationshipHandler.validate((RelateThingCommand) command);
+        }
+
+        if (command instanceof UpdateConnectedRelationshipCommand) {
+            return relationshipHandler.validate((UpdateConnectedRelationshipCommand) command);
         }
 
         if (command instanceof DisconnectRelationshipCommand) {
@@ -238,6 +246,10 @@ public final class ThingCommandService {
 
         if (command instanceof RelateThingCommand) {
             return relationshipHandler.apply((RelateThingCommand) command);
+        }
+
+        if (command instanceof UpdateConnectedRelationshipCommand) {
+            return relationshipHandler.apply((UpdateConnectedRelationshipCommand) command);
         }
 
         if (command instanceof DisconnectRelationshipCommand) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/command/RelationshipReference.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/command/RelationshipReference.java
@@ -2,33 +2,59 @@ package uk.co.compendiumdev.thingifier.application.command;
 
 public final class RelationshipReference {
 
+    private enum Source {
+        BODY,
+        FIELD_BINDING
+    }
+
     private final String relationshipName;
     private final String targetEntityName;
     private final String targetTerm;
     private final String referenceFieldName;
     private final String referenceValue;
+    private final Source source;
 
     private RelationshipReference(
             final String relationshipName,
             final String targetEntityName,
             final String targetTerm,
             final String referenceFieldName,
-            final String referenceValue) {
+            final String referenceValue,
+            final Source source) {
         this.relationshipName = relationshipName;
         this.targetEntityName = targetEntityName == null ? "" : targetEntityName;
         this.targetTerm = targetTerm == null ? "" : targetTerm;
         this.referenceFieldName = referenceFieldName;
         this.referenceValue = referenceValue;
+        this.source = source;
     }
 
+    /**
+     * Creates a relationship reference from the compressed request body syntax.
+     *
+     * @param relationshipName relationship to connect
+     * @param referenceFieldName field used to find the related instance
+     * @param referenceValue value used to find the related instance
+     * @return relationship reference parsed from request body data
+     */
     public static RelationshipReference compressed(
             final String relationshipName,
             final String referenceFieldName,
             final String referenceValue) {
         return new RelationshipReference(
-                relationshipName, "", "", referenceFieldName, referenceValue);
+                relationshipName, "", "", referenceFieldName, referenceValue, Source.BODY);
     }
 
+    /**
+     * Creates a relationship reference from the explicit request body syntax.
+     *
+     * @param relationshipName relationship to connect
+     * @param targetEntityName expected target entity name
+     * @param targetTerm target term supplied by the request
+     * @param referenceFieldName field used to find the related instance
+     * @param referenceValue value used to find the related instance
+     * @return relationship reference parsed from request body data
+     */
     public static RelationshipReference explicit(
             final String relationshipName,
             final String targetEntityName,
@@ -36,30 +62,97 @@ public final class RelationshipReference {
             final String referenceFieldName,
             final String referenceValue) {
         return new RelationshipReference(
-                relationshipName, targetEntityName, targetTerm, referenceFieldName, referenceValue);
+                relationshipName,
+                targetEntityName,
+                targetTerm,
+                referenceFieldName,
+                referenceValue,
+                Source.BODY);
     }
 
+    /**
+     * Creates a relationship reference from a configured field binding.
+     *
+     * @param relationshipName relationship to connect or replace
+     * @param targetEntityName target entity configured by the field
+     * @param referenceFieldName field used to find the related instance
+     * @param referenceValue value supplied in the source field
+     * @return relationship reference derived from field metadata
+     */
+    public static RelationshipReference fieldBinding(
+            final String relationshipName,
+            final String targetEntityName,
+            final String referenceFieldName,
+            final String referenceValue) {
+        return new RelationshipReference(
+                relationshipName,
+                targetEntityName,
+                targetEntityName,
+                referenceFieldName,
+                referenceValue,
+                Source.FIELD_BINDING);
+    }
+
+    /**
+     * Returns the relationship name to connect.
+     *
+     * @return relationship name
+     */
     public String relationshipName() {
         return relationshipName;
     }
 
+    /**
+     * Reports whether the reference specifies its target entity.
+     *
+     * @return true when target entity metadata is present
+     */
     public boolean hasExplicitTargetEntity() {
         return !targetEntityName.isEmpty();
     }
 
+    /**
+     * Returns the explicit target entity name.
+     *
+     * @return target entity name, or an empty string when implicit
+     */
     public String targetEntityName() {
         return targetEntityName;
     }
 
+    /**
+     * Returns the target term used in error messages.
+     *
+     * @return target term from the request or field binding
+     */
     public String targetTerm() {
         return targetTerm;
     }
 
+    /**
+     * Returns the target field name used for lookup.
+     *
+     * @return reference field name
+     */
     public String referenceFieldName() {
         return referenceFieldName;
     }
 
+    /**
+     * Returns the target field value used for lookup.
+     *
+     * @return reference value
+     */
     public String referenceValue() {
         return referenceValue;
+    }
+
+    /**
+     * Reports whether this reference was generated from field metadata.
+     *
+     * @return true when a normal field value should replace the bound relationship
+     */
+    public boolean isFieldBinding() {
+        return source == Source.FIELD_BINDING;
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/command/UpdateConnectedRelationshipCommand.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/command/UpdateConnectedRelationshipCommand.java
@@ -1,0 +1,102 @@
+package uk.co.compendiumdev.thingifier.application.command;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.instance.NamedValue;
+
+/**
+ * Updates an existing child that is already connected to a parent relationship.
+ *
+ * <p>This command backs relationship collection writes that are explicitly configured for {@code
+ * UPDATE_CONNECTED}. It keeps the relationship route semantics separate from normal entity
+ * amendment while reusing the same field validation and relationship-reference processing.
+ */
+public final class UpdateConnectedRelationshipCommand implements ThingWriteCommand {
+
+    private final String parentEntityName;
+    private final String parentIdentifier;
+    private final String relationshipName;
+    private final List<NamedValue> childFieldValues;
+    private final List<BodyFieldValue> childBodyFields;
+    private final List<RelationshipReference> childRelationships;
+
+    /**
+     * Creates a command to update a child already connected through a relationship.
+     *
+     * @param parentEntityName parent entity name
+     * @param parentIdentifier parent route/query identifier
+     * @param relationshipName relationship name from parent to child
+     * @param childFieldValues parsed child field values from the request body
+     * @param childBodyFields parsed child fields with source types
+     * @param childRelationships relationship references supplied for the child
+     */
+    public UpdateConnectedRelationshipCommand(
+            final String parentEntityName,
+            final String parentIdentifier,
+            final String relationshipName,
+            final List<NamedValue> childFieldValues,
+            final List<BodyFieldValue> childBodyFields,
+            final List<RelationshipReference> childRelationships) {
+        this.parentEntityName = parentEntityName;
+        this.parentIdentifier = parentIdentifier;
+        this.relationshipName = relationshipName;
+        this.childFieldValues = Collections.unmodifiableList(new ArrayList<>(childFieldValues));
+        this.childBodyFields = Collections.unmodifiableList(new ArrayList<>(childBodyFields));
+        this.childRelationships = Collections.unmodifiableList(new ArrayList<>(childRelationships));
+    }
+
+    /**
+     * Returns the parent entity name.
+     *
+     * @return parent entity name
+     */
+    public String getParentEntityName() {
+        return parentEntityName;
+    }
+
+    /**
+     * Returns the parent identifier from the relationship route.
+     *
+     * @return parent identifier
+     */
+    public String getParentIdentifier() {
+        return parentIdentifier;
+    }
+
+    /**
+     * Returns the relationship name from parent to child.
+     *
+     * @return relationship name
+     */
+    public String getRelationshipName() {
+        return relationshipName;
+    }
+
+    /**
+     * Returns the parsed child field values.
+     *
+     * @return immutable child field values
+     */
+    public List<NamedValue> getChildFieldValues() {
+        return childFieldValues;
+    }
+
+    /**
+     * Returns the parsed child body fields with original source types.
+     *
+     * @return immutable child body fields
+     */
+    public List<BodyFieldValue> getChildBodyFields() {
+        return childBodyFields;
+    }
+
+    /**
+     * Returns relationship references supplied for the child entity.
+     *
+     * @return immutable child relationship references
+     */
+    public List<RelationshipReference> getChildRelationships() {
+        return childRelationships;
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/schema/FieldReferenceSpec.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/schema/FieldReferenceSpec.java
@@ -1,0 +1,58 @@
+package uk.co.compendiumdev.thingifier.application.schema;
+
+/**
+ * Lightweight schema description of a field-backed relationship reference.
+ *
+ * <p>The field that owns this spec remains a normal value field. The spec tells request mapping
+ * which target entity and field the value should resolve to, and which relationship should be
+ * maintained from the source entity to that target.
+ */
+public final class FieldReferenceSpec {
+
+    private final String targetEntityName;
+    private final String targetFieldName;
+    private final String relationshipName;
+
+    /**
+     * Creates a field reference description.
+     *
+     * @param targetEntityName entity containing the referenced value
+     * @param targetFieldName field on the target entity to match
+     * @param relationshipName relationship from the source entity to the target entity
+     */
+    public FieldReferenceSpec(
+            final String targetEntityName,
+            final String targetFieldName,
+            final String relationshipName) {
+        this.targetEntityName = targetEntityName;
+        this.targetFieldName = targetFieldName;
+        this.relationshipName = relationshipName;
+    }
+
+    /**
+     * Returns the entity containing the referenced value.
+     *
+     * @return target entity name
+     */
+    public String targetEntityName() {
+        return targetEntityName;
+    }
+
+    /**
+     * Returns the target field name used for lookup.
+     *
+     * @return target field name
+     */
+    public String targetFieldName() {
+        return targetFieldName;
+    }
+
+    /**
+     * Returns the relationship maintained by this field.
+     *
+     * @return relationship name
+     */
+    public String relationshipName() {
+        return relationshipName;
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/schema/FieldSpec.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/schema/FieldSpec.java
@@ -7,11 +7,21 @@ public final class FieldSpec {
     private final String name;
     private final FieldType type;
     private final boolean unique;
+    private final FieldReferenceSpec reference;
 
     public FieldSpec(final String name, final FieldType type, final boolean unique) {
+        this(name, type, unique, null);
+    }
+
+    public FieldSpec(
+            final String name,
+            final FieldType type,
+            final boolean unique,
+            final FieldReferenceSpec reference) {
         this.name = name;
         this.type = type;
         this.unique = unique;
+        this.reference = reference;
     }
 
     public String name() {
@@ -28,5 +38,23 @@ public final class FieldSpec {
 
     public boolean isProtectedField() {
         return type == FieldType.AUTO_INCREMENT || type == FieldType.AUTO_GUID;
+    }
+
+    /**
+     * Reports whether this field is bound to a relationship reference.
+     *
+     * @return true when write mapping should also create a relationship reference
+     */
+    public boolean hasRelationshipReference() {
+        return reference != null;
+    }
+
+    /**
+     * Returns the field-backed relationship reference metadata.
+     *
+     * @return relationship reference spec, or null when none is configured
+     */
+    public FieldReferenceSpec relationshipReference() {
+        return reference;
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/schema/definition/FieldDefinitionSpec.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/schema/definition/FieldDefinitionSpec.java
@@ -3,6 +3,7 @@ package uk.co.compendiumdev.thingifier.application.schema.definition;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import uk.co.compendiumdev.thingifier.application.schema.FieldReferenceSpec;
 
 public final class FieldDefinitionSpec {
 
@@ -18,6 +19,7 @@ public final class FieldDefinitionSpec {
     private final String maxValue;
     private final List<ValidationRuleSpec> validationRules;
     private final List<FieldDefinitionSpec> objectFields;
+    private final FieldReferenceSpec reference;
 
     private FieldDefinitionSpec(final Builder builder) {
         name = builder.name;
@@ -32,6 +34,7 @@ public final class FieldDefinitionSpec {
         maxValue = builder.maxValue;
         validationRules = Collections.unmodifiableList(new ArrayList<>(builder.validationRules));
         objectFields = Collections.unmodifiableList(new ArrayList<>(builder.objectFields));
+        reference = builder.reference;
     }
 
     public static Builder named(final String name, final String type) {
@@ -86,6 +89,24 @@ public final class FieldDefinitionSpec {
         return objectFields;
     }
 
+    /**
+     * Reports whether this field has a field-backed relationship reference.
+     *
+     * @return true when the field value should maintain a relationship
+     */
+    public boolean hasRelationshipReference() {
+        return reference != null;
+    }
+
+    /**
+     * Returns this field's relationship reference description.
+     *
+     * @return relationship reference spec, or null when none is configured
+     */
+    public FieldReferenceSpec relationshipReference() {
+        return reference;
+    }
+
     public boolean hasRange() {
         return minValue != null || maxValue != null;
     }
@@ -104,6 +125,7 @@ public final class FieldDefinitionSpec {
         private String maxValue;
         private final List<ValidationRuleSpec> validationRules;
         private final List<FieldDefinitionSpec> objectFields;
+        private FieldReferenceSpec reference;
 
         private Builder(final String name, final String type) {
             this.name = name;
@@ -172,6 +194,33 @@ public final class FieldDefinitionSpec {
         public Builder objectFields(final List<FieldDefinitionSpec> objectFields) {
             this.objectFields.addAll(objectFields);
             return this;
+        }
+
+        /**
+         * Configures a field-backed relationship reference for this field.
+         *
+         * @param reference reference metadata to preserve in model definitions
+         * @return this builder so field definitions can be chained
+         */
+        public Builder reference(final FieldReferenceSpec reference) {
+            this.reference = reference;
+            return this;
+        }
+
+        /**
+         * Configures a field-backed relationship reference for this field.
+         *
+         * @param targetEntityName entity containing the referenced value
+         * @param targetFieldName field on the target entity to match
+         * @param relationshipName relationship from the owning entity to the target entity
+         * @return this builder so field definitions can be chained
+         */
+        public Builder reference(
+                final String targetEntityName,
+                final String targetFieldName,
+                final String relationshipName) {
+            return reference(
+                    new FieldReferenceSpec(targetEntityName, targetFieldName, relationshipName));
         }
 
         public FieldDefinitionSpec build() {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/schema/definition/RelationshipDefinitionSpec.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/schema/definition/RelationshipDefinitionSpec.java
@@ -7,6 +7,8 @@ public final class RelationshipDefinitionSpec {
     private final String toEntityName;
     private final CardinalitySpec cardinality;
     private final String optionality;
+    private final boolean deleteTargetWhenDisconnected;
+    private final boolean deleteTargetsWhenSourceDeleted;
     private final RelationshipVectorSpec reverse;
 
     public RelationshipDefinitionSpec(
@@ -16,11 +18,25 @@ public final class RelationshipDefinitionSpec {
             final CardinalitySpec cardinality,
             final String optionality,
             final RelationshipVectorSpec reverse) {
+        this(fromEntityName, name, toEntityName, cardinality, optionality, false, false, reverse);
+    }
+
+    public RelationshipDefinitionSpec(
+            final String fromEntityName,
+            final String name,
+            final String toEntityName,
+            final CardinalitySpec cardinality,
+            final String optionality,
+            final boolean deleteTargetWhenDisconnected,
+            final boolean deleteTargetsWhenSourceDeleted,
+            final RelationshipVectorSpec reverse) {
         this.fromEntityName = fromEntityName;
         this.name = name;
         this.toEntityName = toEntityName;
         this.cardinality = cardinality;
         this.optionality = optionality;
+        this.deleteTargetWhenDisconnected = deleteTargetWhenDisconnected;
+        this.deleteTargetsWhenSourceDeleted = deleteTargetsWhenSourceDeleted;
         this.reverse = reverse;
     }
 
@@ -42,6 +58,24 @@ public final class RelationshipDefinitionSpec {
 
     public String optionality() {
         return optionality;
+    }
+
+    /**
+     * Reports whether disconnecting the forward vector deletes the target entity.
+     *
+     * @return true when the forward vector owns the target on disconnect
+     */
+    public boolean deleteTargetWhenDisconnected() {
+        return deleteTargetWhenDisconnected;
+    }
+
+    /**
+     * Reports whether deleting the forward source deletes current target entities.
+     *
+     * @return true when the forward vector cascades source deletes to targets
+     */
+    public boolean deleteTargetsWhenSourceDeleted() {
+        return deleteTargetsWhenSourceDeleted;
     }
 
     public RelationshipVectorSpec reverse() {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/schema/definition/RelationshipVectorSpec.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/schema/definition/RelationshipVectorSpec.java
@@ -5,12 +5,25 @@ public final class RelationshipVectorSpec {
     private final String name;
     private final CardinalitySpec cardinality;
     private final String optionality;
+    private final boolean deleteTargetWhenDisconnected;
+    private final boolean deleteTargetsWhenSourceDeleted;
 
     public RelationshipVectorSpec(
             final String name, final CardinalitySpec cardinality, final String optionality) {
+        this(name, cardinality, optionality, false, false);
+    }
+
+    public RelationshipVectorSpec(
+            final String name,
+            final CardinalitySpec cardinality,
+            final String optionality,
+            final boolean deleteTargetWhenDisconnected,
+            final boolean deleteTargetsWhenSourceDeleted) {
         this.name = name;
         this.cardinality = cardinality;
         this.optionality = optionality;
+        this.deleteTargetWhenDisconnected = deleteTargetWhenDisconnected;
+        this.deleteTargetsWhenSourceDeleted = deleteTargetsWhenSourceDeleted;
     }
 
     public String name() {
@@ -23,5 +36,23 @@ public final class RelationshipVectorSpec {
 
     public String optionality() {
         return optionality;
+    }
+
+    /**
+     * Reports whether disconnecting this vector deletes the target entity.
+     *
+     * @return true when this vector owns the target on disconnect
+     */
+    public boolean deleteTargetWhenDisconnected() {
+        return deleteTargetWhenDisconnected;
+    }
+
+    /**
+     * Reports whether deleting this vector's source deletes current target entities.
+     *
+     * @return true when this vector cascades source deletes to targets
+     */
+    public boolean deleteTargetsWhenSourceDeleted() {
+        return deleteTargetsWhenSourceDeleted;
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/schema/definition/ThingifierModelAssembler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/schema/definition/ThingifierModelAssembler.java
@@ -1,11 +1,13 @@
 package uk.co.compendiumdev.thingifier.application.schema.definition;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.application.schema.FieldReferenceSpec;
 import uk.co.compendiumdev.thingifier.core.EntityRelModel;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.Cardinality;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
@@ -31,6 +33,7 @@ public final class ThingifierModelAssembler {
         }
         validateEntities(definition, report);
         validateRelationships(definition, report);
+        validateFieldReferences(definition, report);
         return report;
     }
 
@@ -73,6 +76,8 @@ public final class ThingifierModelAssembler {
             }
         }
 
+        applyFieldReferences(thingifier, definition);
+
         for (RelationshipDefinitionSpec relationshipSpec : definition.relationships()) {
             final EntityDefinition from =
                     thingifier.getDefinitionNamed(relationshipSpec.fromEntityName());
@@ -92,10 +97,31 @@ public final class ThingifierModelAssembler {
                 applyOptionality(
                         relationship.getReversedRelationship(),
                         relationshipSpec.reverse().optionality());
+                applyRelationshipPolicies(
+                        relationship.getReversedRelationship(), relationshipSpec.reverse());
             }
+            applyRelationshipPolicies(relationship.getFromRelationship(), relationshipSpec);
         }
 
         return thingifier;
+    }
+
+    private void applyFieldReferences(
+            final Thingifier thingifier, final ThingifierModelDefinition definition) {
+        for (EntityDefinitionSpec entitySpec : definition.entities()) {
+            final EntityDefinition entity = thingifier.getDefinitionNamed(entitySpec.name());
+            for (FieldDefinitionSpec fieldSpec : entitySpec.fields()) {
+                if (!fieldSpec.hasRelationshipReference()) {
+                    continue;
+                }
+                FieldReferenceSpec reference = fieldSpec.relationshipReference();
+                entity.getField(fieldSpec.name())
+                        .references(
+                                thingifier.getDefinitionNamed(reference.targetEntityName()),
+                                reference.targetFieldName(),
+                                reference.relationshipName());
+            }
+        }
     }
 
     private void validateEntities(
@@ -199,6 +225,97 @@ public final class ThingifierModelAssembler {
 
         validateRange(field, fieldPath, fieldType, report);
         validateRules(field, fieldPath, report);
+    }
+
+    private void validateFieldReferences(
+            final ThingifierModelDefinition definition,
+            final SchemaDefinitionValidationReport report) {
+        for (EntityDefinitionSpec entity : definition.entities()) {
+            validateFieldReferencesFor(
+                    definition,
+                    entity,
+                    entity.fields(),
+                    "entities." + emptyIfNull(entity.name()) + ".fields",
+                    false,
+                    report);
+        }
+    }
+
+    private void validateFieldReferencesFor(
+            final ThingifierModelDefinition definition,
+            final EntityDefinitionSpec sourceEntity,
+            final List<FieldDefinitionSpec> fields,
+            final String fieldPath,
+            final boolean nested,
+            final SchemaDefinitionValidationReport report) {
+        for (FieldDefinitionSpec field : fields) {
+            final String path = fieldPath + "." + emptyIfNull(field.name()) + ".reference";
+            if (field.hasRelationshipReference()) {
+                validateFieldReference(definition, sourceEntity, field, path, nested, report);
+            }
+            validateFieldReferencesFor(
+                    definition, sourceEntity, field.objectFields(), path + ".fields", true, report);
+        }
+    }
+
+    private void validateFieldReference(
+            final ThingifierModelDefinition definition,
+            final EntityDefinitionSpec sourceEntity,
+            final FieldDefinitionSpec field,
+            final String path,
+            final boolean nested,
+            final SchemaDefinitionValidationReport report) {
+        if (nested) {
+            report.addError(path, "Only top-level fields can define relationship references");
+            return;
+        }
+
+        FieldReferenceSpec reference = field.relationshipReference();
+        if (isBlank(reference.targetEntityName())) {
+            report.addError(path + ".entity", "Reference target entity is required");
+            return;
+        }
+        if (isBlank(reference.targetFieldName())) {
+            report.addError(path + ".field", "Reference target field is required");
+            return;
+        }
+        if (isBlank(reference.relationshipName())) {
+            report.addError(path + ".relationship", "Reference relationship is required");
+            return;
+        }
+
+        EntityDefinitionSpec targetEntity = definition.entityNamed(reference.targetEntityName());
+        if (targetEntity == null) {
+            report.addError(
+                    path + ".entity", "Unknown reference target " + reference.targetEntityName());
+            return;
+        }
+
+        FieldDefinitionSpec targetField = targetEntity.fieldNamed(reference.targetFieldName());
+        if (targetField == null) {
+            report.addError(
+                    path + ".field",
+                    "Unknown reference target field " + reference.targetFieldName());
+            return;
+        }
+        if (!isStableReferenceField(targetEntity, targetField)) {
+            report.addError(
+                    path + ".field",
+                    "Reference target field must be unique, primary, or protected");
+        }
+        if (!relationshipConnects(
+                definition,
+                sourceEntity.name(),
+                reference.relationshipName(),
+                targetEntity.name())) {
+            report.addError(
+                    path + ".relationship",
+                    String.format(
+                            "Relationship %s does not connect %s to %s",
+                            reference.relationshipName(),
+                            sourceEntity.name(),
+                            targetEntity.name()));
+        }
     }
 
     private void validateRange(
@@ -436,6 +553,61 @@ public final class ThingifierModelAssembler {
     private void applyOptionality(
             final RelationshipVectorDefinition relationship, final String optionality) {
         relationship.setOptionality(optionalityFor(optionality));
+    }
+
+    private void applyRelationshipPolicies(
+            final RelationshipVectorDefinition relationship,
+            final RelationshipDefinitionSpec relationshipSpec) {
+        if (relationshipSpec.deleteTargetWhenDisconnected()) {
+            relationship.deleteTargetWhenDisconnected();
+        }
+        if (relationshipSpec.deleteTargetsWhenSourceDeleted()) {
+            relationship.deleteTargetsWhenSourceDeleted();
+        }
+    }
+
+    private void applyRelationshipPolicies(
+            final RelationshipVectorDefinition relationship, final RelationshipVectorSpec spec) {
+        if (spec.deleteTargetWhenDisconnected()) {
+            relationship.deleteTargetWhenDisconnected();
+        }
+        if (spec.deleteTargetsWhenSourceDeleted()) {
+            relationship.deleteTargetsWhenSourceDeleted();
+        }
+    }
+
+    private boolean isStableReferenceField(
+            final EntityDefinitionSpec targetEntity, final FieldDefinitionSpec targetField) {
+        if (targetField.unique()) {
+            return true;
+        }
+        if (targetEntity.hasPrimaryKeyField()
+                && targetEntity.primaryKeyFieldName().equals(targetField.name())) {
+            return true;
+        }
+        final FieldType type = fieldTypeFor(targetField.type());
+        return type == FieldType.AUTO_INCREMENT || type == FieldType.AUTO_GUID;
+    }
+
+    private boolean relationshipConnects(
+            final ThingifierModelDefinition definition,
+            final String sourceEntityName,
+            final String relationshipName,
+            final String targetEntityName) {
+        for (RelationshipDefinitionSpec relationship : definition.relationships()) {
+            if (relationship.fromEntityName().equals(sourceEntityName)
+                    && relationship.toEntityName().equals(targetEntityName)
+                    && relationship.name().equals(relationshipName)) {
+                return true;
+            }
+            if (relationship.hasReverse()
+                    && relationship.toEntityName().equals(sourceEntityName)
+                    && relationship.fromEntityName().equals(targetEntityName)
+                    && relationship.reverse().name().equals(relationshipName)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private Optionality optionalityFor(final String optionality) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/schema/definition/ThingifierModelExporter.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/application/schema/definition/ThingifierModelExporter.java
@@ -9,6 +9,7 @@ import uk.co.compendiumdev.thingifier.core.domain.definitions.Cardinality;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.DefinedFields;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.Field;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldRelationshipReference;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldType;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.relationship.Optionality;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.relationship.RelationshipDefinition;
@@ -87,6 +88,13 @@ public final class ThingifierModelExporter {
         }
         if (field.getObjectDefinition() != null) {
             addObjectFields(builder, field.getObjectDefinition());
+        }
+        if (field.hasRelationshipReference()) {
+            FieldRelationshipReference reference = field.relationshipReference();
+            builder.reference(
+                    reference.targetEntity().getName(),
+                    reference.targetFieldName(),
+                    reference.relationshipName());
         }
         return builder.build();
     }
@@ -178,6 +186,8 @@ public final class ThingifierModelExporter {
                 forward.getTo().getName(),
                 cardinalitySpecFor(forward.getCardinality()),
                 optionalityNameFor(forward.getOptionality()),
+                forward.shouldDeleteTargetWhenDisconnected(),
+                forward.shouldDeleteTargetsWhenSourceDeleted(),
                 reverse);
     }
 
@@ -185,7 +195,9 @@ public final class ThingifierModelExporter {
         return new RelationshipVectorSpec(
                 vector.getName(),
                 cardinalitySpecFor(vector.getCardinality()),
-                optionalityNameFor(vector.getOptionality()));
+                optionalityNameFor(vector.getOptionality()),
+                vector.shouldDeleteTargetWhenDisconnected(),
+                vector.shouldDeleteTargetsWhenSourceDeleted());
     }
 
     private CardinalitySpec cardinalitySpecFor(final Cardinality cardinality) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/Swaggerizer.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/Swaggerizer.java
@@ -133,6 +133,9 @@ public class Swaggerizer {
         Components components = convertEntityDefinitionsToComponents(routingDefinitions);
 
         api.components(components);
+        for (String bearerSchemeName : thingifier.apiSpec().security().bearerSchemes()) {
+            addHttpSecurityScheme(components, bearerSchemeName, "bearer", null);
+        }
 
         if (routes != null) {
 
@@ -248,9 +251,10 @@ public class Swaggerizer {
                             }
 
                             if (subroute.isSecuredByBearerAuth()) {
-                                addHttpSecurityScheme(components, "bearerAuth", "bearer", null);
+                                final String bearerSchemeName = subroute.bearerAuthSchemeName();
+                                addHttpSecurityScheme(components, bearerSchemeName, "bearer", null);
                                 operation.addSecurityItem(
-                                        new SecurityRequirement().addList("bearerAuth"));
+                                        new SecurityRequirement().addList(bearerSchemeName));
                             }
 
                             if (shouldDocumentSortParameter(thingifier, subroute)) {

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/hooks/ThingifierApiLifecycleHooksTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/hooks/ThingifierApiLifecycleHooksTest.java
@@ -1,0 +1,536 @@
+package uk.co.compendiumdev.thingifier.api.http.hooks;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import uk.co.compendiumdev.casestudy.todomanager.TodoManagerModel;
+import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.adapter.hooks.HookScope;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleHookRegistry;
+import uk.co.compendiumdev.thingifier.adapter.http.messagehooks.HttpApiHookRegistry;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
+import uk.co.compendiumdev.thingifier.api.http.HttpApiRequest;
+import uk.co.compendiumdev.thingifier.api.http.HttpApiResponse;
+import uk.co.compendiumdev.thingifier.api.http.ThingifierHttpApi;
+import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields;
+import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
+import uk.co.compendiumdev.thingifier.application.ThingCommandResult;
+import uk.co.compendiumdev.thingifier.application.command.CreateThingCommand;
+import uk.co.compendiumdev.thingifier.application.query.ReadCollectionQuery;
+import uk.co.compendiumdev.thingifier.core.EntityRelModel;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.instance.NamedValue;
+import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
+import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstanceDraft;
+import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
+import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
+
+class ThingifierApiLifecycleHooksTest {
+
+    @ParameterizedTest
+    @EnumSource(
+            value = ThingifierHttpApi.HttpVerb.class,
+            names = {"GET", "HEAD", "QUERY", "POST", "PUT", "PATCH", "DELETE"})
+    void routeMatchedHookRunsForDynamicThingifierOperation(final ThingifierHttpApi.HttpVerb verb) {
+        Thingifier thingifier = todoThingifier();
+        ThingifierApiLifecycleHookRegistry hooks = new ThingifierApiLifecycleHookRegistry();
+        AtomicInteger callCount = new AtomicInteger();
+        hooks.registerRouteMatchedHook(context -> callCount.incrementAndGet());
+
+        perform(thingifier, hooks, verb);
+
+        Assertions.assertEquals(1, callCount.get());
+    }
+
+    @Test
+    void globalScopedLifecycleHookRunsForEveryApiRequest() {
+        ThingifierApiLifecycleHookRegistry hooks = new ThingifierApiLifecycleHookRegistry();
+        AtomicInteger callCount = new AtomicInteger();
+        hooks.registerRouteMatchedHook(context -> callCount.incrementAndGet());
+        ThingifierHttpApi api = api(todoThingifier(), hooks);
+
+        api.get(new HttpApiRequest("/todos"));
+        api.get(new HttpApiRequest("/projects"));
+
+        Assertions.assertEquals(2, callCount.get());
+    }
+
+    @Test
+    void endpointScopedLifecycleHookRunsOnlyForMatchingPath() {
+        ThingifierApiLifecycleHookRegistry hooks = new ThingifierApiLifecycleHookRegistry();
+        AtomicInteger callCount = new AtomicInteger();
+        hooks.registerRouteMatchedHook("todos", context -> callCount.incrementAndGet());
+        ThingifierHttpApi api = api(todoThingifier(), hooks);
+
+        api.get(new HttpApiRequest("/todos"));
+        api.get(new HttpApiRequest("/projects"));
+
+        Assertions.assertEquals(1, callCount.get());
+    }
+
+    @Test
+    void verbScopedLifecycleHookRunsOnlyForMatchingVerb() {
+        ThingifierApiLifecycleHookRegistry hooks = new ThingifierApiLifecycleHookRegistry();
+        AtomicInteger callCount = new AtomicInteger();
+        hooks.registerRouteMatchedHook(
+                HookScope.verbs(RoutingVerb.POST), context -> callCount.incrementAndGet());
+        ThingifierHttpApi api = api(todoThingifier(), hooks);
+
+        api.get(new HttpApiRequest("/todos"));
+        api.post(jsonRequest("/todos", "{\"title\":\"created\"}"));
+
+        Assertions.assertEquals(1, callCount.get());
+    }
+
+    @Test
+    void endpointAndVerbScopedLifecycleHookRequiresBothToMatch() {
+        ThingifierApiLifecycleHookRegistry hooks = new ThingifierApiLifecycleHookRegistry();
+        AtomicInteger callCount = new AtomicInteger();
+        hooks.registerRouteMatchedHook(
+                "todos", List.of(RoutingVerb.POST), context -> callCount.incrementAndGet());
+        ThingifierHttpApi api = api(todoThingifier(), hooks);
+
+        api.get(new HttpApiRequest("/todos"));
+        api.post(jsonRequest("/projects", "{\"title\":\"project\"}"));
+        api.post(jsonRequest("/todos", "{\"title\":\"todo\"}"));
+
+        Assertions.assertEquals(1, callCount.get());
+    }
+
+    @Test
+    void endpointScopedLifecycleHookMatchesPathParameter() {
+        ThingifierApiLifecycleHookRegistry hooks = new ThingifierApiLifecycleHookRegistry();
+        AtomicInteger callCount = new AtomicInteger();
+        hooks.registerRouteMatchedHook("todos/{guid}", context -> callCount.incrementAndGet());
+
+        api(todoThingifier(), hooks).get(new HttpApiRequest("/todos/123"));
+
+        Assertions.assertEquals(1, callCount.get());
+    }
+
+    @Test
+    void routeMatchedContextExposesCollectionRouteTarget() {
+        ThingifierApiLifecycleHookRegistry hooks = new ThingifierApiLifecycleHookRegistry();
+        AtomicReference<String> targetEntity = new AtomicReference<>();
+        hooks.registerRouteMatchedHook(
+                context -> targetEntity.set(context.targetEntity().getName()));
+
+        api(todoThingifier(), hooks).get(new HttpApiRequest("/todos"));
+
+        Assertions.assertEquals("todo", targetEntity.get());
+    }
+
+    @Test
+    void routeMatchedContextExposesInstanceRouteIdentifier() {
+        Thingifier thingifier = todoThingifier();
+        EntityInstance todo = createTodo(thingifier, "inspect me");
+        ThingifierApiLifecycleHookRegistry hooks = new ThingifierApiLifecycleHookRegistry();
+        AtomicReference<String> targetIdentifier = new AtomicReference<>();
+        hooks.registerRouteMatchedHook(context -> targetIdentifier.set(context.targetIdentifier()));
+
+        api(thingifier, hooks).get(new HttpApiRequest("/todos/" + todo.getPrimaryKeyValue()));
+
+        Assertions.assertEquals(todo.getPrimaryKeyValue(), targetIdentifier.get());
+    }
+
+    @Test
+    void routeMatchedContextExposesRelationshipCollectionDetails() {
+        Thingifier thingifier = todoThingifier();
+        EntityInstance project = createProject(thingifier, "project");
+        ThingifierApiLifecycleHookRegistry hooks = new ThingifierApiLifecycleHookRegistry();
+        AtomicReference<String> parentEntity = new AtomicReference<>();
+        AtomicReference<String> parentIdentifier = new AtomicReference<>();
+        AtomicReference<String> relationshipName = new AtomicReference<>();
+        AtomicReference<String> targetEntity = new AtomicReference<>();
+        hooks.registerRouteMatchedHook(
+                context -> {
+                    parentEntity.set(context.parentEntity().getName());
+                    parentIdentifier.set(context.parentIdentifier());
+                    relationshipName.set(context.relationshipName());
+                    targetEntity.set(context.targetEntity().getName());
+                });
+
+        api(thingifier, hooks)
+                .get(new HttpApiRequest("/projects/" + project.getPrimaryKeyValue() + "/tasks"));
+
+        Assertions.assertEquals("project", parentEntity.get());
+        Assertions.assertEquals(project.getPrimaryKeyValue(), parentIdentifier.get());
+        Assertions.assertEquals("tasks", relationshipName.get());
+        Assertions.assertEquals("todo", targetEntity.get());
+    }
+
+    @Test
+    void routeMatchedContextExposesRelationshipInstanceChildIdentifier() {
+        Thingifier thingifier = todoThingifier();
+        EntityInstance project = createProject(thingifier, "project");
+        EntityInstance todo = createTodo(thingifier, "task");
+        ThingifierApiLifecycleHookRegistry hooks = new ThingifierApiLifecycleHookRegistry();
+        AtomicReference<String> childIdentifier = new AtomicReference<>();
+        hooks.registerRouteMatchedHook(context -> childIdentifier.set(context.childIdentifier()));
+
+        api(thingifier, hooks)
+                .get(
+                        new HttpApiRequest(
+                                "/projects/"
+                                        + project.getPrimaryKeyValue()
+                                        + "/tasks/"
+                                        + todo.getPrimaryKeyValue()));
+
+        Assertions.assertEquals(todo.getPrimaryKeyValue(), childIdentifier.get());
+    }
+
+    @Test
+    void bodyParsedHookCanChangeParsedFieldsBeforeCreateValidation() {
+        ThingifierApiLifecycleHookRegistry hooks = new ThingifierApiLifecycleHookRegistry();
+        hooks.registerBodyParsedHook(
+                context ->
+                        context.replaceBodyFields(
+                                ApiBodyFields.fromMap(Map.of("title", "from body hook"))));
+
+        HttpApiResponse response = api(todoThingifier(), hooks).post(jsonRequest("/todos", "{}"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals("from body hook", returnedTitle(response));
+    }
+
+    @Test
+    void beforeValidationHookCanReplaceWriteCommandBeforeThingifierValidation() {
+        ThingifierApiLifecycleHookRegistry hooks = new ThingifierApiLifecycleHookRegistry();
+        hooks.registerBeforeValidationHook(
+                context ->
+                        context.replaceWriteCommand(
+                                new CreateThingCommand(
+                                        "todo",
+                                        List.of(new NamedValue("title", "from command hook")),
+                                        List.of(),
+                                        true)));
+
+        HttpApiResponse response = api(todoThingifier(), hooks).post(jsonRequest("/todos", "{}"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals("from command hook", returnedTitle(response));
+    }
+
+    @Test
+    void afterValidationHookCanRejectValidWrite() {
+        Thingifier thingifier = todoThingifier();
+        ThingifierApiLifecycleHookRegistry hooks = new ThingifierApiLifecycleHookRegistry();
+        hooks.registerAfterValidationHook(
+                context -> context.replaceValidationResult(ThingCommandResult.error("blocked")));
+
+        HttpApiResponse response =
+                api(thingifier, hooks).post(jsonRequest("/todos", "{\"title\":\"valid\"}"));
+
+        Assertions.assertEquals(422, response.getStatusCode());
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    @Test
+    void afterValidationHookCanReplaceValidationFailureWithValidCommand() {
+        ThingifierApiLifecycleHookRegistry hooks = new ThingifierApiLifecycleHookRegistry();
+        hooks.registerAfterValidationHook(
+                context -> {
+                    context.replaceWriteCommand(
+                            new CreateThingCommand(
+                                    "todo",
+                                    List.of(new NamedValue("title", "after validation")),
+                                    List.of(),
+                                    true));
+                    context.clearValidationResult();
+                });
+
+        HttpApiResponse response = api(todoThingifier(), hooks).post(jsonRequest("/todos", "{}"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals("after validation", returnedTitle(response));
+    }
+
+    @Test
+    void beforeActionHookCanReplaceReadQueryBeforeExecution() {
+        Thingifier thingifier = todoThingifier();
+        createTodo(thingifier, "visible");
+        createTodo(thingifier, "hidden");
+        ThingifierApiLifecycleHookRegistry hooks = new ThingifierApiLifecycleHookRegistry();
+        hooks.registerBeforeActionHook(
+                context ->
+                        context.replaceReadQuery(
+                                new ReadCollectionQuery("todo", queryParams("title", "visible"))));
+        HttpApiRequest request =
+                new HttpApiRequest("/todos").setFilterableQueryParams("title=hidden");
+
+        HttpApiResponse response = api(thingifier, hooks).get(request);
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals("visible", returnedCollectionTitle(response));
+    }
+
+    @Test
+    void beforeActionHookCanReplaceWriteCommandBeforeExecution() {
+        ThingifierApiLifecycleHookRegistry hooks = new ThingifierApiLifecycleHookRegistry();
+        hooks.registerBeforeActionHook(
+                context ->
+                        context.replaceWriteCommand(
+                                new CreateThingCommand(
+                                        "todo",
+                                        List.of(new NamedValue("title", "from action hook")),
+                                        List.of(),
+                                        true)));
+
+        HttpApiResponse response =
+                api(todoThingifier(), hooks).post(jsonRequest("/todos", "{\"title\":\"valid\"}"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals("from action hook", returnedTitle(response));
+    }
+
+    @Test
+    void afterActionHookCanInspectCreatedResultAndMutateApiResponse() {
+        ThingifierApiLifecycleHookRegistry hooks = new ThingifierApiLifecycleHookRegistry();
+        AtomicReference<String> createdTitle = new AtomicReference<>();
+        hooks.registerAfterActionHook(
+                context -> {
+                    createdTitle.set(
+                            context.writeCommandResult()
+                                    .getInstance()
+                                    .getFieldValue("title")
+                                    .asString());
+                    context.apiResponse().setHeader("X-Hook-Phase", "after-action");
+                });
+
+        HttpApiResponse response =
+                api(todoThingifier(), hooks).post(jsonRequest("/todos", "{\"title\":\"created\"}"));
+
+        Assertions.assertEquals("created", createdTitle.get());
+        Assertions.assertEquals("after-action", response.getHeaders().get("X-Hook-Phase"));
+    }
+
+    @Test
+    void afterActionHookCanInspectUpdatedResult() {
+        Thingifier thingifier = todoThingifier();
+        EntityInstance todo = createTodo(thingifier, "before");
+        ThingifierApiLifecycleHookRegistry hooks = new ThingifierApiLifecycleHookRegistry();
+        AtomicReference<String> updatedTitle = new AtomicReference<>();
+        hooks.registerAfterActionHook(
+                context ->
+                        updatedTitle.set(
+                                context.writeCommandResult()
+                                        .getInstance()
+                                        .getFieldValue("title")
+                                        .asString()));
+
+        HttpApiResponse response =
+                api(thingifier, hooks)
+                        .post(
+                                jsonRequest(
+                                        "/todos/" + todo.getPrimaryKeyValue(),
+                                        "{\"title\":\"updated\"}"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals("updated", updatedTitle.get());
+    }
+
+    @Test
+    void afterActionHookCanInspectDeletedResult() {
+        Thingifier thingifier = todoThingifier();
+        EntityInstance todo = createTodo(thingifier, "delete me");
+        ThingifierApiLifecycleHookRegistry hooks = new ThingifierApiLifecycleHookRegistry();
+        AtomicBoolean deletedSuccessfully = new AtomicBoolean(false);
+        hooks.registerAfterActionHook(
+                context -> deletedSuccessfully.set(context.writeCommandResult().isSuccessful()));
+
+        HttpApiResponse response =
+                api(thingifier, hooks)
+                        .delete(new HttpApiRequest("/todos/" + todo.getPrimaryKeyValue()));
+
+        Assertions.assertEquals(204, response.getStatusCode());
+        Assertions.assertTrue(deletedSuccessfully.get());
+    }
+
+    @Test
+    void afterActionHookCanInspectReadResultAndMutateApiResponse() {
+        Thingifier thingifier = todoThingifier();
+        createTodo(thingifier, "read me");
+        ThingifierApiLifecycleHookRegistry hooks = new ThingifierApiLifecycleHookRegistry();
+        AtomicInteger resultSize = new AtomicInteger();
+        hooks.registerAfterActionHook(
+                context -> {
+                    resultSize.set(context.readQueryResult().getListEntityInstances().size());
+                    context.apiResponse().setHeader("X-Read-Hook", "inspected");
+                });
+
+        HttpApiResponse response = api(thingifier, hooks).get(new HttpApiRequest("/todos"));
+
+        Assertions.assertEquals(1, resultSize.get());
+        Assertions.assertEquals("inspected", response.getHeaders().get("X-Read-Hook"));
+    }
+
+    @Test
+    void afterActionHookChangingWriteResultToErrorRollsBackCommand() {
+        Thingifier thingifier = todoThingifier();
+        ThingifierApiLifecycleHookRegistry hooks = new ThingifierApiLifecycleHookRegistry();
+        hooks.registerAfterActionHook(
+                context -> context.replaceWriteCommandResult(ThingCommandResult.error("rollback")));
+
+        HttpApiResponse response =
+                api(thingifier, hooks).post(jsonRequest("/todos", "{\"title\":\"created\"}"));
+
+        Assertions.assertEquals(422, response.getStatusCode());
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    @Test
+    void lifecycleHooksRunBetweenExistingRequestAndResponseHooks() {
+        ThingifierApiLifecycleHookRegistry lifecycleHooks =
+                new ThingifierApiLifecycleHookRegistry();
+        List<String> calls = new ArrayList<>();
+        lifecycleHooks.registerRouteMatchedHook(context -> calls.add("route matched"));
+        lifecycleHooks.registerBodyParsedHook(context -> calls.add("body parsed"));
+        lifecycleHooks.registerBeforeValidationHook(context -> calls.add("before validation"));
+        lifecycleHooks.registerAfterValidationHook(context -> calls.add("after validation"));
+        lifecycleHooks.registerBeforeActionHook(context -> calls.add("before action"));
+        lifecycleHooks.registerAfterActionHook(context -> calls.add("after action"));
+        HttpApiHookRegistry httpHooks = new HttpApiHookRegistry();
+        httpHooks.registerRequestHook(
+                (request, config) -> {
+                    calls.add("request");
+                    return null;
+                });
+        httpHooks.registerResponseHook(
+                (request, response, config) -> {
+                    calls.add("response");
+                    return null;
+                });
+
+        ThingifierHttpApi.withHookRegistries(todoThingifier(), httpHooks, lifecycleHooks)
+                .get(new HttpApiRequest("/todos"));
+
+        Assertions.assertEquals(
+                List.of(
+                        "request",
+                        "route matched",
+                        "body parsed",
+                        "before validation",
+                        "after validation",
+                        "before action",
+                        "after action",
+                        "response"),
+                calls);
+    }
+
+    @Test
+    void existingRequestHookShortCircuitSkipsLifecycleHooks() {
+        ThingifierApiLifecycleHookRegistry lifecycleHooks =
+                new ThingifierApiLifecycleHookRegistry();
+        AtomicInteger callCount = new AtomicInteger();
+        lifecycleHooks.registerRouteMatchedHook(context -> callCount.incrementAndGet());
+        HttpApiHookRegistry httpHooks = new HttpApiHookRegistry();
+        httpHooks.registerRequestHook(
+                (request, config) ->
+                        new HttpApiResponse(
+                                null, ApiResponse.error(409, "existing hook"), null, config));
+
+        HttpApiResponse response =
+                ThingifierHttpApi.withHookRegistries(todoThingifier(), httpHooks, lifecycleHooks)
+                        .get(new HttpApiRequest("/todos"));
+
+        Assertions.assertEquals(409, response.getStatusCode());
+        Assertions.assertEquals(0, callCount.get());
+    }
+
+    private void perform(
+            final Thingifier thingifier,
+            final ThingifierApiLifecycleHookRegistry hooks,
+            final ThingifierHttpApi.HttpVerb verb) {
+        ThingifierHttpApi api = api(thingifier, hooks);
+        switch (verb) {
+            case GET:
+                api.get(new HttpApiRequest("/todos"));
+                break;
+            case HEAD:
+                api.head(new HttpApiRequest("/todos"));
+                break;
+            case QUERY:
+                api.queryRequest(new HttpApiRequest("/todos"));
+                break;
+            case POST:
+                api.post(jsonRequest("/todos", "{\"title\":\"created\"}"));
+                break;
+            case PUT:
+                api.put(jsonRequest("/todos/123", "{\"title\":\"replaced\"}"));
+                break;
+            case PATCH:
+                api.patch(jsonRequest("/todos/123", "{\"title\":\"patched\"}"));
+                break;
+            case DELETE:
+                api.delete(new HttpApiRequest("/todos/123"));
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported test verb " + verb);
+        }
+    }
+
+    private ThingifierHttpApi api(
+            final Thingifier thingifier, final ThingifierApiLifecycleHookRegistry hooks) {
+        return new ThingifierHttpApi(thingifier, null, null, hooks);
+    }
+
+    private Thingifier todoThingifier() {
+        Thingifier thingifier = TodoManagerModel.definedAsThingifier();
+        thingifier.apiConfig().setApiToEnforceAcceptHeaderForResponses(false);
+        thingifier.apiConfig().setApiToEnforceContentTypeForRequests(false);
+        return thingifier;
+    }
+
+    private HttpApiRequest jsonRequest(final String path, final String body) {
+        return new HttpApiRequest(path).addHeader("Content-Type", "application/json").setBody(body);
+    }
+
+    private String returnedTitle(final HttpApiResponse response) {
+        return response.apiResponse().getReturnedInstance().getFieldValue("title").asString();
+    }
+
+    private String returnedCollectionTitle(final HttpApiResponse response) {
+        return response.apiResponse()
+                .getReturnedInstanceCollection()
+                .get(0)
+                .getFieldValue("title")
+                .asString();
+    }
+
+    private EntityInstance createTodo(final Thingifier thingifier, final String title) {
+        return create(thingifier, "todo", title);
+    }
+
+    private EntityInstance createProject(final Thingifier thingifier, final String title) {
+        return create(thingifier, "project", title);
+    }
+
+    private EntityInstance create(
+            final Thingifier thingifier, final String entityName, final String title) {
+        EntityDefinition entity = thingifier.getDefinitionNamed(entityName);
+        return storeFor(thingifier)
+                .entities()
+                .create(EntityInstanceDraft.forEntity(entity).withField("title", title));
+    }
+
+    private int todoCount(final Thingifier thingifier) {
+        return storeFor(thingifier).entityQueries().count(thingifier.getDefinitionNamed("todo"));
+    }
+
+    private QueryFilterParams queryParams(final String fieldName, final String fieldValue) {
+        QueryFilterParams params = new QueryFilterParams();
+        params.put(fieldName, fieldValue);
+        return params;
+    }
+
+    private ThingStore storeFor(final Thingifier thingifier) {
+        return thingifier.getStore(EntityRelModel.DEFAULT_DATABASE_NAME);
+    }
+}

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RelationshipBodyCommandParserTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RelationshipBodyCommandParserTest.java
@@ -94,6 +94,50 @@ public class RelationshipBodyCommandParserTest {
                         .isError());
     }
 
+    @Test
+    public void parsesFieldReferenceAsRelationshipReference() {
+        Thingifier thingifier = productItemThingifier();
+        ThingifierSchemaCatalog schema = new ThingifierSchemaCatalog(thingifier);
+        Map<String, String> body = new HashMap<>();
+        body.put("productId", "1");
+        body.put("quantity", "2");
+
+        RelationshipBodyCommands commands =
+                new RelationshipBodyCommandParser(schema)
+                        .parse(
+                                bodyFieldsFor(body).asFlattenedStringMap(),
+                                schema.entityWithSingularOrPluralName("item"));
+
+        Assertions.assertTrue(commands.validationReport().isValid());
+        Assertions.assertEquals(1, commands.references().size());
+        Assertions.assertTrue(commands.references().get(0).isFieldBinding());
+        Assertions.assertEquals("product", commands.references().get(0).relationshipName());
+        Assertions.assertEquals("id", commands.references().get(0).referenceFieldName());
+        Assertions.assertEquals("1", commands.references().get(0).referenceValue());
+        Assertions.assertTrue(commands.relationshipEntries().isEmpty());
+    }
+
+    @Test
+    public void rejectsConflictingFieldAndExplicitRelationshipReferences() {
+        Thingifier thingifier = productItemThingifier();
+        ThingifierSchemaCatalog schema = new ThingifierSchemaCatalog(thingifier);
+        Map<String, String> body = new HashMap<>();
+        body.put("productId", "1");
+        body.put("product.id", "2");
+
+        RelationshipBodyCommands commands =
+                new RelationshipBodyCommandParser(schema)
+                        .parse(
+                                bodyFieldsFor(body).asFlattenedStringMap(),
+                                schema.entityWithSingularOrPluralName("item"));
+
+        Assertions.assertFalse(commands.validationReport().isValid());
+        Assertions.assertTrue(
+                commands.validationReport()
+                        .getErrorMessages()
+                        .contains("Conflicting relationship references supplied for product"));
+    }
+
     private Thingifier taskProjectThingifier() {
         Thingifier thingifier = new Thingifier();
         EntityDefinition task = thingifier.defineThing("task", "tasks");
@@ -107,6 +151,21 @@ public class RelationshipBodyCommandParserTest {
         thingifier
                 .defineRelationship(task, project, "task-of", Cardinality.ONE_TO_ONE())
                 .whenReversed(Cardinality.ONE_TO_MANY(), "tasks");
+        return thingifier;
+    }
+
+    private Thingifier productItemThingifier() {
+        Thingifier thingifier = new Thingifier();
+        EntityDefinition product = thingifier.defineThing("product", "products");
+        product.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT));
+
+        EntityDefinition item = thingifier.defineThing("item", "items");
+        item.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT));
+        item.addField(
+                Field.is("productId", FieldType.INTEGER).references(product, "id", "product"));
+        item.addField(Field.is("quantity", FieldType.INTEGER));
+
+        thingifier.defineRelationship(item, product, "product", Cardinality.ONE_TO_ONE());
         return thingifier;
     }
 

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RelationshipFunctionalityTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RelationshipFunctionalityTest.java
@@ -1,0 +1,511 @@
+package uk.co.compendiumdev.thingifier.api.restapihandlers;
+
+import static uk.co.compendiumdev.thingifier.apiconfig.RelationshipWriteOperation.UPDATE_CONNECTED;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
+import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields;
+import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
+import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
+import uk.co.compendiumdev.thingifier.core.EntityRelModel;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.Cardinality;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.Field;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldType;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.validation.VRule;
+import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
+import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstanceDraft;
+import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
+
+public class RelationshipFunctionalityTest {
+
+    @Test
+    public void relationshipPostUpdatesAlreadyConnectedChildWhenEnabled() {
+        Thingifier thingifier = projectTaskThingifier(false, false);
+        thingifier.apiDefaults().writeMethods().relationships().postCan(UPDATE_CONNECTED);
+        EntityInstance project = createProject(thingifier, "Project");
+        EntityInstance task = createTask(thingifier, "Original");
+        storeFor(thingifier).relationships().connect(project, "tasks", task);
+
+        ApiResponse response =
+                postRelationship(
+                        thingifier,
+                        project,
+                        Map.of("id", Integer.valueOf(task.getPrimaryKeyValue()), "title", "New"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(
+                "New", currentTask(thingifier, task).getFieldValue("title").asString());
+        Assertions.assertEquals(1, relatedTasks(thingifier, project).size());
+    }
+
+    @Test
+    public void defaultRelationshipPostKeepsRepeatedConnectExistingBehavior() {
+        Thingifier thingifier = projectTaskThingifier(false, false);
+        EntityInstance project = createProject(thingifier, "Project");
+        EntityInstance task = createTask(thingifier, "Original");
+        storeFor(thingifier).relationships().connect(project, "tasks", task);
+
+        ApiResponse response =
+                postRelationship(
+                        thingifier,
+                        project,
+                        Map.of("id", Integer.valueOf(task.getPrimaryKeyValue()), "title", "New"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals(
+                "Original", currentTask(thingifier, task).getFieldValue("title").asString());
+        Assertions.assertEquals(1, relatedTasks(thingifier, project).size());
+    }
+
+    @Test
+    public void updateOnlyRelationshipPostRejectsUnconnectedChildren() {
+        Thingifier thingifier = projectTaskThingifier(false, false);
+        thingifier.apiDefaults().writeMethods().relationships().postCan(UPDATE_CONNECTED);
+        EntityInstance project = createProject(thingifier, "Project");
+        EntityInstance task = createTask(thingifier, "Original");
+
+        ApiResponse response =
+                postRelationship(
+                        thingifier,
+                        project,
+                        Map.of("id", Integer.valueOf(task.getPrimaryKeyValue()), "title", "New"));
+
+        Assertions.assertEquals(405, response.getStatusCode());
+        Assertions.assertEquals(
+                "Original", currentTask(thingifier, task).getFieldValue("title").asString());
+        Assertions.assertTrue(relatedTasks(thingifier, project).isEmpty());
+    }
+
+    @Test
+    public void invalidUpdateConnectedChildLeavesExistingChildUnchanged() {
+        Thingifier thingifier = projectTaskThingifier(false, false);
+        thingifier.apiDefaults().writeMethods().relationships().postCan(UPDATE_CONNECTED);
+        EntityInstance project = createProject(thingifier, "Project");
+        EntityInstance task = createTask(thingifier, "Original");
+        storeFor(thingifier).relationships().connect(project, "tasks", task);
+
+        ApiResponse response =
+                postRelationship(
+                        thingifier,
+                        project,
+                        Map.of("id", Integer.valueOf(task.getPrimaryKeyValue()), "title", ""));
+
+        Assertions.assertEquals(422, response.getStatusCode());
+        Assertions.assertEquals(
+                "Original", currentTask(thingifier, task).getFieldValue("title").asString());
+    }
+
+    @Test
+    public void relationshipDeleteDisconnectsByDefault() {
+        Thingifier thingifier = projectTaskThingifier(false, false);
+        EntityInstance project = createProject(thingifier, "Project");
+        EntityInstance task = createTask(thingifier, "Task");
+        storeFor(thingifier).relationships().connect(project, "tasks", task);
+
+        ApiResponse response =
+                thingifier
+                        .api()
+                        .delete(
+                                "projects/"
+                                        + project.getPrimaryKeyValue()
+                                        + "/tasks/"
+                                        + task.getPrimaryKeyValue(),
+                                new HttpHeadersBlock());
+
+        Assertions.assertEquals(204, response.getStatusCode());
+        Assertions.assertNotNull(currentTask(thingifier, task));
+        Assertions.assertTrue(relatedTasks(thingifier, project).isEmpty());
+    }
+
+    @Test
+    public void relationshipDeleteCanDeleteDisconnectedTarget() {
+        Thingifier thingifier = projectTaskThingifier(true, false);
+        EntityInstance project = createProject(thingifier, "Project");
+        EntityInstance task = createTask(thingifier, "Task");
+        storeFor(thingifier).relationships().connect(project, "tasks", task);
+
+        ApiResponse response =
+                thingifier
+                        .api()
+                        .delete(
+                                "projects/"
+                                        + project.getPrimaryKeyValue()
+                                        + "/tasks/"
+                                        + task.getPrimaryKeyValue(),
+                                new HttpHeadersBlock());
+
+        Assertions.assertEquals(204, response.getStatusCode());
+        Assertions.assertNull(currentTask(thingifier, task));
+    }
+
+    @Test
+    public void parentDeleteCanCascadeToRelatedTargets() {
+        Thingifier thingifier = projectTaskThingifier(false, true);
+        EntityInstance project = createProject(thingifier, "Project");
+        EntityInstance firstTask = createTask(thingifier, "First");
+        EntityInstance secondTask = createTask(thingifier, "Second");
+        storeFor(thingifier).relationships().connect(project, "tasks", firstTask);
+        storeFor(thingifier).relationships().connect(project, "tasks", secondTask);
+
+        ApiResponse response =
+                thingifier
+                        .api()
+                        .delete("projects/" + project.getPrimaryKeyValue(), new HttpHeadersBlock());
+
+        Assertions.assertEquals(204, response.getStatusCode());
+        Assertions.assertNull(currentProject(thingifier, project));
+        Assertions.assertNull(currentTask(thingifier, firstTask));
+        Assertions.assertNull(currentTask(thingifier, secondTask));
+    }
+
+    @Test
+    public void parentDeleteCascadeHandlesRelationshipCycles() {
+        Thingifier thingifier = nodeThingifier();
+        EntityInstance first = createNode(thingifier, "a");
+        EntityInstance second = createNode(thingifier, "b");
+        storeFor(thingifier).relationships().connect(first, "children", second);
+        storeFor(thingifier).relationships().connect(second, "children", first);
+
+        ApiResponse response = thingifier.api().delete("nodes/a", new HttpHeadersBlock());
+
+        Assertions.assertEquals(204, response.getStatusCode());
+        Assertions.assertNull(currentNode(thingifier, "a"));
+        Assertions.assertNull(currentNode(thingifier, "b"));
+    }
+
+    @Test
+    public void fieldReferenceCreateConnectsReferencedTarget() {
+        Thingifier thingifier = productItemThingifier();
+        EntityInstance product = createProduct(thingifier, "Widget");
+
+        ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "items",
+                                body(
+                                        Map.of(
+                                                "productId",
+                                                Integer.valueOf(product.getPrimaryKeyValue()),
+                                                "quantity",
+                                                2)),
+                                contextFor(thingifier));
+
+        EntityInstance item = response.getReturnedInstance();
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals(
+                product.getPrimaryKeyValue(), item.getFieldValue("productId").asString());
+        Assertions.assertTrue(isRelated(thingifier, item, "product", product));
+    }
+
+    @Test
+    public void fieldReferenceCreateRejectsUnknownTarget() {
+        Thingifier thingifier = productItemThingifier();
+
+        ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "items",
+                                body(Map.of("productId", 999, "quantity", 2)),
+                                contextFor(thingifier));
+
+        Assertions.assertEquals(422, response.getStatusCode());
+        Assertions.assertEquals(
+                0, storeFor(thingifier).entityQueries().count(itemEntity(thingifier)));
+    }
+
+    @Test
+    public void fieldReferenceAmendReplacesExistingRelationship() {
+        Thingifier thingifier = productItemThingifier();
+        EntityInstance firstProduct = createProduct(thingifier, "First");
+        EntityInstance secondProduct = createProduct(thingifier, "Second");
+        EntityInstance item = createItem(thingifier, firstProduct, 1);
+
+        ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "items/" + item.getPrimaryKeyValue(),
+                                body(
+                                        Map.of(
+                                                "productId",
+                                                Integer.valueOf(
+                                                        secondProduct.getPrimaryKeyValue()))),
+                                contextFor(thingifier));
+
+        EntityInstance updated = currentItem(thingifier, item);
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertFalse(isRelated(thingifier, updated, "product", firstProduct));
+        Assertions.assertTrue(isRelated(thingifier, updated, "product", secondProduct));
+    }
+
+    @Test
+    public void partialAmendWithoutFieldReferenceLeavesRelationshipUnchanged() {
+        Thingifier thingifier = productItemThingifier();
+        EntityInstance product = createProduct(thingifier, "Widget");
+        EntityInstance item = createItem(thingifier, product, 1);
+
+        ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "items/" + item.getPrimaryKeyValue(),
+                                body(Map.of("quantity", 3)),
+                                contextFor(thingifier));
+
+        EntityInstance updated = currentItem(thingifier, item);
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals("3", updated.getFieldValue("quantity").asString());
+        Assertions.assertTrue(isRelated(thingifier, updated, "product", product));
+    }
+
+    @Test
+    public void fullReplaceWithFieldReferenceReconnectsSuppliedRelationship() {
+        Thingifier thingifier = productItemThingifier();
+        EntityInstance firstProduct = createProduct(thingifier, "First");
+        EntityInstance secondProduct = createProduct(thingifier, "Second");
+        EntityInstance item = createItem(thingifier, firstProduct, 1);
+
+        ApiResponse response =
+                thingifier
+                        .api()
+                        .put(
+                                "items/" + item.getPrimaryKeyValue(),
+                                body(
+                                        Map.of(
+                                                "productId",
+                                                Integer.valueOf(secondProduct.getPrimaryKeyValue()),
+                                                "quantity",
+                                                7)),
+                                contextFor(thingifier));
+
+        EntityInstance updated = currentItem(thingifier, item);
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertFalse(isRelated(thingifier, updated, "product", firstProduct));
+        Assertions.assertTrue(isRelated(thingifier, updated, "product", secondProduct));
+    }
+
+    @Test
+    public void fullReplaceWithoutFieldReferenceDisconnectsPreviousRelationship() {
+        Thingifier thingifier = productItemThingifier();
+        EntityInstance product = createProduct(thingifier, "Widget");
+        EntityInstance item = createItem(thingifier, product, 1);
+
+        ApiResponse response =
+                thingifier
+                        .api()
+                        .put(
+                                "items/" + item.getPrimaryKeyValue(),
+                                body(Map.of("quantity", 7)),
+                                contextFor(thingifier));
+
+        EntityInstance updated = currentItem(thingifier, item);
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertTrue(relatedProducts(thingifier, updated).isEmpty());
+    }
+
+    @Test
+    public void fieldReferenceConflictWithExplicitRelationshipReferenceIsRejected() {
+        Thingifier thingifier = productItemThingifier();
+        EntityInstance firstProduct = createProduct(thingifier, "First");
+        EntityInstance secondProduct = createProduct(thingifier, "Second");
+        Map<String, Object> explicitRelationship = new HashMap<>();
+        explicitRelationship.put("id", Integer.valueOf(secondProduct.getPrimaryKeyValue()));
+
+        ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "items",
+                                body(
+                                        Map.of(
+                                                "productId",
+                                                Integer.valueOf(firstProduct.getPrimaryKeyValue()),
+                                                "product",
+                                                explicitRelationship,
+                                                "quantity",
+                                                2)),
+                                contextFor(thingifier));
+
+        Assertions.assertEquals(400, response.getStatusCode());
+        Assertions.assertEquals(
+                0, storeFor(thingifier).entityQueries().count(itemEntity(thingifier)));
+    }
+
+    private Thingifier projectTaskThingifier(
+            final boolean deleteTargetWhenDisconnected,
+            final boolean deleteTargetsWhenSourceDeleted) {
+        Thingifier thingifier = new Thingifier();
+        EntityDefinition project = thingifier.defineThing("project", "projects");
+        project.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT));
+        project.addField(Field.is("title", FieldType.STRING));
+
+        EntityDefinition task = thingifier.defineThing("task", "tasks");
+        task.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT));
+        task.addField(Field.is("title", FieldType.STRING).withValidation(VRule.notEmpty()));
+
+        uk.co.compendiumdev.thingifier.core.domain.definitions.relationship.RelationshipDefinition
+                relationship =
+                        thingifier.defineRelationship(
+                                project, task, "tasks", Cardinality.ONE_TO_MANY());
+        if (deleteTargetWhenDisconnected) {
+            relationship.deleteTargetWhenDisconnected();
+        }
+        if (deleteTargetsWhenSourceDeleted) {
+            relationship.deleteTargetsWhenSourceDeleted();
+        }
+        return thingifier;
+    }
+
+    private Thingifier nodeThingifier() {
+        Thingifier thingifier = new Thingifier();
+        EntityDefinition node = thingifier.defineThing("node", "nodes");
+        node.addAsPrimaryKeyField(Field.is("id", FieldType.STRING));
+        thingifier
+                .defineRelationship(node, node, "children", Cardinality.ONE_TO_MANY())
+                .deleteTargetsWhenSourceDeleted();
+        return thingifier;
+    }
+
+    private Thingifier productItemThingifier() {
+        Thingifier thingifier = new Thingifier();
+        EntityDefinition product = thingifier.defineThing("product", "products");
+        product.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT));
+        product.addField(Field.is("name", FieldType.STRING));
+
+        EntityDefinition item = thingifier.defineThing("item", "items");
+        item.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT));
+        item.addField(
+                Field.is("productId", FieldType.INTEGER).references(product, "id", "product"));
+        item.addField(Field.is("quantity", FieldType.INTEGER));
+
+        thingifier.defineRelationship(item, product, "product", Cardinality.ONE_TO_ONE());
+        return thingifier;
+    }
+
+    private EntityInstance createProject(final Thingifier thingifier, final String title) {
+        return storeFor(thingifier)
+                .entities()
+                .create(
+                        EntityInstanceDraft.forEntity(thingifier.getDefinitionNamed("project"))
+                                .withField("title", title));
+    }
+
+    private EntityInstance createTask(final Thingifier thingifier, final String title) {
+        return storeFor(thingifier)
+                .entities()
+                .create(
+                        EntityInstanceDraft.forEntity(thingifier.getDefinitionNamed("task"))
+                                .withField("title", title));
+    }
+
+    private EntityInstance createNode(final Thingifier thingifier, final String id) {
+        return storeFor(thingifier)
+                .entities()
+                .create(
+                        EntityInstanceDraft.forEntity(thingifier.getDefinitionNamed("node"))
+                                .withField("id", id));
+    }
+
+    private EntityInstance createProduct(final Thingifier thingifier, final String name) {
+        return storeFor(thingifier)
+                .entities()
+                .create(
+                        EntityInstanceDraft.forEntity(thingifier.getDefinitionNamed("product"))
+                                .withField("name", name));
+    }
+
+    private EntityInstance createItem(
+            final Thingifier thingifier, final EntityInstance product, final int quantity) {
+        EntityInstance item =
+                storeFor(thingifier)
+                        .entities()
+                        .create(
+                                EntityInstanceDraft.forEntity(itemEntity(thingifier))
+                                        .withField("productId", product.getPrimaryKeyValue())
+                                        .withField("quantity", String.valueOf(quantity)));
+        storeFor(thingifier).relationships().connect(item, "product", product);
+        return item;
+    }
+
+    private ApiResponse postRelationship(
+            final Thingifier thingifier,
+            final EntityInstance project,
+            final Map<String, Object> values) {
+        return thingifier
+                .api()
+                .post(
+                        "projects/" + project.getPrimaryKeyValue() + "/tasks",
+                        body(values),
+                        contextFor(thingifier));
+    }
+
+    private EntityInstance currentProject(
+            final Thingifier thingifier, final EntityInstance project) {
+        return storeFor(thingifier)
+                .entityQueries()
+                .findByQueryIdentifier(
+                        thingifier.getDefinitionNamed("project"), project.getPrimaryKeyValue());
+    }
+
+    private EntityInstance currentTask(final Thingifier thingifier, final EntityInstance task) {
+        return storeFor(thingifier)
+                .entityQueries()
+                .findByQueryIdentifier(
+                        thingifier.getDefinitionNamed("task"), task.getPrimaryKeyValue());
+    }
+
+    private EntityInstance currentNode(final Thingifier thingifier, final String identifier) {
+        return storeFor(thingifier)
+                .entityQueries()
+                .findByQueryIdentifier(thingifier.getDefinitionNamed("node"), identifier);
+    }
+
+    private EntityInstance currentItem(final Thingifier thingifier, final EntityInstance item) {
+        return storeFor(thingifier)
+                .entityQueries()
+                .findByQueryIdentifier(itemEntity(thingifier), item.getPrimaryKeyValue());
+    }
+
+    private EntityDefinition itemEntity(final Thingifier thingifier) {
+        return thingifier.getDefinitionNamed("item");
+    }
+
+    private List<EntityInstance> relatedTasks(
+            final Thingifier thingifier, final EntityInstance project) {
+        return storeFor(thingifier).relationships().listRelated(project, "tasks");
+    }
+
+    private List<EntityInstance> relatedProducts(
+            final Thingifier thingifier, final EntityInstance item) {
+        return storeFor(thingifier).relationships().listRelated(item, "product");
+    }
+
+    private boolean isRelated(
+            final Thingifier thingifier,
+            final EntityInstance source,
+            final String relationshipName,
+            final EntityInstance target) {
+        return storeFor(thingifier).relationships().listRelated(source, relationshipName).stream()
+                .anyMatch(related -> related.getInternalId().equals(target.getInternalId()));
+    }
+
+    private ApiBodyFields body(final Map<String, Object> values) {
+        return ApiBodyFields.fromMap(values);
+    }
+
+    private ThingifierRequestContext contextFor(final Thingifier thingifier) {
+        return ThingifierRequestContext.from(thingifier, new HttpHeadersBlock());
+    }
+
+    private ThingStore storeFor(final Thingifier thingifier) {
+        return thingifier.getStore(EntityRelModel.DEFAULT_DATABASE_NAME);
+    }
+}

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/ThingWriteRequestMapperTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/ThingWriteRequestMapperTest.java
@@ -3,10 +3,12 @@ package uk.co.compendiumdev.thingifier.api.restapihandlers;
 import static uk.co.compendiumdev.thingifier.apiconfig.PutIdentifierPolicy.DISALLOWED;
 import static uk.co.compendiumdev.thingifier.apiconfig.PutIdentifierPolicy.MANDATORY;
 import static uk.co.compendiumdev.thingifier.apiconfig.PutIdentifierPolicy.OPTIONAL;
+import static uk.co.compendiumdev.thingifier.apiconfig.RelationshipWriteOperation.UPDATE_CONNECTED;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import uk.co.compendiumdev.thingifier.Thingifier;
@@ -15,7 +17,9 @@ import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingWriteRequest
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierSchemaCatalog;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRouteMapper;
+import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields;
+import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
 import uk.co.compendiumdev.thingifier.apiconfig.EntityWriteMethodConfig;
 import uk.co.compendiumdev.thingifier.application.command.AmendThingCommand;
 import uk.co.compendiumdev.thingifier.application.command.CreateThingCommand;
@@ -23,6 +27,7 @@ import uk.co.compendiumdev.thingifier.application.command.DeleteThingCommand;
 import uk.co.compendiumdev.thingifier.application.command.DisconnectRelationshipCommand;
 import uk.co.compendiumdev.thingifier.application.command.RelateThingCommand;
 import uk.co.compendiumdev.thingifier.application.command.ReplaceThingCommand;
+import uk.co.compendiumdev.thingifier.application.command.UpdateConnectedRelationshipCommand;
 import uk.co.compendiumdev.thingifier.core.EntityRelModel;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.Cardinality;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
@@ -231,6 +236,32 @@ public class ThingWriteRequestMapperTest {
     }
 
     @Test
+    public void mapsRelationshipPostWithConnectedChildToUpdateCommandWhenConfigured() {
+        Thingifier thingifier = taskProjectThingifier();
+        ThingStore store = storeFor(thingifier);
+        EntityInstance task = createTask(thingifier, "Task");
+        EntityInstance project = createProject(thingifier, "Project");
+        store.relationships().connect(project, "tasks", task);
+
+        ThingWriteRequestMapping mapping =
+                mapperFor(thingifier, Set.of(UPDATE_CONNECTED))
+                        .mapPost(
+                                routeFor(
+                                        thingifier,
+                                        String.format(
+                                                "project/%s/tasks", project.getPrimaryKeyValue())),
+                                parserFor(
+                                        Map.of(
+                                                "guid",
+                                                task.getPrimaryKeyValue(),
+                                                "title",
+                                                "Updated")));
+
+        Assertions.assertFalse(mapping.isError());
+        Assertions.assertTrue(mapping.getCommand() instanceof UpdateConnectedRelationshipCommand);
+    }
+
+    @Test
     public void mapsDeleteInstanceToDeleteCommand() {
         Thingifier thingifier = taskProjectThingifier();
         EntityInstance task = createTask(thingifier, "Task");
@@ -328,6 +359,17 @@ public class ThingWriteRequestMapperTest {
     private ThingWriteRequestMapper mapperFor(
             final Thingifier thingifier, final EntityWriteMethodConfig config) {
         return new ThingWriteRequestMapper(new ThingifierSchemaCatalog(thingifier), config);
+    }
+
+    private ThingWriteRequestMapper mapperFor(
+            final Thingifier thingifier,
+            final Set<uk.co.compendiumdev.thingifier.apiconfig.RelationshipWriteOperation>
+                    relationshipOperations) {
+        return new ThingWriteRequestMapper(
+                new ThingifierSchemaCatalog(thingifier),
+                thingifier.apiDefaults().writeMethods().entities(),
+                relationshipOperations,
+                ThingifierRequestContext.from(thingifier, new HttpHeadersBlock()));
     }
 
     private ThingStore storeFor(final Thingifier thingifier) {

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/WriteMethodPolicyTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/restapihandlers/WriteMethodPolicyTest.java
@@ -10,6 +10,7 @@ import static uk.co.compendiumdev.thingifier.apiconfig.PutIdentifierPolicy.MANDA
 import static uk.co.compendiumdev.thingifier.apiconfig.PutIdentifierPolicy.OPTIONAL;
 import static uk.co.compendiumdev.thingifier.apiconfig.RelationshipWriteOperation.CONNECT_EXISTING;
 import static uk.co.compendiumdev.thingifier.apiconfig.RelationshipWriteOperation.CREATE_AND_CONNECT;
+import static uk.co.compendiumdev.thingifier.apiconfig.RelationshipWriteOperation.UPDATE_CONNECTED;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -620,6 +621,23 @@ public class WriteMethodPolicyTest {
                                 new HttpHeadersBlock());
 
         Assertions.assertEquals(405, response.getStatusCode());
+    }
+
+    @Test
+    public void generatedDocsTreatUpdateConnectedAsRelationshipPostSupport() {
+        Thingifier thingifier = relationshipModel();
+        thingifier.apiConfig().writeMethods().relationships().postCan(UPDATE_CONNECTED);
+
+        ApiRoutingDefinition definition =
+                new ApiRoutingDefinitionDocGenerator(thingifier).generate("");
+
+        Assertions.assertTrue(
+                route(definition, RoutingVerb.POST, "projects/:id/tasks")
+                        .status()
+                        .isReturnedFromCall());
+        Assertions.assertEquals(
+                "OPTIONS, GET, HEAD, POST, QUERY",
+                route(definition, RoutingVerb.OPTIONS, "projects/:id/tasks").headerValue());
     }
 
     @Test

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthPolicyTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthPolicyTest.java
@@ -1,0 +1,404 @@
+package uk.co.compendiumdev.thingifier.api.security;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
+import uk.co.compendiumdev.thingifier.api.docgen.ThingifierApiDocumentationDefn;
+import uk.co.compendiumdev.thingifier.api.http.HttpApiRequest;
+import uk.co.compendiumdev.thingifier.api.http.HttpApiResponse;
+import uk.co.compendiumdev.thingifier.api.http.ThingifierHttpApi;
+import uk.co.compendiumdev.thingifier.api.http.bodyparser.BodyParser;
+import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
+import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
+import uk.co.compendiumdev.thingifier.api.spec.ThingifierApiRouteRule;
+import uk.co.compendiumdev.thingifier.apiconfig.ThingifierApiConfig;
+import uk.co.compendiumdev.thingifier.core.EntityRelModel;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.Field;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldType;
+import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
+import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstanceDraft;
+import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
+
+class ThingifierApiAuthPolicyTest {
+
+    @Test
+    void namedBearerSchemeIsDocumentedOnProtectedGeneratedRoute() {
+        final Thingifier thingifier = todoModel();
+        thingifier.apiSpec().security().bearer("cartToken");
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.POST, "/api/todos")
+                .secureWithBearerAuth("cartToken");
+        final ThingifierApiDocumentationDefn apiDefn = new ThingifierApiDocumentationDefn();
+        apiDefn.setThingifier(thingifier);
+        apiDefn.setPathPrefix("/api");
+
+        final OpenAPI openApi =
+                new uk.co.compendiumdev.thingifier.swaggerizer.Swaggerizer(apiDefn).swagger();
+
+        final SecurityScheme scheme = openApi.getComponents().getSecuritySchemes().get("cartToken");
+        Assertions.assertNotNull(scheme);
+        Assertions.assertEquals(SecurityScheme.Type.HTTP, scheme.getType());
+        Assertions.assertEquals("bearer", scheme.getScheme());
+        Assertions.assertEquals(
+                "cartToken",
+                openApi.getPaths()
+                        .get("/api/todos")
+                        .getPost()
+                        .getSecurity()
+                        .get(0)
+                        .keySet()
+                        .iterator()
+                        .next());
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void legacyBearerMarkerRemainsDocumentationOnly() {
+        final Thingifier thingifier = todoModel();
+        thingifier.apiSpec().route(RoutingVerb.POST, "/todos").secureWithBearerAuth();
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"created\"}"),
+                                new HttpHeadersBlock());
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals(1, todoCount(thingifier));
+    }
+
+    @Test
+    void directApiMissingBearerTokenReturns401WithoutMutation() {
+        final Thingifier thingifier = todoModel();
+        protectTodoPost(thingifier);
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"blocked\"}"),
+                                new HttpHeadersBlock());
+
+        Assertions.assertEquals(401, response.getStatusCode());
+        Assertions.assertEquals("Bearer", response.getHeaders().get("WWW-Authenticate"));
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    @Test
+    void directApiInvalidBearerTokenReturns401WithoutMutation() {
+        final Thingifier thingifier = todoModel();
+        protectTodoPost(thingifier);
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"blocked\"}"),
+                                headersWithBearer("wrong"));
+
+        Assertions.assertEquals(401, response.getStatusCode());
+        Assertions.assertEquals("Bearer", response.getHeaders().get("WWW-Authenticate"));
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    @Test
+    void malformedBearerHeaderReturns401BeforeAuthenticator() {
+        final Thingifier thingifier = todoModel();
+        final AtomicReference<Boolean> authenticatorCalled = new AtomicReference<>(false);
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "cartToken",
+                        context -> {
+                            authenticatorCalled.set(true);
+                            return ThingifierApiAuthenticationResult.authenticated();
+                        });
+        thingifier.apiSpec().route(RoutingVerb.POST, "/todos").secureWithBearerAuth("cartToken");
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"blocked\"}"),
+                                headersWithAuthorization("Basic valid-token"));
+
+        Assertions.assertEquals(401, response.getStatusCode());
+        Assertions.assertFalse(authenticatorCalled.get());
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    @Test
+    void directApiValidBearerTokenAllowsMutation() {
+        final Thingifier thingifier = todoModel();
+        protectTodoPost(thingifier);
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"created\"}"),
+                                headersWithBearer("valid-token"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals(1, todoCount(thingifier));
+    }
+
+    @Test
+    void directApiMissingBearerTokenReturns401ForProtectedRead() {
+        final Thingifier thingifier = todoModel();
+        createTodo(thingifier, "existing");
+        thingifier.apiSpec().authenticator("cartToken", this::validTokenAuthenticator);
+        thingifier.apiSpec().route(RoutingVerb.GET, "/todos").secureWithBearerAuth("cartToken");
+
+        final ApiResponse response =
+                thingifier.api().get("todos", new QueryFilterParams(), new HttpHeadersBlock());
+
+        Assertions.assertEquals(401, response.getStatusCode());
+        Assertions.assertEquals("Bearer", response.getHeaders().get("WWW-Authenticate"));
+    }
+
+    @Test
+    void authorizerDenialReturns403WithoutMutation() {
+        final Thingifier thingifier = todoModel();
+        protectTodoPost(thingifier)
+                .authorizeWith(context -> ThingifierApiAuthorizationResult.forbidden());
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"blocked\"}"),
+                                headersWithBearer("valid-token"));
+
+        Assertions.assertEquals(403, response.getStatusCode());
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    @Test
+    void authorizerReceivesAuthenticatedPrincipal() {
+        final Thingifier thingifier = todoModel();
+        final AtomicReference<Object> seenPrincipal = new AtomicReference<>();
+        protectTodoPost(thingifier)
+                .authorizeWith(
+                        context -> {
+                            seenPrincipal.set(context.principal());
+                            return ThingifierApiAuthorizationResult.authorized();
+                        });
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"created\"}"),
+                                headersWithBearer("valid-token"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals("valid-principal", seenPrincipal.get());
+    }
+
+    @Test
+    void httpApiMissingBearerTokenReturns401WithoutMutation() {
+        final Thingifier thingifier = todoModel();
+        thingifier.apiConfig().setFrom(new ThingifierApiConfig("/api"));
+        protectPrefixedTodoPost(thingifier);
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .post(jsonPostRequest("/api/todos", "{\"title\":\"blocked\"}"));
+
+        Assertions.assertEquals(401, response.getStatusCode());
+        Assertions.assertEquals("Bearer", response.getHeaders().get("WWW-Authenticate"));
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    @Test
+    void httpApiValidBearerTokenAllowsMutation() {
+        final Thingifier thingifier = todoModel();
+        thingifier.apiConfig().setFrom(new ThingifierApiConfig("/api"));
+        protectPrefixedTodoPost(thingifier);
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .post(
+                                jsonPostRequest("/api/todos", "{\"title\":\"created\"}")
+                                        .addHeader("Authorization", "Bearer valid-token"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals(1, todoCount(thingifier));
+    }
+
+    @Test
+    void authorizerReceivesNamedPathParameters() {
+        final Thingifier thingifier = cartModel();
+        thingifier.apiConfig().setFrom(new ThingifierApiConfig("/api"));
+        createCart(thingifier);
+        final AtomicReference<String> seenCartId = new AtomicReference<>();
+        thingifier.apiSpec().authenticator("cartToken", this::validTokenAuthenticator);
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.GET, "/api/carts/{cartId}")
+                .secureWithBearerAuth("cartToken")
+                .authorizeWith(
+                        context -> {
+                            seenCartId.set(context.pathParameter("cartId"));
+                            return ThingifierApiAuthorizationResult.authorized();
+                        });
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .get(
+                                new HttpApiRequest("/api/carts/1")
+                                        .addHeader("Authorization", "Bearer valid-token"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals("1", seenCartId.get());
+    }
+
+    @Test
+    void authorizerReceivesRouteIdentifiers() {
+        final Thingifier thingifier = cartModel();
+        thingifier.apiConfig().setFrom(new ThingifierApiConfig("/api"));
+        createCart(thingifier);
+        final AtomicReference<String> seenTargetIdentifier = new AtomicReference<>();
+        thingifier.apiSpec().authenticator("cartToken", this::validTokenAuthenticator);
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.GET, "/api/carts/{cartId}")
+                .secureWithBearerAuth("cartToken")
+                .authorizeWith(
+                        context -> {
+                            seenTargetIdentifier.set(context.targetIdentifier());
+                            return ThingifierApiAuthorizationResult.authorized();
+                        });
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .get(
+                                new HttpApiRequest("/api/carts/1")
+                                        .addHeader("Authorization", "Bearer valid-token"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals("1", seenTargetIdentifier.get());
+    }
+
+    @Test
+    void missingAuthenticatorReturnsConfigurationError() {
+        final Thingifier thingifier = todoModel();
+        thingifier.apiSpec().route(RoutingVerb.POST, "/todos").secureWithBearerAuth("cartToken");
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"blocked\"}"),
+                                headersWithBearer("valid-token"));
+
+        Assertions.assertEquals(500, response.getStatusCode());
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    private ThingifierApiRouteRule protectTodoPost(final Thingifier thingifier) {
+        thingifier.apiSpec().authenticator("cartToken", this::validTokenAuthenticator);
+        return thingifier
+                .apiSpec()
+                .route(RoutingVerb.POST, "/todos")
+                .secureWithBearerAuth("cartToken");
+    }
+
+    private void protectPrefixedTodoPost(final Thingifier thingifier) {
+        thingifier.apiSpec().authenticator("cartToken", this::validTokenAuthenticator);
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.POST, "/api/todos")
+                .secureWithBearerAuth("cartToken");
+    }
+
+    private ThingifierApiAuthenticationResult validTokenAuthenticator(
+            final ThingifierApiAuthenticationContext context) {
+        if ("valid-token".equals(context.bearerToken())) {
+            return ThingifierApiAuthenticationResult.authenticated("valid-principal");
+        }
+        return ThingifierApiAuthenticationResult.rejected("Invalid bearer token");
+    }
+
+    private Thingifier todoModel() {
+        final Thingifier thingifier = new Thingifier();
+        final EntityDefinition todo = thingifier.defineThing("todo", "todos", 5);
+        todo.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT));
+        todo.addField(Field.is("title", FieldType.STRING).makeMandatory());
+        return thingifier;
+    }
+
+    private Thingifier cartModel() {
+        final Thingifier thingifier = new Thingifier();
+        final EntityDefinition cart = thingifier.defineThing("cart", "carts", 5);
+        cart.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT));
+        cart.addField(Field.is("state", FieldType.STRING));
+        return thingifier;
+    }
+
+    private EntityInstance createCart(final Thingifier thingifier) {
+        final EntityDefinition cart = thingifier.getDefinitionNamed("cart");
+        return thingifier
+                .getStore(EntityRelModel.DEFAULT_DATABASE_NAME)
+                .entities()
+                .create(EntityInstanceDraft.forEntity(cart).withField("state", "open"));
+    }
+
+    private EntityInstance createTodo(final Thingifier thingifier, final String title) {
+        final EntityDefinition todo = thingifier.getDefinitionNamed("todo");
+        return thingifier
+                .getStore(EntityRelModel.DEFAULT_DATABASE_NAME)
+                .entities()
+                .create(EntityInstanceDraft.forEntity(todo).withField("title", title));
+    }
+
+    private BodyParser parser(final Thingifier thingifier, final String body) {
+        return new BodyParser(
+                new HttpApiRequest("/request")
+                        .addHeader("Content-Type", "application/json")
+                        .setBody(body),
+                thingifier.getThingNames());
+    }
+
+    private HttpHeadersBlock headersWithBearer(final String token) {
+        return headersWithAuthorization("Bearer " + token);
+    }
+
+    private HttpHeadersBlock headersWithAuthorization(final String authorization) {
+        final HttpHeadersBlock headers = new HttpHeadersBlock();
+        headers.put("Authorization", authorization);
+        return headers;
+    }
+
+    private HttpApiRequest jsonPostRequest(final String path, final String body) {
+        return new HttpApiRequest(path)
+                .setVerb("POST")
+                .addHeader("Content-Type", "application/json")
+                .addHeader("Accept", "application/json")
+                .setBody(body);
+    }
+
+    private int todoCount(final Thingifier thingifier) {
+        return thingifier
+                .api()
+                .get("todos", new QueryFilterParams(), new HttpHeadersBlock())
+                .getReturnedInstanceCollection()
+                .size();
+    }
+}

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiDefaultEntityViewsTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiDefaultEntityViewsTest.java
@@ -1,0 +1,288 @@
+package uk.co.compendiumdev.thingifier.api.spec;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.api.docgen.ApiRoutingDefinition;
+import uk.co.compendiumdev.thingifier.api.docgen.ApiRoutingDefinitionDocGenerator;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingDefinition;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
+import uk.co.compendiumdev.thingifier.api.ermodelconversion.JsonThing;
+import uk.co.compendiumdev.thingifier.api.http.HttpApiRequest;
+import uk.co.compendiumdev.thingifier.api.http.HttpApiResponse;
+import uk.co.compendiumdev.thingifier.api.http.ThingifierHttpApi;
+import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
+import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
+import uk.co.compendiumdev.thingifier.api.response.ApiResponseAsJson;
+import uk.co.compendiumdev.thingifier.core.EntityRelModel;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.Cardinality;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.Field;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldType;
+import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
+import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstanceDraft;
+import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
+import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
+
+class ThingifierApiDefaultEntityViewsTest {
+
+    @Test
+    void defaultEntityViewConfiguresRequestAndResponseDefaults() {
+        final Thingifier thingifier = shop();
+
+        final ThingifierApiEntityRule rule =
+                thingifier.apiSpec().entity("cart").defaultEntityView("PublicCart");
+
+        Assertions.assertEquals("PublicCart", rule.defaultRequestView());
+        Assertions.assertEquals("PublicCart", rule.defaultResponseView());
+    }
+
+    @Test
+    void defaultResponseViewHidesFieldsForCollectionGet() {
+        final Thingifier thingifier = shop();
+        thingifier.apiSpec().entity("cart").defaultResponseView("PublicCart");
+        createCart(thingifier, "basket", "secret-token");
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier).get(jsonRequest("carts"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertTrue(response.getBody().contains("basket"));
+        Assertions.assertFalse(response.getBody().contains("token"));
+        Assertions.assertFalse(response.getBody().contains("secret-token"));
+    }
+
+    @Test
+    void defaultResponseViewHidesFieldsForInstanceGet() {
+        final Thingifier thingifier = shop();
+        thingifier.apiSpec().entity("cart").defaultResponseView("PublicCart");
+        final EntityInstance cart = createCart(thingifier, "basket", "secret-token");
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .get(jsonRequest("carts/" + cart.getPrimaryKeyValue()));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertTrue(response.getBody().contains("basket"));
+        Assertions.assertFalse(response.getBody().contains("token"));
+        Assertions.assertFalse(response.getBody().contains("secret-token"));
+    }
+
+    @Test
+    void defaultResponseViewUsesPluralEntityRuleNames() {
+        final Thingifier thingifier = shop();
+        thingifier.apiSpec().entity("carts").defaultResponseView("PublicCart");
+        createCart(thingifier, "basket", "secret-token");
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier).get(jsonRequest("carts"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertFalse(response.getBody().contains("token"));
+    }
+
+    @Test
+    void routeResponseViewOverridesEntityDefaultResponseView() {
+        final Thingifier thingifier = shop();
+        thingifier.apiSpec().entity("cart").defaultResponseView("PublicCart");
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.GET, "/carts/{cartId}")
+                .responseEntityView(200, "InternalCart");
+        final EntityInstance cart = createCart(thingifier, "basket", "secret-token");
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .get(jsonRequest("carts/" + cart.getPrimaryKeyValue()));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertTrue(response.getBody().contains("token"));
+        Assertions.assertTrue(response.getBody().contains("secret-token"));
+    }
+
+    @Test
+    void defaultResponseViewHidesFieldsForRelationshipCollectionGet() {
+        final Thingifier thingifier = shop();
+        thingifier.apiSpec().entity("cart").defaultResponseView("PublicCart");
+        final EntityInstance user = createUser(thingifier, "Alice");
+        final EntityInstance cart = createCart(thingifier, "basket", "secret-token");
+        storeFor(thingifier).relationships().connect(user, "carts", cart);
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .get(jsonRequest("users/" + user.getPrimaryKeyValue() + "/carts"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertTrue(response.getBody().contains("basket"));
+        Assertions.assertFalse(response.getBody().contains("token"));
+        Assertions.assertFalse(response.getBody().contains("secret-token"));
+    }
+
+    @Test
+    void defaultResponseViewHidesFieldsForDirectApiResponses() {
+        final Thingifier thingifier = shop();
+        thingifier.apiSpec().entity("cart").defaultResponseView("PublicCart");
+        createCart(thingifier, "basket", "secret-token");
+
+        final ApiResponse response =
+                thingifier.api().get("carts", new QueryFilterParams(), new HttpHeadersBlock());
+        final String json =
+                new ApiResponseAsJson(response, new JsonThing(thingifier.apiConfig().jsonOutput()))
+                        .getJson();
+
+        Assertions.assertFalse(json.contains("token"));
+        Assertions.assertFalse(json.contains("secret-token"));
+    }
+
+    @Test
+    void defaultRequestViewRejectsDisallowedInputFields() {
+        final Thingifier thingifier = shop();
+        thingifier.apiSpec().entity("cart").defaultRequestView("PublicCart");
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .post(jsonPost("carts", "{\"name\":\"basket\",\"token\":\"blocked\"}"));
+
+        Assertions.assertEquals(422, response.getStatusCode());
+        Assertions.assertEquals(0, cartCount(thingifier));
+    }
+
+    @Test
+    void routeRequestViewOverridesEntityDefaultRequestView() {
+        final Thingifier thingifier = shop();
+        thingifier.apiSpec().entity("cart").defaultRequestView("PublicCart");
+        thingifier.apiSpec().route(RoutingVerb.POST, "/carts").requestEntityView("InternalCart");
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .post(jsonPost("carts", "{\"name\":\"basket\",\"token\":\"allowed\"}"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals(1, cartCount(thingifier));
+    }
+
+    @Test
+    void jsonPathQueryUsesDefaultResponseViewBeforeFiltering() {
+        final Thingifier thingifier = shop();
+        thingifier.apiSpec().entity("cart").defaultResponseView("PublicCart");
+        createCart(thingifier, "basket", "secret-token");
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .queryRequest(
+                                jsonPathQuery("carts", "$.carts[?(@.token == 'secret-token')]"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(0, response.apiResponse().getReturnedInstanceCollection().size());
+    }
+
+    @Test
+    void defaultRequestViewUpdatesGeneratedRequestPayloadDocumentation() {
+        final Thingifier thingifier = shop();
+        thingifier.apiSpec().entity("cart").defaultRequestView("PublicCart");
+
+        final RoutingDefinition route =
+                route(
+                        new ApiRoutingDefinitionDocGenerator(thingifier).generate(""),
+                        RoutingVerb.POST,
+                        "carts");
+
+        Assertions.assertTrue(route.hasRequestEntityView());
+        Assertions.assertEquals("create_PublicCart", route.getRequestPayload());
+    }
+
+    @Test
+    void defaultResponseViewUpdatesGeneratedResponsePayloadDocumentation() {
+        final Thingifier thingifier = shop();
+        thingifier.apiSpec().entity("cart").defaultResponseView("PublicCart");
+
+        final RoutingDefinition route =
+                route(
+                        new ApiRoutingDefinitionDocGenerator(thingifier).generate(""),
+                        RoutingVerb.GET,
+                        "carts");
+
+        Assertions.assertEquals("PublicCart", route.getResponseEntityViewFor(200));
+        Assertions.assertEquals("PublicCart", route.getReturnPayloadFor(200));
+    }
+
+    private Thingifier shop() {
+        final Thingifier thingifier = new Thingifier();
+
+        final EntityDefinition user = thingifier.defineThing("user", "users");
+        user.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT));
+        user.addField(Field.is("name", FieldType.STRING));
+
+        final EntityDefinition cart = thingifier.defineThing("cart", "carts");
+        cart.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT));
+        cart.addField(Field.is("name", FieldType.STRING));
+        cart.addField(Field.is("token", FieldType.STRING));
+        cart.defineView("PublicCart")
+                .hideRequestFields("token")
+                .hideResponseFields("token")
+                .disallowInputFields("token");
+        cart.defineView("InternalCart");
+
+        thingifier
+                .defineRelationship(user, cart, "carts", Cardinality.ONE_TO_MANY())
+                .whenReversed(Cardinality.ONE_TO_ONE(), "owner");
+
+        return thingifier;
+    }
+
+    private EntityInstance createUser(final Thingifier thingifier, final String name) {
+        final EntityDefinition user = thingifier.getDefinitionNamed("user");
+        return storeFor(thingifier)
+                .entities()
+                .create(EntityInstanceDraft.forEntity(user).withField("name", name));
+    }
+
+    private EntityInstance createCart(
+            final Thingifier thingifier, final String name, final String token) {
+        final EntityDefinition cart = thingifier.getDefinitionNamed("cart");
+        return storeFor(thingifier)
+                .entities()
+                .create(
+                        EntityInstanceDraft.forEntity(cart)
+                                .withField("name", name)
+                                .withField("token", token));
+    }
+
+    private int cartCount(final Thingifier thingifier) {
+        return storeFor(thingifier)
+                .entityQueries()
+                .list(thingifier.getDefinitionNamed("cart"))
+                .size();
+    }
+
+    private ThingStore storeFor(final Thingifier thingifier) {
+        return thingifier.getStore(EntityRelModel.DEFAULT_DATABASE_NAME);
+    }
+
+    private HttpApiRequest jsonRequest(final String path) {
+        return new HttpApiRequest(path).addHeader("Accept", "application/json");
+    }
+
+    private HttpApiRequest jsonPost(final String path, final String body) {
+        return new HttpApiRequest(path)
+                .addHeader("Content-Type", "application/json")
+                .addHeader("Accept", "application/json")
+                .setBody(body);
+    }
+
+    private HttpApiRequest jsonPathQuery(final String path, final String body) {
+        return new HttpApiRequest(path)
+                .addHeader("Content-Type", ThingifierHttpApi.JSONPATH_QUERY_CONTENT_TYPE)
+                .addHeader("Accept", "application/json")
+                .setBody(body);
+    }
+
+    private RoutingDefinition route(
+            final ApiRoutingDefinition definition, final RoutingVerb verb, final String url) {
+        return definition.definitions().stream()
+                .filter(route -> route.verb() == verb)
+                .filter(route -> route.url().equals(url))
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpecTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpecTest.java
@@ -6,6 +6,8 @@ import static uk.co.compendiumdev.thingifier.apiconfig.EntityPatchUpdateStyle.PA
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.api.docgen.ApiRoutingDefinition;
 import uk.co.compendiumdev.thingifier.api.docgen.ApiRoutingDefinitionDocGenerator;
@@ -14,6 +16,9 @@ import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.api.http.HttpApiRequest;
 import uk.co.compendiumdev.thingifier.api.http.HttpApiResponse;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierHttpApi;
+import uk.co.compendiumdev.thingifier.api.http.bodyparser.BodyParser;
+import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
+import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
 import uk.co.compendiumdev.thingifier.apiconfig.ThingifierApiConfig;
 import uk.co.compendiumdev.thingifier.core.EntityRelModel;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.Cardinality;
@@ -22,6 +27,7 @@ import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.F
 import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldType;
 import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
 import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstanceDraft;
+import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
 
 class ThingifierApiSpecTest {
 
@@ -85,6 +91,136 @@ class ThingifierApiSpecTest {
                 new ThingifierHttpApi(thingifier).post(new HttpApiRequest("/api/todos"));
 
         Assertions.assertEquals(404, response.getStatusCode());
+    }
+
+    @Test
+    void pathLevelMethodNotAllowedMarksSelectedRoutesAsStatic405() {
+        final Thingifier thingifier = model();
+        thingifier
+                .apiSpec()
+                .route("/api/todos")
+                .methodNotAllowed(RoutingVerb.POST, RoutingVerb.PUT);
+
+        final ApiRoutingDefinition definition =
+                new ApiRoutingDefinitionDocGenerator(thingifier).generate("/api");
+
+        Assertions.assertEquals(
+                405, route(definition, RoutingVerb.POST, "api/todos").status().value());
+        Assertions.assertEquals(
+                405, route(definition, RoutingVerb.PUT, "api/todos").status().value());
+    }
+
+    @Test
+    void methodNotAllowedDoesNotDisableGeneratedRoute() {
+        final Thingifier thingifier = model();
+        thingifier.apiSpec().route("/api/todos").methodNotAllowed(RoutingVerb.POST);
+
+        final ApiRoutingDefinition definition =
+                new ApiRoutingDefinitionDocGenerator(thingifier).generate("/api");
+        final RoutingDefinition post = route(definition, RoutingVerb.POST, "api/todos");
+
+        Assertions.assertFalse(post.isDisabled());
+        Assertions.assertFalse(post.isHiddenFromDocumentation());
+    }
+
+    @Test
+    void methodNotAllowedRemovesVerbFromOptionsAllowHeader() {
+        final Thingifier thingifier = model();
+        thingifier.apiSpec().route("/api/todos").methodNotAllowed(RoutingVerb.POST);
+
+        final ApiRoutingDefinition definition =
+                new ApiRoutingDefinitionDocGenerator(thingifier).generate("/api");
+
+        Assertions.assertEquals(
+                "OPTIONS, GET, HEAD, QUERY",
+                route(definition, RoutingVerb.OPTIONS, "api/todos").headerValue());
+    }
+
+    @Test
+    void methodNotAllowedReusesExistingVerbRouteRule() {
+        final Thingifier thingifier = model();
+        thingifier.apiSpec().route(RoutingVerb.POST, "/api/todos").secureWithBearerAuth();
+        thingifier.apiSpec().route("/api/todos").methodNotAllowed(RoutingVerb.POST);
+
+        final ApiRoutingDefinition definition =
+                new ApiRoutingDefinitionDocGenerator(thingifier).generate("/api");
+        final RoutingDefinition post = route(definition, RoutingVerb.POST, "api/todos");
+
+        Assertions.assertEquals(405, post.status().value());
+        Assertions.assertTrue(post.isSecuredByBearerAuth());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/api/todos/{todoId}", "/api/todos/:todoId"})
+    void methodNotAllowedMatchesPathParameterStyles(final String pathPattern) {
+        final Thingifier thingifier = model();
+        thingifier.apiSpec().route(pathPattern).methodNotAllowed(RoutingVerb.POST);
+
+        Assertions.assertTrue(
+                thingifier
+                        .apiSpec()
+                        .isMethodNotAllowed(RoutingVerb.POST, "/api/todos/123", "/api"));
+    }
+
+    @Test
+    void directApiMethodNotAllowedReturns405WithoutMutation() {
+        final Thingifier thingifier = model();
+        thingifier.apiSpec().route("/todos").methodNotAllowed(RoutingVerb.POST);
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"blocked\"}"),
+                                new HttpHeadersBlock());
+
+        Assertions.assertEquals(405, response.getStatusCode());
+        Assertions.assertEquals(
+                "Method Not Allowed", response.getErrorMessages().iterator().next());
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    @Test
+    void httpApiMethodNotAllowedReturns405WithoutMutation() {
+        final Thingifier thingifier = model();
+        thingifier.apiConfig().setFrom(new ThingifierApiConfig("/api"));
+        thingifier.apiSpec().route("/api/todos").methodNotAllowed(RoutingVerb.POST);
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .post(jsonRequest("/api/todos", "{\"title\":\"blocked\"}"));
+
+        Assertions.assertEquals(405, response.getStatusCode());
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    @Test
+    void methodNotAllowedRejectsEmptyVerbList() {
+        final Thingifier thingifier = model();
+
+        final IllegalArgumentException thrown =
+                Assertions.assertThrows(
+                        IllegalArgumentException.class,
+                        () -> thingifier.apiSpec().route("/api/todos").methodNotAllowed());
+
+        Assertions.assertEquals("methodNotAllowed requires at least one verb", thrown.getMessage());
+    }
+
+    @Test
+    void methodNotAllowedRejectsNullVerbList() {
+        final Thingifier thingifier = model();
+
+        final IllegalArgumentException thrown =
+                Assertions.assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                thingifier
+                                        .apiSpec()
+                                        .route("/api/todos")
+                                        .methodNotAllowed((RoutingVerb[]) null));
+
+        Assertions.assertEquals("methodNotAllowed requires at least one verb", thrown.getMessage());
     }
 
     @Test
@@ -356,6 +492,19 @@ class ThingifierApiSpecTest {
                 .addHeader("Content-Type", contentType)
                 .addHeader("Accept", "application/json")
                 .setBody(null);
+    }
+
+    private BodyParser parser(final Thingifier thingifier, final String body) {
+        return new BodyParser(
+                new HttpApiRequest("/request").setBody(body), thingifier.getThingNames());
+    }
+
+    private int todoCount(final Thingifier thingifier) {
+        return thingifier
+                .api()
+                .get("todos", new QueryFilterParams(), new HttpHeadersBlock())
+                .getReturnedInstanceCollection()
+                .size();
     }
 
     private RoutingDefinition route(

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/apiconfig/WriteMethodsConfigTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/apiconfig/WriteMethodsConfigTest.java
@@ -9,6 +9,7 @@ import static uk.co.compendiumdev.thingifier.apiconfig.PutIdentifierPolicy.OPTIO
 import static uk.co.compendiumdev.thingifier.apiconfig.RelationshipWriteOperation.CONNECT_EXISTING;
 import static uk.co.compendiumdev.thingifier.apiconfig.RelationshipWriteOperation.CREATE_AND_CONNECT;
 import static uk.co.compendiumdev.thingifier.apiconfig.RelationshipWriteOperation.DISCONNECT;
+import static uk.co.compendiumdev.thingifier.apiconfig.RelationshipWriteOperation.UPDATE_CONNECTED;
 
 import java.util.Set;
 import org.junit.jupiter.api.Assertions;
@@ -41,6 +42,15 @@ public class WriteMethodsConfigTest {
 
         Assertions.assertEquals(Set.of(), config.entities().postOperations());
         Assertions.assertEquals(Set.of(), config.relationships().deleteOperations());
+    }
+
+    @Test
+    public void relationshipPostCanBeConfiguredToUpdateConnectedChildren() {
+        WriteMethodsConfig config = new WriteMethodsConfig();
+
+        config.relationships().postCan(UPDATE_CONNECTED);
+
+        Assertions.assertEquals(Set.of(UPDATE_CONNECTED), config.relationships().postOperations());
     }
 
     @Test

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/application/schema/definition/ThingifierModelAssemblerTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/application/schema/definition/ThingifierModelAssemblerTest.java
@@ -7,7 +7,9 @@ import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierSchemaCatalog;
 import uk.co.compendiumdev.thingifier.application.schema.EntityTypeRef;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldRelationshipReference;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldType;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.relationship.RelationshipVectorDefinition;
 
 class ThingifierModelAssemblerTest {
 
@@ -44,6 +46,44 @@ class ThingifierModelAssemblerTest {
         Assertions.assertEquals("todos", task.pluralName());
         Assertions.assertEquals("id", task.primaryKeyFieldName());
         Assertions.assertEquals("title", task.fieldNamed("title").name());
+    }
+
+    @Test
+    void assemblerPreservesRelationshipOwnershipPolicies() {
+        Thingifier thingifier =
+                new ThingifierModelAssembler().assemble(relationshipMetadataDefinition());
+        EntityDefinition item = thingifier.getDefinitionNamed("item");
+        EntityDefinition product = thingifier.getDefinitionNamed("product");
+
+        RelationshipVectorDefinition relationship = item.getNamedRelationshipTo("product", product);
+
+        Assertions.assertTrue(relationship.shouldDeleteTargetWhenDisconnected());
+        Assertions.assertTrue(relationship.shouldDeleteTargetsWhenSourceDeleted());
+    }
+
+    @Test
+    void assemblerPreservesFieldRelationshipReferences() {
+        Thingifier thingifier =
+                new ThingifierModelAssembler().assemble(relationshipMetadataDefinition());
+
+        FieldRelationshipReference reference =
+                thingifier.getDefinitionNamed("item").getField("productId").relationshipReference();
+
+        Assertions.assertEquals("product", reference.targetEntity().getName());
+        Assertions.assertEquals("id", reference.targetFieldName());
+        Assertions.assertEquals("product", reference.relationshipName());
+    }
+
+    @Test
+    void fieldReferenceRequiresStableTargetField() {
+        SchemaDefinitionValidationReport report =
+                new ThingifierModelAssembler().validate(unstableFieldReferenceDefinition());
+
+        Assertions.assertFalse(report.isValid());
+        Assertions.assertTrue(
+                messages(report)
+                        .contains(
+                                "entities.item.fields.productName.reference.field: Reference target field must be unique, primary, or protected"));
     }
 
     @Test
@@ -173,6 +213,67 @@ class ThingifierModelAssemblerTest {
                                 "optional",
                                 new RelationshipVectorSpec(
                                         "taskof", CardinalitySpec.oneToOne(), "mandatory")))
+                .build();
+    }
+
+    private ThingifierModelDefinition relationshipMetadataDefinition() {
+        return ThingifierModelDefinition.builder()
+                .entity(
+                        EntityDefinitionSpec.named("product")
+                                .plural("products")
+                                .primaryKey("id")
+                                .field(FieldDefinitionSpec.named("id", "auto-increment").build())
+                                .build())
+                .entity(
+                        EntityDefinitionSpec.named("item")
+                                .plural("items")
+                                .primaryKey("id")
+                                .field(FieldDefinitionSpec.named("id", "auto-increment").build())
+                                .field(
+                                        FieldDefinitionSpec.named("productId", "integer")
+                                                .reference("product", "id", "product")
+                                                .build())
+                                .build())
+                .relationship(
+                        new RelationshipDefinitionSpec(
+                                "item",
+                                "product",
+                                "product",
+                                CardinalitySpec.oneToOne(),
+                                "optional",
+                                true,
+                                true,
+                                null))
+                .build();
+    }
+
+    private ThingifierModelDefinition unstableFieldReferenceDefinition() {
+        return ThingifierModelDefinition.builder()
+                .entity(
+                        EntityDefinitionSpec.named("product")
+                                .plural("products")
+                                .primaryKey("id")
+                                .field(FieldDefinitionSpec.named("id", "string").build())
+                                .field(FieldDefinitionSpec.named("name", "string").build())
+                                .build())
+                .entity(
+                        EntityDefinitionSpec.named("item")
+                                .plural("items")
+                                .primaryKey("id")
+                                .field(FieldDefinitionSpec.named("id", "string").build())
+                                .field(
+                                        FieldDefinitionSpec.named("productName", "string")
+                                                .reference("product", "name", "product")
+                                                .build())
+                                .build())
+                .relationship(
+                        new RelationshipDefinitionSpec(
+                                "item",
+                                "product",
+                                "product",
+                                CardinalitySpec.oneToOne(),
+                                "optional",
+                                null))
                 .build();
     }
 

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/application/schema/definition/ThingifierModelExporterTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/application/schema/definition/ThingifierModelExporterTest.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.application.schema.FieldReferenceSpec;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.Cardinality;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.Field;
@@ -73,6 +74,30 @@ class ThingifierModelExporterTest {
     }
 
     @Test
+    void exporterCapturesRelationshipOwnershipPolicies() {
+        ThingifierModelDefinition definition =
+                new ThingifierModelExporter().export(relationshipMetadataModel());
+
+        RelationshipDefinitionSpec relationship = definition.relationships().get(0);
+
+        Assertions.assertTrue(relationship.deleteTargetWhenDisconnected());
+        Assertions.assertTrue(relationship.deleteTargetsWhenSourceDeleted());
+    }
+
+    @Test
+    void exporterCapturesFieldRelationshipReferences() {
+        ThingifierModelDefinition definition =
+                new ThingifierModelExporter().export(relationshipMetadataModel());
+
+        FieldReferenceSpec reference =
+                definition.entityNamed("item").fieldNamed("productId").relationshipReference();
+
+        Assertions.assertEquals("product", reference.targetEntityName());
+        Assertions.assertEquals("id", reference.targetFieldName());
+        Assertions.assertEquals("product", reference.relationshipName());
+    }
+
+    @Test
     void exportedDefinitionCanBeAssembledAgain() {
         ThingifierModelDefinition definition = new ThingifierModelExporter().export(model());
 
@@ -118,6 +143,23 @@ class ThingifierModelExporterTest {
                 .defineRelationship(project, task, "tasks", Cardinality.ONE_TO_MANY())
                 .whenReversed(Cardinality.ONE_TO_ONE(), "taskof");
 
+        return thingifier;
+    }
+
+    private Thingifier relationshipMetadataModel() {
+        Thingifier thingifier = new Thingifier();
+        EntityDefinition product = thingifier.defineThing("product", "products");
+        product.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT));
+
+        EntityDefinition item = thingifier.defineThing("item", "items");
+        item.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT));
+        item.addField(
+                Field.is("productId", FieldType.INTEGER).references(product, "id", "product"));
+
+        thingifier
+                .defineRelationship(item, product, "product", Cardinality.ONE_TO_ONE())
+                .deleteTargetWhenDisconnected()
+                .deleteTargetsWhenSourceDeleted();
         return thingifier;
     }
 }


### PR DESCRIPTION
## Summary
- Add opt-in update-connected relationship writes for already-connected children.
- Add declarative relationship ownership policies for cascade deletes.
- Add field-backed relationship references, including model definition and YAML round-tripping.
- Keep existing default relationship behavior unless APIs opt into the new functionality.

## Verification
- Full commit-hook verification passed with the 14-module Maven reactor.
- `mvn test` passed before commit.
- `mvn install -DskipTests` passed and installed updated `1.5.6-SNAPSHOT` artifacts locally.

Closes #142