### PR TITLE
Add custom validation pipeline

### DIFF
--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/EntityRelModel.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/EntityRelModel.java
@@ -6,6 +6,7 @@ import uk.co.compendiumdev.thingifier.core.domain.definitions.Cardinality;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.ERSchema;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.relationship.RelationshipDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.validation.GlobalValidator;
 import uk.co.compendiumdev.thingifier.core.reporting.ERModelReport;
 import uk.co.compendiumdev.thingifier.core.reporting.RepositoryJsonExporter;
 import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
@@ -61,6 +62,31 @@ public class EntityRelModel implements AutoCloseable {
 
     public ERSchema getSchema() {
         return schema;
+    }
+
+    /**
+     * Adds a schema-wide validator that runs for every entity write in this model.
+     *
+     * <p>This is a convenience delegate to the underlying schema. Use entity-level domain
+     * validation when the rule is owned by one entity definition.
+     *
+     * @param validationRule validator to add to the schema
+     * @return this model for fluent setup
+     */
+    public EntityRelModel withGlobalValidation(final GlobalValidator validationRule) {
+        schema.withGlobalValidation(validationRule);
+        return this;
+    }
+
+    /**
+     * Adds schema-wide validators that run for every entity write in this model.
+     *
+     * @param validationRule validators to add to the schema
+     * @return this model for fluent setup
+     */
+    public EntityRelModel withGlobalValidation(final GlobalValidator... validationRule) {
+        schema.withGlobalValidation(validationRule);
+        return this;
     }
 
     public String exportInstanceDataAsJson(final String databaseKey) {

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/ERSchema.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/ERSchema.java
@@ -2,19 +2,23 @@ package uk.co.compendiumdev.thingifier.core.domain.definitions;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.relationship.RelationshipDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.relationship.RelationshipVectorDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.validation.GlobalValidator;
 
 public class ERSchema {
 
     private final ConcurrentHashMap<String, RelationshipDefinition> relationships;
     private final ConcurrentHashMap<String, EntityDefinition> entityDefinitions;
+    private final List<GlobalValidator> globalValidators;
 
     public ERSchema() {
         relationships = new ConcurrentHashMap<>();
         entityDefinitions = new ConcurrentHashMap<>();
+        globalValidators = new ArrayList<>();
     }
 
     public EntityDefinition defineEntity(
@@ -31,6 +35,41 @@ public class ERSchema {
 
     public Collection<EntityDefinition> getEntityDefinitions() {
         return entityDefinitions.values();
+    }
+
+    /**
+     * Adds a schema-wide validator that runs for every entity write.
+     *
+     * <p>Global validators are for cross-cutting rules that are not owned by one entity. Use {@link
+     * EntityDefinition#withDomainValidation} when the rule belongs to a specific entity but needs
+     * access to the active schema or store.
+     *
+     * @param validationRule validator to add to the schema
+     * @return this schema for fluent model setup
+     */
+    public ERSchema withGlobalValidation(final GlobalValidator validationRule) {
+        globalValidators.add(validationRule);
+        return this;
+    }
+
+    /**
+     * Adds schema-wide validators that run for every entity write.
+     *
+     * @param validationRule validators to add to the schema
+     * @return this schema for fluent model setup
+     */
+    public ERSchema withGlobalValidation(final GlobalValidator... validationRule) {
+        Collections.addAll(globalValidators, validationRule);
+        return this;
+    }
+
+    /**
+     * Returns the schema-wide global validators.
+     *
+     * @return immutable list of global validators
+     */
+    public List<GlobalValidator> globalValidators() {
+        return Collections.unmodifiableList(globalValidators);
     }
 
     public RelationshipDefinition defineRelationship(

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/EntityDefinition.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/EntityDefinition.java
@@ -4,6 +4,8 @@ import java.util.*;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.Field;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldType;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.relationship.RelationshipVectorDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.validation.EntityDomainValidator;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.validation.InstanceValidator;
 import uk.co.compendiumdev.thingifier.core.domain.instances.InstanceFields;
 
 public class EntityDefinition {
@@ -19,6 +21,8 @@ public class EntityDefinition {
     private final DefinedFields fields;
     private final DefinedRelationships definedRelationships;
     private final Map<String, EntityViewDefinition> views;
+    private final List<InstanceValidator> instanceValidators;
+    private final List<EntityDomainValidator> domainValidators;
 
     private static final int NO_INSTANCE_LIMIT = -1;
 
@@ -33,6 +37,8 @@ public class EntityDefinition {
         definedRelationships = new DefinedRelationships();
         fields = new DefinedFields();
         views = new HashMap<>();
+        instanceValidators = new ArrayList<>();
+        domainValidators = new ArrayList<>();
         this.maxInstanceCount = maxInstanceCount;
         this.description = "";
 
@@ -87,6 +93,77 @@ public class EntityDefinition {
     public EntityDefinition addFields(Field... theseFields) {
         fields.addFields(theseFields);
         return this;
+    }
+
+    /**
+     * Adds a cross-field validator that only needs the candidate instance.
+     *
+     * <p>Instance validators run after field validation and uniqueness pass. They are intentionally
+     * scoped to one candidate instance; use {@link #withDomainValidation(EntityDomainValidator)}
+     * when a rule for this entity needs the active schema or store.
+     *
+     * @param validationRule validator to add to this entity definition
+     * @return this entity definition for fluent model setup
+     */
+    public EntityDefinition withInstanceValidation(final InstanceValidator validationRule) {
+        instanceValidators.add(validationRule);
+        return this;
+    }
+
+    /**
+     * Adds cross-field validators that only need the candidate instance.
+     *
+     * @param validationRule validators to add to this entity definition
+     * @return this entity definition for fluent model setup
+     */
+    public EntityDefinition withInstanceValidation(final InstanceValidator... validationRule) {
+        instanceValidators.addAll(Arrays.asList(validationRule));
+        return this;
+    }
+
+    /**
+     * Returns the instance validators attached to this entity.
+     *
+     * @return immutable list of instance validators
+     */
+    public List<InstanceValidator> instanceValidators() {
+        return Collections.unmodifiableList(instanceValidators);
+    }
+
+    /**
+     * Adds an entity domain validator for rules that belong to this entity but need domain access.
+     *
+     * <p>Entity domain validators run after field, uniqueness, and instance validation have passed.
+     * They receive the active schema and store, but only execute for writes to this entity
+     * definition. This is the right home for entity-owned rules that must compare against other
+     * instances or relationships.
+     *
+     * @param validationRule validator to add to this entity definition
+     * @return this entity definition for fluent model setup
+     */
+    public EntityDefinition withDomainValidation(final EntityDomainValidator validationRule) {
+        domainValidators.add(validationRule);
+        return this;
+    }
+
+    /**
+     * Adds entity domain validators for rules that belong to this entity but need domain access.
+     *
+     * @param validationRule validators to add to this entity definition
+     * @return this entity definition for fluent model setup
+     */
+    public EntityDefinition withDomainValidation(final EntityDomainValidator... validationRule) {
+        domainValidators.addAll(Arrays.asList(validationRule));
+        return this;
+    }
+
+    /**
+     * Returns the entity domain validators attached to this entity.
+     *
+     * @return immutable list of entity domain validators
+     */
+    public List<EntityDomainValidator> domainValidators() {
+        return Collections.unmodifiableList(domainValidators);
     }
 
     public Field getField(String fieldName) {

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/field/definition/Field.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/field/definition/Field.java
@@ -21,6 +21,7 @@ public final class Field {
     // default value for the field
     private String defaultValue;
     private final List<ValidationRule> validationRules;
+    private final List<FieldValidator> customValidators;
     private boolean truncateStringIfTooLong;
 
     private final boolean allowedNullable;
@@ -43,6 +44,7 @@ public final class Field {
         this.name = name;
         this.type = type;
         validationRules = new ArrayList<>();
+        customValidators = new ArrayList<>();
 
         fieldIsOptional = true;
         if (type == FieldType.AUTO_INCREMENT || type == FieldType.AUTO_GUID) {
@@ -130,14 +132,97 @@ public final class Field {
         return this;
     }
 
-    // TODO: when all field values use field, then this could move to the value and out of the field
-    public ValidationReport validate(FieldValue value) {
-        boolean NOT_ALLOWED_TO_SET_IDs = false;
-        return validate(value, NOT_ALLOWED_TO_SET_IDs);
+    /**
+     * Adds a code-only custom validator for this field.
+     *
+     * <p>Custom validators run after built-in field checks and standard {@link ValidationRule}
+     * checks have passed. This keeps custom code focused on business rules and prevents it from
+     * seeing values that Thingifier already knows are structurally invalid.
+     *
+     * @param validationRule validator to add to this field
+     * @return this field for fluent model setup
+     */
+    public Field withCustomValidation(FieldValidator validationRule) {
+        customValidators.add(validationRule);
+        return this;
     }
 
-    // allowedToSetIds is a bit of hack - refactor other code so not required
-    public ValidationReport validate(FieldValue value, boolean allowedToSetIds) {
+    /**
+     * Adds code-only custom validators for this field.
+     *
+     * @param validationRule validators to add to this field
+     * @return this field for fluent model setup
+     */
+    public Field withCustomValidation(FieldValidator... validationRule) {
+        customValidators.addAll(Arrays.asList(validationRule));
+        return this;
+    }
+
+    /**
+     * Validates a field value for user-supplied writes.
+     *
+     * <p>This is the default field validation entry point. It rejects caller-supplied protected ID
+     * values and runs the complete field pipeline: built-in structural/type/object checks, standard
+     * {@link ValidationRule} checks, and then custom field validators.
+     *
+     * @param value value to validate, or null when the field is absent from the candidate
+     * @return validation report for the field value
+     */
+    public ValidationReport validate(FieldValue value) {
+        return validateWithIdPolicy(value, IdWritePolicy.REJECT_SUPPLIED_IDS);
+    }
+
+    /**
+     * Validates a field value for trusted repository/system writes.
+     *
+     * <p>Protected writes allow generated or restored ID values while still running the complete
+     * field pipeline. This is intended for internal materialization, imports, and repository paths
+     * that legitimately need to carry protected fields.
+     *
+     * @param value value to validate, or null when the field is absent from the candidate
+     * @return validation report for the field value
+     */
+    public ValidationReport validateForProtectedWrite(FieldValue value) {
+        return validateWithIdPolicy(value, IdWritePolicy.ALLOW_SUPPLIED_IDS);
+    }
+
+    private ValidationReport validateWithIdPolicy(FieldValue value, IdWritePolicy idWritePolicy) {
+        ValidationReport report = validateBuiltInWithIdPolicy(value, idWritePolicy);
+        if (!report.isValid()) {
+            return report;
+        }
+        report.combine(validateCustom(value));
+        return report;
+    }
+
+    /**
+     * Runs only built-in and standard field validation for a user-supplied write.
+     *
+     * <p>This is used by the repository write pipeline so uniqueness can be checked before custom
+     * field validators run.
+     *
+     * @param value value to validate, or null when the field is absent from the candidate
+     * @return validation report for built-in field checks
+     */
+    public ValidationReport validateBuiltInForNormalWrite(FieldValue value) {
+        return validateBuiltInWithIdPolicy(value, IdWritePolicy.REJECT_SUPPLIED_IDS);
+    }
+
+    /**
+     * Runs only built-in and standard field validation for a trusted repository/system write.
+     *
+     * <p>This supports validation of already generated or restored protected IDs without running
+     * custom validators before the ordered repository pipeline reaches that stage.
+     *
+     * @param value value to validate, or null when the field is absent from the candidate
+     * @return validation report for built-in field checks
+     */
+    public ValidationReport validateBuiltInForProtectedWrite(FieldValue value) {
+        return validateBuiltInWithIdPolicy(value, IdWritePolicy.ALLOW_SUPPLIED_IDS);
+    }
+
+    private ValidationReport validateBuiltInWithIdPolicy(
+            FieldValue value, IdWritePolicy idWritePolicy) {
 
         ValidationReport report = new ValidationReport();
 
@@ -148,7 +233,7 @@ public final class Field {
             return report;
         }
 
-        if (!allowedToSetIds) {
+        if (idWritePolicy == IdWritePolicy.REJECT_SUPPLIED_IDS) {
             if (type == FieldType.AUTO_INCREMENT) {
                 report.setValid(false);
                 report.addErrorMessage(
@@ -198,6 +283,32 @@ public final class Field {
         return report;
     }
 
+    /**
+     * Runs only code-defined custom validators for this field.
+     *
+     * <p>Callers should use this after built-in field validation has passed. The repository write
+     * pipeline keeps this separate so it can enforce stage ordering and short-circuit behavior.
+     *
+     * @param value value to validate, or null when the field is absent from the candidate
+     * @return validation report for custom field validators
+     */
+    public ValidationReport validateCustom(final FieldValue value) {
+        ValidationReport report = new ValidationReport();
+        if (value == null) {
+            return report;
+        }
+        if (type == FieldType.OBJECT && value.asObject() != null) {
+            report.combine(value.asObject().validateCustomFields(new ArrayList<>()));
+        }
+        for (FieldValidator validator : customValidators) {
+            ValidationReport validity = validator.validate(value);
+            if (validity != null) {
+                report.combine(validity);
+            }
+        }
+        return report;
+    }
+
     public List<ValidationRule> getAllValidationRules() {
         List<ValidationRule> rules = new ArrayList<>();
 
@@ -231,13 +342,25 @@ public final class Field {
     private void validateObjectValue(final FieldValue value, final ValidationReport report) {
         if (value != null && value.asObject() != null) {
             final ValidationReport objectValidity =
-                    value.asObject().validateFields(new ArrayList<>(), true);
+                    value.asObject().validateBuiltInFieldsForProtectedWrite(new ArrayList<>());
             report.combine(objectValidity);
         }
     }
 
     public List<ValidationRule> validationRules() {
         return validationRules;
+    }
+
+    /**
+     * Returns custom validators attached to this field.
+     *
+     * <p>These validators are intentionally excluded from model export/import because functions
+     * cannot safely round-trip through YAML or schema metadata.
+     *
+     * @return immutable list of custom field validators
+     */
+    public List<FieldValidator> customValidators() {
+        return Collections.unmodifiableList(customValidators);
     }
 
     public boolean isMandatory() {
@@ -504,5 +627,10 @@ public final class Field {
             }
         }
         return this;
+    }
+
+    private enum IdWritePolicy {
+        REJECT_SUPPLIED_IDS,
+        ALLOW_SUPPLIED_IDS
     }
 }

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/validation/EntityDomainValidationContext.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/validation/EntityDomainValidationContext.java
@@ -1,0 +1,89 @@
+package uk.co.compendiumdev.thingifier.core.domain.definitions.validation;
+
+import uk.co.compendiumdev.thingifier.core.domain.definitions.ERSchema;
+import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
+import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
+
+/**
+ * Context passed to an entity domain validator.
+ *
+ * <p>Entity domain validation is attached to a single entity definition, but it can still inspect
+ * the wider schema and active store. This exists for rules such as "a task title must be unique
+ * within its project" where the rule belongs to the task entity but needs relationship or other
+ * stored data to make the decision.
+ */
+public final class EntityDomainValidationContext {
+
+    private final ERSchema schema;
+    private final ThingStore store;
+    private final EntityInstance candidate;
+    private final EntityInstance existing;
+    private final ValidationOperation operation;
+
+    /**
+     * Creates an immutable validation context for one candidate write.
+     *
+     * @param schema active schema for resolving entities and relationships
+     * @param store active store, including existing persisted data
+     * @param candidate fully materialized instance about to be written
+     * @param existing current persisted instance for amend/replace, or null for create
+     * @param operation write operation being validated
+     */
+    public EntityDomainValidationContext(
+            final ERSchema schema,
+            final ThingStore store,
+            final EntityInstance candidate,
+            final EntityInstance existing,
+            final ValidationOperation operation) {
+        this.schema = schema;
+        this.store = store;
+        this.candidate = candidate;
+        this.existing = existing;
+        this.operation = operation;
+    }
+
+    /**
+     * Active schema for resolving definitions and relationships.
+     *
+     * @return active schema
+     */
+    public ERSchema schema() {
+        return schema;
+    }
+
+    /**
+     * Active store for querying persisted instances and relationships.
+     *
+     * @return active store
+     */
+    public ThingStore store() {
+        return store;
+    }
+
+    /**
+     * Candidate instance after create IDs have been prepared or amend/replace values materialized.
+     *
+     * @return candidate instance
+     */
+    public EntityInstance candidate() {
+        return candidate;
+    }
+
+    /**
+     * Existing persisted instance for amend/replace operations.
+     *
+     * @return existing instance, or null for create
+     */
+    public EntityInstance existing() {
+        return existing;
+    }
+
+    /**
+     * Operation being validated.
+     *
+     * @return validation operation
+     */
+    public ValidationOperation operation() {
+        return operation;
+    }
+}

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/validation/EntityDomainValidator.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/validation/EntityDomainValidator.java
@@ -1,0 +1,22 @@
+package uk.co.compendiumdev.thingifier.core.domain.definitions.validation;
+
+import uk.co.compendiumdev.thingifier.core.reporting.ValidationReport;
+
+/**
+ * Entity-scoped validator that can inspect the wider domain.
+ *
+ * <p>Use this when the rule belongs to one entity type, but the decision needs more than the
+ * candidate instance. The validator receives the active schema and store so it can compare the
+ * candidate with other instances, relationships, or domain state.
+ */
+@FunctionalInterface
+public interface EntityDomainValidator {
+
+    /**
+     * Validates one candidate write for the owning entity.
+     *
+     * @param context immutable context for the candidate write
+     * @return validation report, or a valid report when the candidate is acceptable
+     */
+    ValidationReport validate(EntityDomainValidationContext context);
+}

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/validation/FieldValidator.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/validation/FieldValidator.java
@@ -1,0 +1,23 @@
+package uk.co.compendiumdev.thingifier.core.domain.definitions.validation;
+
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.instance.FieldValue;
+import uk.co.compendiumdev.thingifier.core.reporting.ValidationReport;
+
+/**
+ * Field-level custom validator for code-only checks on a single value.
+ *
+ * <p>Field validators run after Thingifier's built-in type, mandatory, object, and standard {@code
+ * ValidationRule} checks have passed. They are intentionally code-only because arbitrary functions
+ * cannot be safely exported to YAML or reassembled from model metadata.
+ */
+@FunctionalInterface
+public interface FieldValidator {
+
+    /**
+     * Validates one field value.
+     *
+     * @param value candidate field value
+     * @return validation report, or a valid report when the value is acceptable
+     */
+    ValidationReport validate(FieldValue value);
+}

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/validation/GlobalValidationContext.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/validation/GlobalValidationContext.java
@@ -1,0 +1,88 @@
+package uk.co.compendiumdev.thingifier.core.domain.definitions.validation;
+
+import uk.co.compendiumdev.thingifier.core.domain.definitions.ERSchema;
+import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
+import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
+
+/**
+ * Context passed to a schema-wide global validator.
+ *
+ * <p>Global validation is intentionally attached to the schema, not a single entity. It is for
+ * cross-cutting rules that should see every entity write, such as a tenant-wide quota or an audit
+ * rule that applies across the whole model.
+ */
+public final class GlobalValidationContext {
+
+    private final ERSchema schema;
+    private final ThingStore store;
+    private final EntityInstance candidate;
+    private final EntityInstance existing;
+    private final ValidationOperation operation;
+
+    /**
+     * Creates an immutable validation context for one candidate write.
+     *
+     * @param schema active schema for resolving entities and relationships
+     * @param store active store, including existing persisted data
+     * @param candidate fully materialized instance about to be written
+     * @param existing current persisted instance for amend/replace, or null for create
+     * @param operation write operation being validated
+     */
+    public GlobalValidationContext(
+            final ERSchema schema,
+            final ThingStore store,
+            final EntityInstance candidate,
+            final EntityInstance existing,
+            final ValidationOperation operation) {
+        this.schema = schema;
+        this.store = store;
+        this.candidate = candidate;
+        this.existing = existing;
+        this.operation = operation;
+    }
+
+    /**
+     * Active schema for resolving definitions and relationships.
+     *
+     * @return active schema
+     */
+    public ERSchema schema() {
+        return schema;
+    }
+
+    /**
+     * Active store for querying persisted instances and relationships.
+     *
+     * @return active store
+     */
+    public ThingStore store() {
+        return store;
+    }
+
+    /**
+     * Candidate instance after create IDs have been prepared or amend/replace values materialized.
+     *
+     * @return candidate instance
+     */
+    public EntityInstance candidate() {
+        return candidate;
+    }
+
+    /**
+     * Existing persisted instance for amend/replace operations.
+     *
+     * @return existing instance, or null for create
+     */
+    public EntityInstance existing() {
+        return existing;
+    }
+
+    /**
+     * Operation being validated.
+     *
+     * @return validation operation
+     */
+    public ValidationOperation operation() {
+        return operation;
+    }
+}

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/validation/GlobalValidator.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/validation/GlobalValidator.java
@@ -1,0 +1,21 @@
+package uk.co.compendiumdev.thingifier.core.domain.definitions.validation;
+
+import uk.co.compendiumdev.thingifier.core.reporting.ValidationReport;
+
+/**
+ * Schema-wide validator that sees every entity write.
+ *
+ * <p>Use this for truly global rules. If a rule belongs to one entity type but needs store/schema
+ * access, use {@link EntityDomainValidator} instead so the model communicates the rule's owner.
+ */
+@FunctionalInterface
+public interface GlobalValidator {
+
+    /**
+     * Validates one candidate write in the context of the whole schema.
+     *
+     * @param context immutable context for the candidate write
+     * @return validation report, or a valid report when the candidate is acceptable
+     */
+    ValidationReport validate(GlobalValidationContext context);
+}

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/validation/InstanceValidationContext.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/validation/InstanceValidationContext.java
@@ -1,0 +1,60 @@
+package uk.co.compendiumdev.thingifier.core.domain.definitions.validation;
+
+import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
+
+/**
+ * Context passed to an instance validator.
+ *
+ * <p>This context deliberately contains only the candidate, existing instance, and operation. It
+ * keeps instance validation focused on consistency within one instance rather than allowing hidden
+ * dependencies on repository state.
+ */
+public final class InstanceValidationContext {
+
+    private final EntityInstance candidate;
+    private final EntityInstance existing;
+    private final ValidationOperation operation;
+
+    /**
+     * Creates an immutable context for one instance-level validation.
+     *
+     * @param candidate fully materialized instance about to be written
+     * @param existing current persisted instance for amend/replace, or null for create
+     * @param operation write operation being validated
+     */
+    public InstanceValidationContext(
+            final EntityInstance candidate,
+            final EntityInstance existing,
+            final ValidationOperation operation) {
+        this.candidate = candidate;
+        this.existing = existing;
+        this.operation = operation;
+    }
+
+    /**
+     * Candidate instance after create IDs have been prepared or amend/replace values materialized.
+     *
+     * @return candidate instance
+     */
+    public EntityInstance candidate() {
+        return candidate;
+    }
+
+    /**
+     * Existing persisted instance for amend/replace operations.
+     *
+     * @return existing instance, or null for create
+     */
+    public EntityInstance existing() {
+        return existing;
+    }
+
+    /**
+     * Operation being validated.
+     *
+     * @return validation operation
+     */
+    public ValidationOperation operation() {
+        return operation;
+    }
+}

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/validation/InstanceValidator.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/validation/InstanceValidator.java
@@ -1,0 +1,22 @@
+package uk.co.compendiumdev.thingifier.core.domain.definitions.validation;
+
+import uk.co.compendiumdev.thingifier.core.reporting.ValidationReport;
+
+/**
+ * Entity instance validator for cross-field rules on one candidate instance.
+ *
+ * <p>Use this when all data needed to decide the rule is already on the candidate instance, for
+ * example checking that an end date is after a start date. Use {@link EntityDomainValidator} when
+ * the rule belongs to an entity but needs the active store or schema.
+ */
+@FunctionalInterface
+public interface InstanceValidator {
+
+    /**
+     * Validates one candidate instance.
+     *
+     * @param context immutable context for the candidate write
+     * @return validation report, or a valid report when the candidate is acceptable
+     */
+    ValidationReport validate(InstanceValidationContext context);
+}

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/validation/ValidationOperation.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/definitions/validation/ValidationOperation.java
@@ -1,0 +1,16 @@
+package uk.co.compendiumdev.thingifier.core.domain.definitions.validation;
+
+/**
+ * Write operation being validated by custom validators.
+ *
+ * <p>Validators receive the operation so one rule can distinguish new instances from partial
+ * amendment and full replacement without guessing from the shape of the candidate data.
+ */
+public enum ValidationOperation {
+    /** Candidate is being inserted as a new instance. */
+    CREATE,
+    /** Candidate is the result of applying a partial amendment to an existing instance. */
+    AMEND,
+    /** Candidate is the result of replacing an existing instance's fields. */
+    REPLACE
+}

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/instances/EntityInstance.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/instances/EntityInstance.java
@@ -92,11 +92,67 @@ public class EntityInstance {
     */
 
     private ValidationReport validateFields() {
-        return validateFieldValues(new ArrayList<>(), false);
+        return validateFieldValuesForNormalWrite(new ArrayList<>());
     }
 
-    public ValidationReport validateFieldValues(List<String> excluding, boolean amAllowedToSetIds) {
-        return instanceFields.validateFields(excluding, amAllowedToSetIds);
+    /**
+     * Validates this instance's field values as a user-supplied write.
+     *
+     * <p>Use this for ordinary candidate validation where callers must not provide protected ID
+     * values. It runs built-in field checks before custom field validators.
+     *
+     * @param excluding field names to skip during validation
+     * @return validation report for field-level validation
+     */
+    public ValidationReport validateFieldValuesForNormalWrite(List<String> excluding) {
+        return instanceFields.validateFieldsForNormalWrite(excluding);
+    }
+
+    /**
+     * Validates this instance's field values as a trusted repository/system write.
+     *
+     * <p>Use this when a candidate already contains generated or restored protected IDs. It still
+     * preserves built-in-before-custom field validation ordering.
+     *
+     * @param excluding field names to skip during validation
+     * @return validation report for field-level validation
+     */
+    public ValidationReport validateFieldValuesForProtectedWrite(List<String> excluding) {
+        return instanceFields.validateFieldsForProtectedWrite(excluding);
+    }
+
+    /**
+     * Runs only built-in and standard field validation for a user-supplied write.
+     *
+     * <p>The repository write validator uses this as the first stage of the larger write pipeline.
+     *
+     * @param excluding field names to skip during validation
+     * @return validation report for built-in field checks
+     */
+    public ValidationReport validateBuiltInFieldValuesForNormalWrite(List<String> excluding) {
+        return instanceFields.validateBuiltInFieldsForNormalWrite(excluding);
+    }
+
+    /**
+     * Runs only built-in and standard field validation for a trusted repository/system write.
+     *
+     * @param excluding field names to skip during validation
+     * @return validation report for built-in field checks
+     */
+    public ValidationReport validateBuiltInFieldValuesForProtectedWrite(List<String> excluding) {
+        return instanceFields.validateBuiltInFieldsForProtectedWrite(excluding);
+    }
+
+    /**
+     * Runs only code-defined custom field validators for this instance.
+     *
+     * <p>This should be called only after built-in field validation has succeeded.
+     *
+     * @param excluding field names to skip during validation
+     * @return validation report for custom field validators
+     */
+    public ValidationReport validateCustomFieldValues(List<String> excluding) {
+        return instanceFields.validateCustomFields(excluding);
     }
 
     public ValidationReport validate() {

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/instances/InstanceFields.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/instances/InstanceFields.java
@@ -220,19 +220,104 @@ public class InstanceFields {
         throw new RuntimeException("Could not find field: " + fieldName);
     }
 
-    // todo: not sure about the amAllowedToSetIds would prefer a different
-    // way to configure the validation rules or exceptions to the rules
-    public ValidationReport validateFields(
-            final List<String> excluding, final boolean amAllowedToSetIds) {
-        ValidationReport report = new ValidationReport();
+    /**
+     * Validates all field values for a user-supplied write.
+     *
+     * <p>Normal writes reject supplied protected IDs. Built-in checks run first and custom field
+     * validators only run if every built-in field check passes.
+     *
+     * @param excluding field names to skip during validation
+     * @return validation report for the first failing field-validation stage, or valid when all
+     *     pass
+     */
+    public ValidationReport validateFieldsForNormalWrite(final List<String> excluding) {
+        ValidationReport report = validateBuiltInFieldsForNormalWrite(excluding);
+        if (!report.isValid()) {
+            return report;
+        }
+        report.combine(validateCustomFields(excluding));
+        return report;
+    }
 
-        // Field validation
+    /**
+     * Validates all field values for a trusted repository/system write.
+     *
+     * <p>Protected writes allow generated or restored ID values while preserving the same
+     * built-in-before-custom ordering used for normal writes.
+     *
+     * @param excluding field names to skip during validation
+     * @return validation report for the first failing field-validation stage, or valid when all
+     *     pass
+     */
+    public ValidationReport validateFieldsForProtectedWrite(final List<String> excluding) {
+        ValidationReport report = validateBuiltInFieldsForProtectedWrite(excluding);
+        if (!report.isValid()) {
+            return report;
+        }
+        report.combine(validateCustomFields(excluding));
+        return report;
+    }
+
+    /**
+     * Runs only built-in and standard field validation for a user-supplied write.
+     *
+     * @param excluding field names to skip during validation
+     * @return validation report for built-in field checks
+     */
+    public ValidationReport validateBuiltInFieldsForNormalWrite(final List<String> excluding) {
+        return validateBuiltInFields(excluding, IdWritePolicy.REJECT_SUPPLIED_IDS);
+    }
+
+    /**
+     * Runs only built-in and standard field validation for a trusted repository/system write.
+     *
+     * @param excluding field names to skip during validation
+     * @return validation report for built-in field checks
+     */
+    public ValidationReport validateBuiltInFieldsForProtectedWrite(final List<String> excluding) {
+        return validateBuiltInFields(excluding, IdWritePolicy.ALLOW_SUPPLIED_IDS);
+    }
+
+    private ValidationReport validateBuiltInFields(
+            final List<String> excluding, final IdWritePolicy idWritePolicy) {
+        ValidationReport report = new ValidationReport();
 
         for (String fieldName : objectDefinition.getFieldNames()) {
             if (!excluding.contains(fieldName)) {
                 Field field = objectDefinition.getField(fieldName);
-                ValidationReport validity =
-                        field.validate(getAssignedValue(fieldName), amAllowedToSetIds);
+                ValidationReport validity = validateBuiltIn(field, fieldName, idWritePolicy);
+                report.combine(validity);
+            }
+        }
+
+        return report;
+    }
+
+    private ValidationReport validateBuiltIn(
+            final Field field, final String fieldName, final IdWritePolicy idWritePolicy) {
+        if (idWritePolicy == IdWritePolicy.ALLOW_SUPPLIED_IDS) {
+            return field.validateBuiltInForProtectedWrite(getAssignedValue(fieldName));
+        }
+        return field.validateBuiltInForNormalWrite(getAssignedValue(fieldName));
+    }
+
+    /**
+     * Runs only code-defined custom field validators.
+     *
+     * <p>This method assumes built-in validation has already passed. The repository write validator
+     * calls it as its own stage so later instance, entity domain, and global validators are skipped
+     * when custom field validation fails.
+     *
+     * @param excluding field names to skip during validation
+     * @return validation report for custom field validators
+     */
+    public ValidationReport validateCustomFields(final List<String> excluding) {
+        ValidationReport report = new ValidationReport();
+
+        for (String fieldName : objectDefinition.getFieldNames()) {
+            if (!excluding.contains(fieldName)) {
+                Field field = objectDefinition.getField(fieldName);
+                ValidationReport validity = field.validateCustom(getAssignedValue(fieldName));
                 report.combine(validity);
             }
         }
@@ -242,5 +327,10 @@ public class InstanceFields {
 
     public boolean hasAssignedValue(String fieldName) {
         return values.containsKey(fieldName.toLowerCase());
+    }
+
+    private enum IdWritePolicy {
+        REJECT_SUPPLIED_IDS,
+        ALLOW_SUPPLIED_IDS
     }
 }

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/instances/validation/EntityInstanceDraftValidator.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/instances/validation/EntityInstanceDraftValidator.java
@@ -79,7 +79,11 @@ public final class EntityInstanceDraftValidator {
 
         FieldValue fieldValue = FieldValue.is(field, value);
         try {
-            report.combine(field.validate(fieldValue, protectedWrite));
+            if (protectedWrite) {
+                report.combine(field.validateBuiltInForProtectedWrite(fieldValue));
+            } else {
+                report.combine(field.validateBuiltInForNormalWrite(fieldValue));
+            }
             validateProtectedAutoIncrement(field, fieldValue, report);
             validateProtectedAutoGuid(field, fieldValue, report);
         } catch (IllegalArgumentException e) {

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/instances/validation/EntityInstanceStateValidator.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/domain/instances/validation/EntityInstanceStateValidator.java
@@ -8,13 +8,36 @@ import uk.co.compendiumdev.thingifier.core.reporting.ValidationReport;
 public final class EntityInstanceStateValidator {
 
     public ValidationReport validate(final EntityInstance instance) {
-        return validateFields(instance, new ArrayList<>(), false);
+        return validateFieldsForNormalWrite(instance, new ArrayList<>());
     }
 
-    public ValidationReport validateFields(
-            final EntityInstance instance,
-            final List<String> excluding,
-            final boolean allowedToSetIds) {
-        return instance.validateFieldValues(excluding, allowedToSetIds);
+    /**
+     * Validates persisted instance state using normal write rules.
+     *
+     * <p>The method name makes the protected-ID policy explicit at the call site and replaces the
+     * older boolean flag that made caller intent difficult to read.
+     *
+     * @param instance instance to validate
+     * @param excluding field names to skip during validation
+     * @return validation report for field-level validation
+     */
+    public ValidationReport validateFieldsForNormalWrite(
+            final EntityInstance instance, final List<String> excluding) {
+        return instance.validateFieldValuesForNormalWrite(excluding);
+    }
+
+    /**
+     * Validates persisted instance state while allowing protected ID fields.
+     *
+     * <p>This is for trusted repository/system paths that must validate a materialized object with
+     * generated or restored protected identifiers already present.
+     *
+     * @param instance instance to validate
+     * @param excluding field names to skip during validation
+     * @return validation report for field-level validation
+     */
+    public ValidationReport validateFieldsForProtectedWrite(
+            final EntityInstance instance, final List<String> excluding) {
+        return instance.validateFieldValuesForProtectedWrite(excluding);
     }
 }

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/repository/MutableEntityInstance.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/repository/MutableEntityInstance.java
@@ -115,9 +115,25 @@ public final class MutableEntityInstance {
         return null;
     }
 
-    public ValidationReport validateFieldValues(
-            final List<String> excluding, final boolean allowedToSetIds) {
-        return fields.validateFields(excluding, allowedToSetIds);
+    /**
+     * Validates mutable field values as a user-supplied write before a repository snapshot is made.
+     *
+     * @param excluding field names to skip during validation
+     * @return validation report for field-level validation
+     */
+    public ValidationReport validateFieldValuesForNormalWrite(final List<String> excluding) {
+        return fields.validateFieldsForNormalWrite(excluding);
+    }
+
+    /**
+     * Validates mutable field values as a trusted repository/system write before a snapshot is
+     * made.
+     *
+     * @param excluding field names to skip during validation
+     * @return validation report for field-level validation
+     */
+    public ValidationReport validateFieldValuesForProtectedWrite(final List<String> excluding) {
+        return fields.validateFieldsForProtectedWrite(excluding);
     }
 
     public EntityInstance toEntityInstance() {

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/repository/inmemory/InMemoryThingStore.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/repository/inmemory/InMemoryThingStore.java
@@ -35,6 +35,7 @@ public class InMemoryThingStore implements ThingStore {
     private final EntityInstanceQuery entityQuery;
     private final RelationshipRepository relationshipRepository;
     private final RepositoryAdministration administration;
+    private ERSchema schema;
 
     public InMemoryThingStore(final String databaseKey) {
         this(databaseKey, new InMemoryEntityInstanceStore());
@@ -44,7 +45,9 @@ public class InMemoryThingStore implements ThingStore {
         this.databaseKey = databaseKey;
         this.instanceData = instanceData;
         this.relationships = new InMemoryRelationshipStore();
-        this.writeValidator = new EntityInstanceWriteValidator(this::checkFieldsForUniqueNess);
+        this.writeValidator =
+                new EntityInstanceWriteValidator(
+                        this::checkFieldsForUniqueNess, () -> schema, this);
         this.entityRepository = new InMemoryEntityInstanceRepository(this);
         this.entityQuery = new InMemoryEntityInstanceQuery(this);
         this.relationshipRepository = new InMemoryRelationshipRepository(this);
@@ -86,6 +89,7 @@ public class InMemoryThingStore implements ThingStore {
     }
 
     void refreshSchema(final ERSchema schema) {
+        this.schema = schema;
         createInstanceCollectionsFrom(schema);
     }
 
@@ -189,7 +193,7 @@ public class InMemoryThingStore implements ThingStore {
     EntityInstance patchInstance(final EntityInstance instance, final EntityInstanceDraft draft) {
         EntityInstance candidate =
                 MutableEntityInstance.fromExisting(instance).patch(draft).toEntityInstance();
-        writeValidator.assertValidForAmendment(candidate);
+        writeValidator.assertValidForAmendment(candidate, instance);
         return getInstanceCollectionForEntityNamed(instance.getEntity().getName())
                 .replaceInstance(candidate);
     }
@@ -197,7 +201,7 @@ public class InMemoryThingStore implements ThingStore {
     EntityInstance replaceInstance(final EntityInstance instance, final EntityInstanceDraft draft) {
         EntityInstance candidate =
                 MutableEntityInstance.fromExisting(instance).replace(draft).toEntityInstance();
-        writeValidator.assertValidForAmendment(candidate);
+        writeValidator.assertValidForReplacement(candidate, instance);
         return getInstanceCollectionForEntityNamed(instance.getEntity().getName())
                 .replaceInstance(candidate);
     }

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/repository/sqlite/SqliteThingStore.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/repository/sqlite/SqliteThingStore.java
@@ -76,7 +76,9 @@ public class SqliteThingStore implements ThingStore {
         this.jdbcUrl = jdbcUrl;
         this.materializedInstances = new HashMap<>();
         this.countersByEntity = new HashMap<>();
-        this.writeValidator = new EntityInstanceWriteValidator(this::checkFieldsForUniqueNess);
+        this.writeValidator =
+                new EntityInstanceWriteValidator(
+                        this::checkFieldsForUniqueNess, () -> schema, this);
         this.relationshipRules = new RelationshipRules();
         this.entityRepository = new SqliteEntityInstanceRepository(this);
         this.entityQuery = new SqliteEntityInstanceQuery(this);
@@ -303,7 +305,7 @@ public class SqliteThingStore implements ThingStore {
         ensureSchemaReady();
         EntityInstance updated =
                 MutableEntityInstance.fromExisting(instance).patch(draft).toEntityInstance();
-        writeValidator.assertValidForAmendment(updated);
+        writeValidator.assertValidForAmendment(updated, instance);
         runInTransaction(
                 () -> {
                     persistInstance(updated);
@@ -317,7 +319,7 @@ public class SqliteThingStore implements ThingStore {
         ensureSchemaReady();
         EntityInstance updated =
                 MutableEntityInstance.fromExisting(instance).replace(draft).toEntityInstance();
-        writeValidator.assertValidForAmendment(updated);
+        writeValidator.assertValidForReplacement(updated, instance);
         runInTransaction(
                 () -> {
                     persistInstance(updated);

--- a/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/repository/validation/EntityInstanceWriteValidator.java
+++ b/ercoremodel/src/main/java/uk/co/compendiumdev/thingifier/core/repository/validation/EntityInstanceWriteValidator.java
@@ -1,42 +1,242 @@
 package uk.co.compendiumdev.thingifier.core.repository.validation;
 
 import java.util.List;
+import java.util.function.Supplier;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.ERSchema;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldType;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.validation.EntityDomainValidationContext;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.validation.EntityDomainValidator;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.validation.GlobalValidationContext;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.validation.GlobalValidator;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.validation.InstanceValidationContext;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.validation.InstanceValidator;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.validation.ValidationOperation;
 import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
 import uk.co.compendiumdev.thingifier.core.reporting.ValidationReport;
+import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
 
+/**
+ * Runs the ordered write validation pipeline for materialized entity candidates.
+ *
+ * <p>The repository owns this pipeline because it has the final candidate instance: create IDs have
+ * already been prepared, and amend/replace drafts have already been merged with the existing
+ * instance. Each stage collects all errors within that stage and short-circuits before later stages
+ * so expensive or stateful validators do not run against structurally invalid data.
+ */
 public final class EntityInstanceWriteValidator {
 
     private final EntityUniquenessChecker uniquenessChecker;
+    private final Supplier<ERSchema> schemaSupplier;
+    private final ThingStore store;
 
+    /**
+     * Creates a validator that can run field and uniqueness checks.
+     *
+     * <p>This constructor is retained for callers that do not have a store-backed schema context.
+     * Entity domain and global validators are skipped when no schema/store is supplied.
+     *
+     * @param uniquenessChecker uniqueness checker for built-in unique field rules
+     */
     public EntityInstanceWriteValidator(final EntityUniquenessChecker uniquenessChecker) {
-        this.uniquenessChecker = uniquenessChecker;
+        this(uniquenessChecker, () -> null, null);
     }
 
+    /**
+     * Creates a validator that can run the full field, instance, entity domain, and global
+     * pipeline.
+     *
+     * @param uniquenessChecker uniqueness checker for built-in unique field rules
+     * @param schemaSupplier supplier for the active schema at write time
+     * @param store active store used by entity domain and global validators
+     */
+    public EntityInstanceWriteValidator(
+            final EntityUniquenessChecker uniquenessChecker,
+            final Supplier<ERSchema> schemaSupplier,
+            final ThingStore store) {
+        this.uniquenessChecker = uniquenessChecker;
+        this.schemaSupplier = schemaSupplier;
+        this.store = store;
+    }
+
+    /**
+     * Validates a fully prepared create candidate and throws if invalid.
+     *
+     * @param instance candidate instance to validate
+     */
     public void assertValidForCreate(final EntityInstance instance) {
         throwIfInvalid(validateForCreate(instance));
     }
 
+    /**
+     * Validates an amendment candidate where no existing instance context is available.
+     *
+     * @param instance candidate instance to validate
+     */
     public void assertValidForAmendment(final EntityInstance instance) {
         throwIfInvalid(validateForAmendment(instance));
     }
 
-    public ValidationReport validateForCreate(final EntityInstance instance) {
-        return validateForWrite(instance, false);
+    /**
+     * Validates an amendment candidate with access to the persisted instance being changed.
+     *
+     * @param candidate materialized amendment candidate
+     * @param existing existing persisted instance
+     */
+    public void assertValidForAmendment(
+            final EntityInstance candidate, final EntityInstance existing) {
+        throwIfInvalid(validateForAmendment(candidate, existing));
     }
 
+    /**
+     * Validates a replacement candidate with access to the persisted instance being replaced.
+     *
+     * @param candidate materialized replacement candidate
+     * @param existing existing persisted instance
+     */
+    public void assertValidForReplacement(
+            final EntityInstance candidate, final EntityInstance existing) {
+        throwIfInvalid(validateForReplacement(candidate, existing));
+    }
+
+    /**
+     * Runs the create validation pipeline.
+     *
+     * @param instance candidate instance to validate
+     * @return validation report for the first failing stage, or a valid report
+     */
+    public ValidationReport validateForCreate(final EntityInstance instance) {
+        return validateForWrite(instance, null, ValidationOperation.CREATE);
+    }
+
+    /**
+     * Runs the amendment validation pipeline without persisted instance context.
+     *
+     * @param instance candidate instance to validate
+     * @return validation report for the first failing stage, or a valid report
+     */
     public ValidationReport validateForAmendment(final EntityInstance instance) {
-        return validateForWrite(instance, true);
+        return validateForWrite(instance, null, ValidationOperation.AMEND);
+    }
+
+    /**
+     * Runs the amendment validation pipeline with persisted instance context.
+     *
+     * @param candidate materialized amendment candidate
+     * @param existing existing persisted instance
+     * @return validation report for the first failing stage, or a valid report
+     */
+    public ValidationReport validateForAmendment(
+            final EntityInstance candidate, final EntityInstance existing) {
+        return validateForWrite(candidate, existing, ValidationOperation.AMEND);
+    }
+
+    /**
+     * Runs the replacement validation pipeline with persisted instance context.
+     *
+     * @param candidate materialized replacement candidate
+     * @param existing existing persisted instance
+     * @return validation report for the first failing stage, or a valid report
+     */
+    public ValidationReport validateForReplacement(
+            final EntityInstance candidate, final EntityInstance existing) {
+        return validateForWrite(candidate, existing, ValidationOperation.REPLACE);
     }
 
     private ValidationReport validateForWrite(
-            final EntityInstance instance, final boolean isAmendment) {
+            final EntityInstance instance,
+            final EntityInstance existing,
+            final ValidationOperation operation) {
         List<String> protectedFields =
                 instance.getEntity()
                         .getFieldNamesOfType(FieldType.AUTO_INCREMENT, FieldType.AUTO_GUID);
-        ValidationReport validation = instance.validateFieldValues(protectedFields, false);
-        validation.combine(uniquenessChecker.checkFieldsForUniqueness(instance, isAmendment));
+        ValidationReport validation =
+                instance.validateBuiltInFieldValuesForNormalWrite(protectedFields);
+        if (!validation.isValid()) {
+            return validation;
+        }
+
+        validation.combine(
+                uniquenessChecker.checkFieldsForUniqueness(
+                        instance, operation != ValidationOperation.CREATE));
+        if (!validation.isValid()) {
+            return validation;
+        }
+
+        validation.combine(instance.validateCustomFieldValues(List.of()));
+        if (!validation.isValid()) {
+            return validation;
+        }
+
+        validation.combine(validateInstanceRules(instance, existing, operation));
+        if (!validation.isValid()) {
+            return validation;
+        }
+
+        validation.combine(validateEntityDomainRules(instance, existing, operation));
+        if (!validation.isValid()) {
+            return validation;
+        }
+
+        validation.combine(validateGlobalRules(instance, existing, operation));
         return validation;
+    }
+
+    private ValidationReport validateInstanceRules(
+            final EntityInstance instance,
+            final EntityInstance existing,
+            final ValidationOperation operation) {
+        ValidationReport report = new ValidationReport();
+        InstanceValidationContext context =
+                new InstanceValidationContext(instance, existing, operation);
+        for (InstanceValidator validator : instance.getEntity().instanceValidators()) {
+            ValidationReport validation = validator.validate(context);
+            if (validation != null) {
+                report.combine(validation);
+            }
+        }
+        return report;
+    }
+
+    private ValidationReport validateEntityDomainRules(
+            final EntityInstance instance,
+            final EntityInstance existing,
+            final ValidationOperation operation) {
+        ValidationReport report = new ValidationReport();
+        ERSchema schema = schemaSupplier.get();
+        if (schema == null || store == null) {
+            return report;
+        }
+
+        EntityDomainValidationContext context =
+                new EntityDomainValidationContext(schema, store, instance, existing, operation);
+        for (EntityDomainValidator validator : instance.getEntity().domainValidators()) {
+            ValidationReport validation = validator.validate(context);
+            if (validation != null) {
+                report.combine(validation);
+            }
+        }
+        return report;
+    }
+
+    private ValidationReport validateGlobalRules(
+            final EntityInstance instance,
+            final EntityInstance existing,
+            final ValidationOperation operation) {
+        ValidationReport report = new ValidationReport();
+        ERSchema schema = schemaSupplier.get();
+        if (schema == null || store == null) {
+            return report;
+        }
+
+        GlobalValidationContext context =
+                new GlobalValidationContext(schema, store, instance, existing, operation);
+        for (GlobalValidator validator : schema.globalValidators()) {
+            ValidationReport validation = validator.validate(context);
+            if (validation != null) {
+                report.combine(validation);
+            }
+        }
+        return report;
     }
 
     private void throwIfInvalid(final ValidationReport validation) {

--- a/ercoremodel/src/test/java/uk/co/compendiumdev/thingifier/core/domain/definitions/field/definition/AutoIncrementIdFieldTest.java
+++ b/ercoremodel/src/test/java/uk/co/compendiumdev/thingifier/core/domain/definitions/field/definition/AutoIncrementIdFieldTest.java
@@ -30,7 +30,7 @@ class AutoIncrementIdFieldTest {
         // e.g. for cloning, and for setting objects
         final Field field = Field.is("id", FieldType.AUTO_INCREMENT);
 
-        final ValidationReport report = field.validate(FieldValue.is(field, "1"), true);
+        final ValidationReport report = field.validateForProtectedWrite(FieldValue.is(field, "1"));
         Assertions.assertTrue(report.isValid());
     }
 

--- a/ercoremodel/src/test/java/uk/co/compendiumdev/thingifier/core/domain/definitions/field/definition/StringFieldTest.java
+++ b/ercoremodel/src/test/java/uk/co/compendiumdev/thingifier/core/domain/definitions/field/definition/StringFieldTest.java
@@ -1,5 +1,6 @@
 package uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.field.instance.FieldValue;
@@ -96,6 +97,44 @@ class StringFieldTest {
     }
 
     @Test
+    void customValidationRunsAfterStandardRulesPass() {
+        final AtomicInteger calls = new AtomicInteger();
+        final Field field =
+                Field.is("field", FieldType.STRING)
+                        .withValidation(VRule.notEmpty())
+                        .withCustomValidation(
+                                value -> {
+                                    calls.incrementAndGet();
+                                    return invalidReport("custom field rejected");
+                                });
+
+        final ValidationReport report = field.validate(FieldValue.is(field, "value"));
+
+        Assertions.assertFalse(report.isValid());
+        Assertions.assertEquals(1, calls.get());
+        Assertions.assertTrue(report.getCombinedErrorMessages().contains("custom field rejected"));
+    }
+
+    @Test
+    void customValidationIsSkippedWhenStandardRulesFail() {
+        final AtomicInteger calls = new AtomicInteger();
+        final Field field =
+                Field.is("field", FieldType.STRING)
+                        .withValidation(VRule.notEmpty())
+                        .withCustomValidation(
+                                value -> {
+                                    calls.incrementAndGet();
+                                    return invalidReport("custom field rejected");
+                                });
+
+        final ValidationReport report = field.validate(FieldValue.is(field, ""));
+
+        Assertions.assertFalse(report.isValid());
+        Assertions.assertEquals(0, calls.get());
+        Assertions.assertFalse(report.getCombinedErrorMessages().contains("custom field rejected"));
+    }
+
+    @Test
     void byDefaultTheStringHasNoValidationRules() {
 
         final Field field = Field.is("field", FieldType.STRING);
@@ -112,5 +151,9 @@ class StringFieldTest {
         Assertions.assertEquals("1234", field.getActualValueToAdd(FieldValue.is(field, "12345")));
 
         Assertions.assertEquals("123", field.getActualValueToAdd(FieldValue.is(field, "123")));
+    }
+
+    private ValidationReport invalidReport(final String message) {
+        return new ValidationReport().setValid(false).addErrorMessage(message);
     }
 }

--- a/ercoremodel/src/test/java/uk/co/compendiumdev/thingifier/core/domain/instances/InstanceFieldsTest.java
+++ b/ercoremodel/src/test/java/uk/co/compendiumdev/thingifier/core/domain/instances/InstanceFieldsTest.java
@@ -208,7 +208,8 @@ class InstanceFieldsTest {
         Assertions.assertEquals("bob", instance.getFieldValue("int").asString());
 
         // but validation should fail
-        final ValidationReport validation = instance.validateFields(new ArrayList<>(), false);
+        final ValidationReport validation =
+                instance.validateFieldsForNormalWrite(new ArrayList<>());
         Assertions.assertFalse(validation.isValid());
     }
 

--- a/ercoremodel/src/test/java/uk/co/compendiumdev/thingifier/core/repository/CustomValidationPipelineTest.java
+++ b/ercoremodel/src/test/java/uk/co/compendiumdev/thingifier/core/repository/CustomValidationPipelineTest.java
@@ -1,0 +1,389 @@
+package uk.co.compendiumdev.thingifier.core.repository;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.co.compendiumdev.thingifier.core.EntityRelModel;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.Cardinality;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.ERSchema;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.Field;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldType;
+import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
+import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstanceDraft;
+import uk.co.compendiumdev.thingifier.core.reporting.ValidationReport;
+import uk.co.compendiumdev.thingifier.core.repository.inmemory.InMemoryThingStore;
+import uk.co.compendiumdev.thingifier.core.repository.sqlite.SqliteThingStore;
+
+class CustomValidationPipelineTest {
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("stores")
+    void customFieldValidatorRejectsCreate(
+            final String storeName, final StoreFactory storeFactory) {
+        final ERSchema schema = taskSchema();
+        final EntityDefinition task = schema.getEntityDefinitionNamed("task");
+        task.getField("title")
+                .withCustomValidation(value -> invalidReport("custom field rejected"));
+
+        try (ThingStore store = initializedStore(storeFactory, schema)) {
+            final IllegalArgumentException thrown =
+                    Assertions.assertThrows(
+                            IllegalArgumentException.class,
+                            () -> createTask(store, task, "custom"));
+
+            Assertions.assertTrue(thrown.getMessage().contains("custom field rejected"), storeName);
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("stores")
+    void instanceValidatorRejectsInconsistentCandidate(
+            final String storeName, final StoreFactory storeFactory) {
+        final ERSchema schema = taskSchema();
+        final EntityDefinition task = schema.getEntityDefinitionNamed("task");
+        task.addField(Field.is("start", FieldType.INTEGER).makeMandatory());
+        task.addField(Field.is("end", FieldType.INTEGER).makeMandatory());
+        task.withInstanceValidation(
+                context -> {
+                    final int start = context.candidate().getFieldValue("start").asInteger();
+                    final int end = context.candidate().getFieldValue("end").asInteger();
+                    if (start > end) {
+                        return invalidReport("start must be before end");
+                    }
+                    return new ValidationReport();
+                });
+
+        try (ThingStore store = initializedStore(storeFactory, schema)) {
+            final IllegalArgumentException thrown =
+                    Assertions.assertThrows(
+                            IllegalArgumentException.class,
+                            () ->
+                                    store.entities()
+                                            .create(
+                                                    EntityInstanceDraft.forEntity(task)
+                                                            .withField("title", "bad range")
+                                                            .withField("start", "10")
+                                                            .withField("end", "5")));
+
+            Assertions.assertTrue(
+                    thrown.getMessage().contains("start must be before end"), storeName);
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("stores")
+    void instanceValidatorIsSkippedWhenBuiltInFieldValidationFails(
+            final String storeName, final StoreFactory storeFactory) {
+        final AtomicInteger calls = new AtomicInteger();
+        final ERSchema schema = taskSchema();
+        final EntityDefinition task = schema.getEntityDefinitionNamed("task");
+        task.addField(Field.is("start", FieldType.INTEGER).makeMandatory());
+        task.withInstanceValidation(
+                context -> {
+                    calls.incrementAndGet();
+                    return invalidReport("instance validator should not run");
+                });
+
+        try (ThingStore store = initializedStore(storeFactory, schema)) {
+            final IllegalArgumentException thrown =
+                    Assertions.assertThrows(
+                            IllegalArgumentException.class,
+                            () ->
+                                    store.entities()
+                                            .create(
+                                                    EntityInstanceDraft.forEntity(task)
+                                                            .withField("title", "missing start")));
+
+            Assertions.assertTrue(thrown.getMessage().contains("start : field is mandatory"));
+            Assertions.assertEquals(0, calls.get(), storeName);
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("stores")
+    void entityDomainValidatorCanCompareCandidateWithStoredInstances(
+            final String storeName, final StoreFactory storeFactory) {
+        final ERSchema schema = taskSchema();
+        final EntityDefinition task = schema.getEntityDefinitionNamed("task");
+        task.withDomainValidation(
+                context -> {
+                    final String title = context.candidate().getFieldValue("title").asString();
+                    final EntityInstance found =
+                            context.store().entityQueries().findByField(task, "title", title);
+                    if (found != null
+                            && !found.getInternalId().equals(context.candidate().getInternalId())) {
+                        return invalidReport("title already exists in domain");
+                    }
+                    return new ValidationReport();
+                });
+
+        try (ThingStore store = initializedStore(storeFactory, schema)) {
+            createTask(store, task, "duplicate");
+
+            final IllegalArgumentException thrown =
+                    Assertions.assertThrows(
+                            IllegalArgumentException.class,
+                            () -> createTask(store, task, "duplicate"));
+
+            Assertions.assertTrue(
+                    thrown.getMessage().contains("title already exists in domain"), storeName);
+            Assertions.assertEquals(1, store.entityQueries().count(task));
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("stores")
+    void entityDomainValidatorOnlyRunsForItsOwningEntity(
+            final String storeName, final StoreFactory storeFactory) {
+        final AtomicInteger calls = new AtomicInteger();
+        final ERSchema schema = taskSchema();
+        final EntityDefinition task = schema.getEntityDefinitionNamed("task");
+        task.withDomainValidation(
+                context -> {
+                    calls.incrementAndGet();
+                    return invalidReport("task domain validator should not run");
+                });
+        final EntityDefinition project = schema.defineEntity("project", "projects", -1);
+        project.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT));
+        project.addField(Field.is("title", FieldType.STRING).makeMandatory());
+
+        try (ThingStore store = initializedStore(storeFactory, schema)) {
+            store.entities()
+                    .create(EntityInstanceDraft.forEntity(project).withField("title", "project"));
+
+            Assertions.assertEquals(0, calls.get(), storeName);
+            Assertions.assertEquals(1, store.entityQueries().count(project));
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("stores")
+    void globalValidatorCanCompareCandidateWithStoredInstances(
+            final String storeName, final StoreFactory storeFactory) {
+        final ERSchema schema = taskSchema();
+        final EntityDefinition task = schema.getEntityDefinitionNamed("task");
+        schema.withGlobalValidation(
+                context -> {
+                    final String title = context.candidate().getFieldValue("title").asString();
+                    final EntityInstance found =
+                            context.store().entityQueries().findByField(task, "title", title);
+                    if (found != null
+                            && !found.getInternalId().equals(context.candidate().getInternalId())) {
+                        return invalidReport("title already exists globally");
+                    }
+                    return new ValidationReport();
+                });
+
+        try (ThingStore store = initializedStore(storeFactory, schema)) {
+            createTask(store, task, "duplicate");
+
+            final IllegalArgumentException thrown =
+                    Assertions.assertThrows(
+                            IllegalArgumentException.class,
+                            () -> createTask(store, task, "duplicate"));
+
+            Assertions.assertTrue(
+                    thrown.getMessage().contains("title already exists globally"), storeName);
+            Assertions.assertEquals(1, store.entityQueries().count(task));
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("stores")
+    void instanceValidatorRunsForAmend(final String storeName, final StoreFactory storeFactory) {
+        final ERSchema schema = taskSchema();
+        final EntityDefinition task = schema.getEntityDefinitionNamed("task");
+        task.addField(Field.is("start", FieldType.INTEGER).makeMandatory());
+        task.addField(Field.is("end", FieldType.INTEGER).makeMandatory());
+        task.withInstanceValidation(
+                context -> {
+                    if (context.candidate().getFieldValue("start").asInteger()
+                            > context.candidate().getFieldValue("end").asInteger()) {
+                        return invalidReport("amended instance is inconsistent");
+                    }
+                    return new ValidationReport();
+                });
+
+        try (ThingStore store = initializedStore(storeFactory, schema)) {
+            final EntityInstance existing =
+                    store.entities()
+                            .create(
+                                    EntityInstanceDraft.forEntity(task)
+                                            .withField("title", "range")
+                                            .withField("start", "1")
+                                            .withField("end", "2"));
+
+            final IllegalArgumentException thrown =
+                    Assertions.assertThrows(
+                            IllegalArgumentException.class,
+                            () ->
+                                    store.entities()
+                                            .patch(
+                                                    existing,
+                                                    EntityInstanceDraft.forEntity(task)
+                                                            .withField("end", "0")));
+
+            Assertions.assertTrue(
+                    thrown.getMessage().contains("amended instance is inconsistent"), storeName);
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("stores")
+    void instanceValidatorRunsForReplace(final String storeName, final StoreFactory storeFactory) {
+        final ERSchema schema = taskSchema();
+        final EntityDefinition task = schema.getEntityDefinitionNamed("task");
+        task.addField(Field.is("start", FieldType.INTEGER).makeMandatory());
+        task.addField(Field.is("end", FieldType.INTEGER).makeMandatory());
+        task.withInstanceValidation(
+                context -> {
+                    if (context.candidate().getFieldValue("start").asInteger()
+                            > context.candidate().getFieldValue("end").asInteger()) {
+                        return invalidReport("replacement is inconsistent");
+                    }
+                    return new ValidationReport();
+                });
+
+        try (ThingStore store = initializedStore(storeFactory, schema)) {
+            final EntityInstance existing =
+                    store.entities()
+                            .create(
+                                    EntityInstanceDraft.forEntity(task)
+                                            .withField("title", "range")
+                                            .withField("start", "1")
+                                            .withField("end", "2"));
+
+            final IllegalArgumentException thrown =
+                    Assertions.assertThrows(
+                            IllegalArgumentException.class,
+                            () ->
+                                    store.entities()
+                                            .replace(
+                                                    existing,
+                                                    EntityInstanceDraft.forEntity(task)
+                                                            .withField("title", "range")
+                                                            .withField("start", "5")
+                                                            .withField("end", "1")));
+
+            Assertions.assertTrue(
+                    thrown.getMessage().contains("replacement is inconsistent"), storeName);
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("stores")
+    void pureRelationshipConnectDoesNotRunEntityDomainValidators(
+            final String storeName, final StoreFactory storeFactory) {
+        final AtomicInteger calls = new AtomicInteger();
+        final ERSchema schema = taskSchema();
+        final EntityDefinition project = schema.defineEntity("project", "projects", -1);
+        project.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT));
+        project.addField(Field.is("title", FieldType.STRING).makeMandatory());
+        final EntityDefinition task = schema.getEntityDefinitionNamed("task");
+        schema.defineRelationship(project, task, "tasks", Cardinality.ONE_TO_MANY());
+
+        try (ThingStore store = initializedStore(storeFactory, schema)) {
+            final EntityInstance projectInstance =
+                    store.entities()
+                            .create(
+                                    EntityInstanceDraft.forEntity(project)
+                                            .withField("title", "project"));
+            final EntityInstance taskInstance = createTask(store, task, "task");
+            task.withDomainValidation(
+                    context -> {
+                        calls.incrementAndGet();
+                        return invalidReport("entity domain validator should not run");
+                    });
+
+            store.relationships().connect(projectInstance, "tasks", taskInstance);
+
+            Assertions.assertEquals(0, calls.get(), storeName);
+            Assertions.assertTrue(
+                    store.relationships()
+                            .listRelated(projectInstance, "tasks")
+                            .contains(taskInstance));
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("stores")
+    void pureRelationshipConnectDoesNotRunGlobalValidators(
+            final String storeName, final StoreFactory storeFactory) {
+        final AtomicInteger calls = new AtomicInteger();
+        final ERSchema schema = taskSchema();
+        final EntityDefinition project = schema.defineEntity("project", "projects", -1);
+        project.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT));
+        project.addField(Field.is("title", FieldType.STRING).makeMandatory());
+        final EntityDefinition task = schema.getEntityDefinitionNamed("task");
+        schema.defineRelationship(project, task, "tasks", Cardinality.ONE_TO_MANY());
+
+        try (ThingStore store = initializedStore(storeFactory, schema)) {
+            final EntityInstance projectInstance =
+                    store.entities()
+                            .create(
+                                    EntityInstanceDraft.forEntity(project)
+                                            .withField("title", "project"));
+            final EntityInstance taskInstance = createTask(store, task, "task");
+            schema.withGlobalValidation(
+                    context -> {
+                        calls.incrementAndGet();
+                        return invalidReport("global validator should not run");
+                    });
+
+            store.relationships().connect(projectInstance, "tasks", taskInstance);
+
+            Assertions.assertEquals(0, calls.get(), storeName);
+            Assertions.assertTrue(
+                    store.relationships()
+                            .listRelated(projectInstance, "tasks")
+                            .contains(taskInstance));
+        }
+    }
+
+    private static Stream<Arguments> stores() {
+        return Stream.of(
+                Arguments.of(
+                        "in-memory",
+                        (StoreFactory)
+                                () -> new InMemoryThingStore(EntityRelModel.DEFAULT_DATABASE_NAME)),
+                Arguments.of(
+                        "sqlite",
+                        (StoreFactory)
+                                () ->
+                                        SqliteThingStore.inMemory(
+                                                EntityRelModel.DEFAULT_DATABASE_NAME)));
+    }
+
+    private static ThingStore initializedStore(
+            final StoreFactory storeFactory, final ERSchema schema) {
+        final ThingStore store = storeFactory.create();
+        store.administration().initializeFrom(schema);
+        return store;
+    }
+
+    private static ERSchema taskSchema() {
+        final ERSchema schema = new ERSchema();
+        final EntityDefinition task = schema.defineEntity("task", "tasks", -1);
+        task.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT));
+        task.addField(Field.is("title", FieldType.STRING).makeMandatory());
+        return schema;
+    }
+
+    private static EntityInstance createTask(
+            final ThingStore store, final EntityDefinition task, final String title) {
+        return store.entities()
+                .create(EntityInstanceDraft.forEntity(task).withField("title", title));
+    }
+
+    private static ValidationReport invalidReport(final String message) {
+        return new ValidationReport().setValid(false).addErrorMessage(message);
+    }
+
+    private interface StoreFactory {
+        ThingStore create();
+    }
+}

--- a/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceSchemaUpgradeService.java
+++ b/thingifier-crud-ui/src/main/java/uk/co/compendiumdev/thingifier/crudui/WorkspaceSchemaUpgradeService.java
@@ -441,7 +441,8 @@ public final class WorkspaceSchemaUpgradeService {
         for (EntityDefinitionSpec entitySpec : targetDefinition.entities()) {
             EntityDefinition entity = targetThingifier.getDefinitionNamed(entitySpec.name());
             for (EntityInstance instance : store.entityQueries().list(entity)) {
-                ValidationReport fieldValidation = instance.validateFieldValues(List.of(), true);
+                ValidationReport fieldValidation =
+                        instance.validateFieldValuesForProtectedWrite(List.of());
                 if (!fieldValidation.isValid()) {
                     result.addBlockingError(
                             "entities." + entitySpec.name(),

--- a/thingifier-yaml/src/test/java/uk/co/compendiumdev/thingifier/yaml/ThingifierYamlExporterTest.java
+++ b/thingifier-yaml/src/test/java/uk/co/compendiumdev/thingifier/yaml/ThingifierYamlExporterTest.java
@@ -5,8 +5,12 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.application.schema.definition.ThingifierModelDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.Field;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldRelationshipReference;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldType;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.relationship.RelationshipVectorDefinition;
+import uk.co.compendiumdev.thingifier.core.reporting.ValidationReport;
 
 class ThingifierYamlExporterTest {
 
@@ -95,6 +99,30 @@ class ThingifierYamlExporterTest {
         Assertions.assertTrue(yaml.contains("source:"));
     }
 
+    @Test
+    void exporterOmitsCodeOnlyCustomValidators() {
+        Thingifier thingifier = new Thingifier();
+        EntityDefinition item = thingifier.defineThing("item", "items");
+        item.addAsPrimaryKeyField(Field.is("id", FieldType.AUTO_INCREMENT));
+        item.addField(
+                Field.is("title", FieldType.STRING)
+                        .withCustomValidation(value -> invalidReport("not exportable")));
+        item.withInstanceValidation(context -> invalidReport("not exportable"));
+        item.withDomainValidation(context -> invalidReport("not exportable"));
+        thingifier.withGlobalValidation(context -> invalidReport("not exportable"));
+
+        String yaml = new ThingifierYamlExporter().export(thingifier);
+        Thingifier loaded = new ThingifierYamlLoader().loadThingifier(yaml);
+
+        Assertions.assertFalse(yaml.contains("not exportable"));
+        Assertions.assertFalse(yaml.contains("custom"));
+        Assertions.assertTrue(
+                loaded.getDefinitionNamed("item").getField("title").customValidators().isEmpty());
+        Assertions.assertTrue(loaded.getDefinitionNamed("item").instanceValidators().isEmpty());
+        Assertions.assertTrue(loaded.getDefinitionNamed("item").domainValidators().isEmpty());
+        Assertions.assertTrue(loaded.getERmodel().getSchema().globalValidators().isEmpty());
+    }
+
     private InputStream resource(final String resourceName) {
         InputStream stream = getClass().getResourceAsStream("/models/" + resourceName);
         Assertions.assertNotNull(stream, resourceName);
@@ -133,5 +161,9 @@ class ThingifierYamlExporterTest {
                 + "    optionality: optional\n"
                 + "    deleteTargetWhenDisconnected: true\n"
                 + "    deleteTargetsWhenSourceDeleted: true\n";
+    }
+
+    private ValidationReport invalidReport(final String message) {
+        return new ValidationReport().setValid(false).addErrorMessage(message);
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/Thingifier.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/Thingifier.java
@@ -12,6 +12,7 @@ import uk.co.compendiumdev.thingifier.core.EntityRelModel;
 import uk.co.compendiumdev.thingifier.core.domain.datapopulator.RepositoryDataPopulator;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.*;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.relationship.RelationshipDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.validation.GlobalValidator;
 import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
 import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
 import uk.co.compendiumdev.thingifier.htmlgui.ThingifierGuiConfig;
@@ -93,6 +94,32 @@ public final class Thingifier implements AutoCloseable {
     public EntityDefinition defineThing(
             final String thingName, final String pluralName, final int maximumNumberOfInstances) {
         return erm.createEntityDefinition(thingName, pluralName, maximumNumberOfInstances);
+    }
+
+    /**
+     * Adds a schema-wide validator that runs for every entity write.
+     *
+     * <p>This is a convenience delegate for application code that builds models through {@code
+     * Thingifier}. Use {@link EntityDefinition#withDomainValidation} when a rule belongs to one
+     * entity but needs wider domain access.
+     *
+     * @param validationRule validator to add to the underlying schema
+     * @return this thingifier for fluent setup
+     */
+    public Thingifier withGlobalValidation(final GlobalValidator validationRule) {
+        erm.withGlobalValidation(validationRule);
+        return this;
+    }
+
+    /**
+     * Adds schema-wide validators that run for every entity write.
+     *
+     * @param validationRule validators to add to the underlying schema
+     * @return this thingifier for fluent setup
+     */
+    public Thingifier withGlobalValidation(final GlobalValidator... validationRule) {
+        erm.withGlobalValidation(validationRule);
+        return this;
     }
 
     public boolean hasThingNamed(final String aName) {

--- a/thingifier/src/test/java/uk/co/compendiumdev/casestudy/todomanager/unit/OptionalityRelationshipTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/casestudy/todomanager/unit/OptionalityRelationshipTest.java
@@ -62,7 +62,8 @@ public class OptionalityRelationshipTest {
                                                 "I need to tidy up my room because it is a mess"));
         Assertions.assertEquals("Tidy up my room", tidy.getFieldValue("title").asString());
 
-        Assertions.assertTrue(tidy.validateFieldValues(new ArrayList<>(), true).isValid());
+        Assertions.assertTrue(
+                tidy.validateFieldValuesForProtectedWrite(new ArrayList<>()).isValid());
     }
 
     @Test

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/application/ThingCommandServiceTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/application/ThingCommandServiceTest.java
@@ -16,6 +16,7 @@ import uk.co.compendiumdev.thingifier.application.command.RelateThingCommand;
 import uk.co.compendiumdev.thingifier.application.command.RelationshipReference;
 import uk.co.compendiumdev.thingifier.application.command.ReplaceThingCommand;
 import uk.co.compendiumdev.thingifier.application.command.ThingWriteCommand;
+import uk.co.compendiumdev.thingifier.application.command.UpdateConnectedRelationshipCommand;
 import uk.co.compendiumdev.thingifier.core.EntityRelModel;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.Cardinality;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
@@ -26,6 +27,7 @@ import uk.co.compendiumdev.thingifier.core.domain.definitions.relationship.Optio
 import uk.co.compendiumdev.thingifier.core.domain.definitions.relationship.RelationshipDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
 import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstanceDraft;
+import uk.co.compendiumdev.thingifier.core.reporting.ValidationReport;
 import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
 
 public class ThingCommandServiceTest {
@@ -948,6 +950,46 @@ public class ThingCommandServiceTest {
     }
 
     @Test
+    public void createAndConnectRelationshipCommandRunsCustomValidationForCreatedChild() {
+        Thingifier thingifier = taskProjectThingifier();
+        EntityDefinition task = thingifier.getDefinitionNamed("task");
+        task.withInstanceValidation(
+                context -> {
+                    if ("Rejected title"
+                            .equals(context.candidate().getFieldValue("title").asString())) {
+                        return invalidReport("relationship target create rejected");
+                    }
+                    return new ValidationReport();
+                });
+        ThingStore store = storeFor(thingifier);
+        EntityDefinition project = thingifier.getDefinitionNamed("project");
+        EntityInstance projectInstance =
+                store.entities()
+                        .create(
+                                EntityInstanceDraft.forEntity(project)
+                                        .withField("title", "Project"));
+        int taskCount = store.entityQueries().count(task);
+
+        ThingCommandResult result =
+                serviceFor(thingifier, store)
+                        .execute(
+                                new CreateAndConnectRelationshipCommand(
+                                        project.getName(),
+                                        projectInstance.getPrimaryKeyValue(),
+                                        "tasks",
+                                        task.getName(),
+                                        fields("title", "Rejected title"),
+                                        List.of()));
+
+        Assertions.assertTrue(result.isError());
+        Assertions.assertTrue(
+                result.getCombinedErrorMessage().contains("relationship target create rejected"));
+        Assertions.assertEquals(taskCount, store.entityQueries().count(task));
+        Assertions.assertTrue(
+                store.relationships().listRelated(projectInstance, "tasks").isEmpty());
+    }
+
+    @Test
     public void relateCommandConnectsExistingTargetWithoutCreatingChild() {
         Thingifier thingifier = taskProjectThingifier();
         ThingStore store = storeFor(thingifier);
@@ -1067,6 +1109,54 @@ public class ThingCommandServiceTest {
         Assertions.assertEquals(
                 result.getInstance(),
                 store.relationships().listRelated(projectInstance, "tasks").get(0));
+    }
+
+    @Test
+    public void updateConnectedRelationshipCommandRunsCustomValidationForUpdatedChild() {
+        Thingifier thingifier = taskProjectThingifier();
+        EntityDefinition task = thingifier.getDefinitionNamed("task");
+        task.withInstanceValidation(
+                context -> {
+                    if ("Rejected update"
+                            .equals(context.candidate().getFieldValue("title").asString())) {
+                        return invalidReport("relationship target update rejected");
+                    }
+                    return new ValidationReport();
+                });
+        ThingStore store = storeFor(thingifier);
+        EntityDefinition project = thingifier.getDefinitionNamed("project");
+        EntityInstance taskInstance =
+                store.entities()
+                        .create(
+                                EntityInstanceDraft.forEntity(task)
+                                        .withField("title", "Existing task"));
+        EntityInstance projectInstance =
+                store.entities()
+                        .create(
+                                EntityInstanceDraft.forEntity(project)
+                                        .withField("title", "Project"));
+        store.relationships().connect(projectInstance, "tasks", taskInstance);
+        List<NamedValue> childFields =
+                fields("guid", taskInstance.getPrimaryKeyValue(), "title", "Rejected update");
+
+        ThingCommandResult result =
+                serviceFor(thingifier, store)
+                        .execute(
+                                new UpdateConnectedRelationshipCommand(
+                                        project.getName(),
+                                        projectInstance.getPrimaryKeyValue(),
+                                        "tasks",
+                                        childFields,
+                                        BodyFieldValue.fromNamedValues(childFields),
+                                        List.of()));
+
+        EntityInstance unchanged =
+                store.entityQueries()
+                        .findByQueryIdentifier(task, taskInstance.getPrimaryKeyValue());
+        Assertions.assertTrue(result.isError());
+        Assertions.assertTrue(
+                result.getCombinedErrorMessage().contains("relationship target update rejected"));
+        Assertions.assertEquals("Existing task", unchanged.getFieldValue("title").asString());
     }
 
     private Thingifier taskProjectThingifier() {
@@ -1210,9 +1300,22 @@ public class ThingCommandServiceTest {
         return List.of(new NamedValue(name, value));
     }
 
+    private List<NamedValue> fields(
+            final String firstName,
+            final String firstValue,
+            final String secondName,
+            final String secondValue) {
+        return List.of(
+                new NamedValue(firstName, firstValue), new NamedValue(secondName, secondValue));
+    }
+
     private BodyFieldValue bodyField(
             final String name, final String value, final BodyFieldValue.SourceType sourceType) {
         return new BodyFieldValue(name, value, sourceType);
+    }
+
+    private ValidationReport invalidReport(final String message) {
+        return new ValidationReport().setValid(false).addErrorMessage(message);
     }
 
     private static final class UnsupportedThingWriteCommand implements ThingWriteCommand {}


### PR DESCRIPTION
## Summary
- Add code-only field, instance, entity domain, and global validators.
- Run entity writes through the ordered validation pipeline: built-in fields, uniqueness, custom fields, instance, entity domain, then global.
- Store the active schema in memory and SQLite stores so write-time validators can discover entity/domain/global rules.
- Keep YAML import/export unchanged for code-only validators.

## Verification
- `mvn clean verify`

Closes #146