### PR TITLE
Add first-class Basic auth enforcement

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/RouteAuthPolicy.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/RouteAuthPolicy.java
@@ -9,6 +9,7 @@ import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRouteMapper;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
+import uk.co.compendiumdev.thingifier.api.http.headers.headerparser.BasicAuthHeaderParser;
 import uk.co.compendiumdev.thingifier.api.http.headers.headerparser.BearerAuthHeaderParser;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
 import uk.co.compendiumdev.thingifier.api.security.ThingifierApiAuthenticationContext;
@@ -27,7 +28,7 @@ import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 /**
  * Enforces route-level authentication and authorization configured in the API spec.
  *
- * <p>The policy handles the generic HTTP bearer mechanics that belong in Thingifier and delegates
+ * <p>The policy handles the generic HTTP auth mechanics that belong in Thingifier and delegates
  * application decisions to registered authenticators and authorizers. It returns an {@link
  * ApiResponse} only when processing should stop.
  */
@@ -91,7 +92,36 @@ public final class RouteAuthPolicy {
         }
 
         final ThingifierApiRouteRule rule = matchingRule.get();
+        if (rule.hasBasicAuthEnforcement()) {
+            return rejectForBasicAuth(verb, path, context, route, rule);
+        }
+
+        return rejectForBearerAuth(verb, path, context, route, rule);
+    }
+
+    /**
+     * Enforces a named Bearer auth route rule.
+     *
+     * @param verb generated API verb
+     * @param path generated API path
+     * @param context active request context
+     * @param route mapped generated route
+     * @param rule matching route rule
+     * @return rejection response, or null when authentication and authorization succeed
+     */
+    private ApiResponse rejectForBearerAuth(
+            final RoutingVerb verb,
+            final String path,
+            final ThingifierRequestContext context,
+            final ThingRoute route,
+            final ThingifierApiRouteRule rule) {
         final String schemeName = rule.bearerAuthEnforcementSchemeName();
+        final BearerAuthHeaderParser bearer =
+                new BearerAuthHeaderParser(context.headers().get(AUTHORIZATION_HEADER));
+        if (!bearer.isValid()) {
+            return unauthorized(BEARER_CHALLENGE);
+        }
+
         final Optional<ThingifierApiAuthenticator> authenticator =
                 runtime.apiSpec().authenticatorFor(schemeName);
         if (authenticator.isEmpty()) {
@@ -99,20 +129,82 @@ public final class RouteAuthPolicy {
                     500, "No authenticator configured for bearer auth scheme " + schemeName);
         }
 
-        final BearerAuthHeaderParser bearer =
-                new BearerAuthHeaderParser(context.headers().get(AUTHORIZATION_HEADER));
-        if (!bearer.isValid()) {
-            return unauthorized();
+        final ThingifierApiAuthenticationContext authenticationContext =
+                new ThingifierApiAuthenticationContext(
+                        authDetails(schemeName, verb, path, context, route, rule),
+                        bearer.getToken());
+        return rejectAfterAuthentication(
+                rule,
+                context,
+                schemeName,
+                authenticator.get(),
+                authenticationContext,
+                BEARER_CHALLENGE);
+    }
+
+    /**
+     * Enforces a named Basic auth route rule.
+     *
+     * @param verb generated API verb
+     * @param path generated API path
+     * @param context active request context
+     * @param route mapped generated route
+     * @param rule matching route rule
+     * @return rejection response, or null when authentication and authorization succeed
+     */
+    private ApiResponse rejectForBasicAuth(
+            final RoutingVerb verb,
+            final String path,
+            final ThingifierRequestContext context,
+            final ThingRoute route,
+            final ThingifierApiRouteRule rule) {
+        final String schemeName = rule.basicAuthEnforcementSchemeName();
+        final String challenge = basicChallengeFor(schemeName);
+        final BasicAuthHeaderParser basic =
+                new BasicAuthHeaderParser(context.headers().get(AUTHORIZATION_HEADER));
+        if (!basic.isValid()) {
+            return unauthorized(challenge);
+        }
+
+        final Optional<ThingifierApiAuthenticator> authenticator =
+                runtime.apiSpec().authenticatorFor(schemeName);
+        if (authenticator.isEmpty()) {
+            return ApiResponse.error(
+                    500, "No authenticator configured for basic auth scheme " + schemeName);
         }
 
         final ThingifierApiAuthenticationContext authenticationContext =
                 new ThingifierApiAuthenticationContext(
                         authDetails(schemeName, verb, path, context, route, rule),
-                        bearer.getToken());
+                        "",
+                        basic.username(),
+                        basic.password());
+        return rejectAfterAuthentication(
+                rule, context, schemeName, authenticator.get(), authenticationContext, challenge);
+    }
+
+    /**
+     * Runs the shared authenticator/principal/authorizer flow after header parsing succeeds.
+     *
+     * @param rule matching route rule
+     * @param context active request context
+     * @param schemeName enforced security scheme name
+     * @param authenticator application authenticator for the scheme
+     * @param authenticationContext parsed auth context
+     * @param challenge default challenge for framework-generated 401 responses
+     * @return rejection response, or null when auth allows request processing
+     */
+    private ApiResponse rejectAfterAuthentication(
+            final ThingifierApiRouteRule rule,
+            final ThingifierRequestContext context,
+            final String schemeName,
+            final ThingifierApiAuthenticator authenticator,
+            final ThingifierApiAuthenticationContext authenticationContext,
+            final String challenge) {
         final ThingifierApiAuthenticationResult authentication =
-                authenticator.get().authenticate(authenticationContext);
+                authenticator.authenticate(authenticationContext);
         if (authentication == null || !authentication.isAuthenticated()) {
-            return authenticationRejected(authentication);
+            return authenticationRejected(authentication, challenge);
         }
 
         context.setAuthenticatedPrincipal(schemeName, authentication.principal());
@@ -123,10 +215,12 @@ public final class RouteAuthPolicy {
      * Reports whether a route rule has enforceable auth policy.
      *
      * @param rule matching route rule
-     * @return true when bearer auth should be enforced for this request
+     * @return true when named auth should be enforced for this request
      */
     private boolean requiresAuth(final ThingifierApiRouteRule rule) {
-        return !rule.isDisabled() && !rule.isMethodNotAllowed() && rule.hasBearerAuthEnforcement();
+        return !rule.isDisabled()
+                && !rule.isMethodNotAllowed()
+                && (rule.hasBasicAuthEnforcement() || rule.hasBearerAuthEnforcement());
     }
 
     /**
@@ -156,7 +250,7 @@ public final class RouteAuthPolicy {
     /**
      * Creates the callback context details for the protected route.
      *
-     * @param schemeName bearer scheme name
+     * @param schemeName auth scheme name
      * @param verb generated API verb
      * @param path generated API path
      * @param context request context
@@ -196,15 +290,19 @@ public final class RouteAuthPolicy {
      * Converts an authentication failure into a response.
      *
      * @param authentication failed authentication result, possibly null
-     * @return rejection response with a bearer challenge for 401 responses
+     * @param challenge default challenge for framework-generated 401 responses
+     * @return rejection response with a challenge when appropriate
      */
     private ApiResponse authenticationRejected(
-            final ThingifierApiAuthenticationResult authentication) {
-        final ApiResponse response =
-                authentication == null || authentication.rejectionResponse() == null
-                        ? unauthorized()
-                        : authentication.rejectionResponse();
-        return challengeIfUnauthorized(response);
+            final ThingifierApiAuthenticationResult authentication, final String challenge) {
+        if (authentication == null || authentication.rejectionResponse() == null) {
+            return unauthorized(challenge);
+        }
+        final ApiResponse response = authentication.rejectionResponse();
+        if (authentication.hasCustomRejectionResponse()) {
+            return response;
+        }
+        return challengeIfUnauthorized(response, challenge);
     }
 
     /**
@@ -222,27 +320,47 @@ public final class RouteAuthPolicy {
     }
 
     /**
-     * Creates the standard bearer unauthorized response.
+     * Creates a standard unauthorized response.
      *
      * @return 401 response with a WWW-Authenticate challenge
      */
-    private ApiResponse unauthorized() {
-        return ApiResponse.error(401, "Unauthorized")
-                .setHeader(WWW_AUTHENTICATE_HEADER, BEARER_CHALLENGE);
+    private ApiResponse unauthorized(final String challenge) {
+        return ApiResponse.error(401, "Unauthorized").setHeader(WWW_AUTHENTICATE_HEADER, challenge);
     }
 
     /**
-     * Ensures authenticator-supplied 401 responses include the bearer challenge header.
+     * Ensures standard 401 responses include the enforced scheme challenge header.
      *
      * @param response response returned by an authenticator
+     * @param challenge default challenge for the enforced scheme
      * @return same response with the challenge header when appropriate
      */
-    private ApiResponse challengeIfUnauthorized(final ApiResponse response) {
+    private ApiResponse challengeIfUnauthorized(
+            final ApiResponse response, final String challenge) {
         if (response.getStatusCode() == 401
                 && response.getHeaderValue(WWW_AUTHENTICATE_HEADER).isEmpty()) {
-            response.setHeader(WWW_AUTHENTICATE_HEADER, BEARER_CHALLENGE);
+            response.setHeader(WWW_AUTHENTICATE_HEADER, challenge);
         }
         return response;
+    }
+
+    /**
+     * Builds the Basic challenge header for a named scheme.
+     *
+     * @param schemeName Basic auth scheme name
+     * @return challenge header value with configured realm
+     */
+    private String basicChallengeFor(final String schemeName) {
+        return "Basic realm=\""
+                + escapedRealm(runtime.apiSpec().security().basicRealm(schemeName))
+                + "\"";
+    }
+
+    private String escapedRealm(final String realm) {
+        return realm.replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\r", "")
+                .replace("\n", "");
     }
 
     /**

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/RoutingDefinition.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/RoutingDefinition.java
@@ -33,6 +33,7 @@ public class RoutingDefinition {
     private HashMap<String, String> customHeaders;
     private HashMap<String, String> responseHeaders;
     private boolean usesBasicAuth = false;
+    private String basicAuthSchemeName = SecuritySchemeNames.DEFAULT_BASIC_AUTH_SCHEME;
     private boolean usesBearerAuth = false;
     private String bearerAuthSchemeName = SecuritySchemeNames.DEFAULT_BEARER_AUTH_SCHEME;
     private boolean hiddenFromDocumentation = false;
@@ -600,7 +601,18 @@ public class RoutingDefinition {
      * @return this definition so route metadata can be chained
      */
     public RoutingDefinition secureWithBasicAuth() {
+        return secureWithBasicAuth(SecuritySchemeNames.DEFAULT_BASIC_AUTH_SCHEME);
+    }
+
+    /**
+     * Marks the route as requiring a named Basic auth scheme in generated documentation.
+     *
+     * @param schemeName Basic security scheme name
+     * @return this definition so route metadata can be chained
+     */
+    public RoutingDefinition secureWithBasicAuth(final String schemeName) {
         usesBasicAuth = true;
+        basicAuthSchemeName = SecuritySchemeNames.requireValid(schemeName);
         return this;
     }
 
@@ -611,6 +623,15 @@ public class RoutingDefinition {
      */
     public boolean isSecuredByBasicAuth() {
         return usesBasicAuth;
+    }
+
+    /**
+     * Returns the Basic auth security scheme name used in generated documentation.
+     *
+     * @return Basic security scheme name
+     */
+    public String basicAuthSchemeName() {
+        return basicAuthSchemeName;
     }
 
     /**

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/HttpApiRequest.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/HttpApiRequest.java
@@ -165,7 +165,13 @@ public final class HttpApiRequest {
     }
 
     public HttpApiRequest addHeader(final String headerName, final String headerValue) {
-        this.headers.put(headerName, headerValue.trim().toLowerCase());
+        final String trimmedHeaderValue = headerValue.trim();
+        // Authorization parameters are case-sensitive, e.g. Basic credentials are Base64.
+        final String value =
+                "authorization".equalsIgnoreCase(headerName)
+                        ? trimmedHeaderValue
+                        : trimmedHeaderValue.toLowerCase();
+        this.headers.put(headerName, value);
         return this;
     }
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/BasicAuthHeaderParser.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/BasicAuthHeaderParser.java
@@ -1,15 +1,24 @@
 package uk.co.compendiumdev.thingifier.api.http.headers.headerparser;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 
+/**
+ * Parses an HTTP Basic Authorization header.
+ *
+ * <p>The parser separates syntactic validity from credential matching so route-level auth can
+ * reject malformed headers before application authenticators are called, while older code can keep
+ * using {@link #matches(String, String)} for direct username/password checks.
+ */
 public class BasicAuthHeaderParser {
     private final String authHeader;
     private String password;
     private String basic;
     private String base64UserNamePass;
     private String username;
+    private boolean valid;
 
     public BasicAuthHeaderParser(final String header) {
         if (header == null) {
@@ -22,6 +31,7 @@ public class BasicAuthHeaderParser {
         this.base64UserNamePass = "";
         this.username = "";
         this.password = "";
+        this.valid = false;
 
         splitParts(this.authHeader);
         decodeBase64();
@@ -33,14 +43,16 @@ public class BasicAuthHeaderParser {
         }
 
         try {
-            String usernamePassword = new String(Base64.getDecoder().decode(base64UserNamePass));
-            final String[] up = usernamePassword.split(":");
-            if (up.length >= 1) {
-                this.username = up[0];
+            String usernamePassword =
+                    new String(
+                            Base64.getDecoder().decode(base64UserNamePass), StandardCharsets.UTF_8);
+            final int separator = usernamePassword.indexOf(":");
+            if (separator <= 0 || separator == usernamePassword.length() - 1) {
+                return;
             }
-            if (up.length >= 2) {
-                this.password = up[1];
-            }
+            this.username = usernamePassword.substring(0, separator);
+            this.password = usernamePassword.substring(separator + 1);
+            this.valid = true;
 
         } catch (Exception e) {
             // ignore
@@ -60,14 +72,63 @@ public class BasicAuthHeaderParser {
         if (parts.size() >= 1) {
             basic = parts.get(0).toLowerCase();
         }
-        if (parts.size() >= 2) {
+        if (parts.size() == 2) {
             base64UserNamePass = parts.get(1);
         }
     }
 
+    /**
+     * Reports whether the header starts with the Basic auth scheme.
+     *
+     * @return true when the Authorization header uses Basic auth syntax
+     */
+    public boolean isBasicAuth() {
+        return basic.equals("basic");
+    }
+
+    /**
+     * Reports whether the header is syntactically valid Basic credentials.
+     *
+     * <p>Valid means the header uses the Basic scheme, has exactly one credential value, decodes as
+     * Base64, and contains a non-empty username and password separated by the first colon.
+     *
+     * @return true when username and password can be safely read
+     */
+    public boolean isValid() {
+        return isBasicAuth() && valid;
+    }
+
+    /**
+     * Returns the parsed Basic username.
+     *
+     * @return username, or an empty string when the header is invalid
+     */
+    public String username() {
+        return username;
+    }
+
+    /**
+     * Returns the parsed Basic password.
+     *
+     * @return password, or an empty string when the header is invalid
+     */
+    public String password() {
+        return password;
+    }
+
+    /**
+     * Checks parsed Basic credentials against expected values.
+     *
+     * <p>This method remains for older callers. It now delegates through {@link #isValid()} so
+     * malformed Basic headers are never treated as partial credential matches.
+     *
+     * @param username expected username
+     * @param password expected password
+     * @return true when the header is valid Basic auth and both values match
+     */
     public boolean matches(final String username, final String password) {
 
-        if (!basic.equals("basic")) {
+        if (!isValid()) {
             return false;
         }
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/SecuritySchemeNames.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/SecuritySchemeNames.java
@@ -11,6 +11,9 @@ public final class SecuritySchemeNames {
     /** Default OpenAPI scheme name used by the historical no-argument bearer marker. */
     public static final String DEFAULT_BEARER_AUTH_SCHEME = "bearerAuth";
 
+    /** Default OpenAPI scheme name used by the historical no-argument Basic marker. */
+    public static final String DEFAULT_BASIC_AUTH_SCHEME = "basicAuth";
+
     private SecuritySchemeNames() {}
 
     /**

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthenticationContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthenticationContext.java
@@ -24,6 +24,8 @@ public final class ThingifierApiAuthenticationContext {
     private final HttpHeadersBlock headers;
     private final ThingifierRequestContext requestContext;
     private final String bearerToken;
+    private final String basicUsername;
+    private final String basicPassword;
     private final EntityDefinition targetEntity;
     private final String targetIdentifier;
     private final EntityDefinition parentEntity;
@@ -39,6 +41,26 @@ public final class ThingifierApiAuthenticationContext {
      */
     public ThingifierApiAuthenticationContext(
             final ThingifierApiRouteAuthDetails details, final String bearerToken) {
+        this(details, bearerToken, "", "");
+    }
+
+    /**
+     * Creates an immutable authentication context with parsed auth credentials.
+     *
+     * <p>Only the fields relevant to the enforced scheme are populated. Bearer routes receive a
+     * bearer token, and Basic routes receive username/password values. Keeping one context type
+     * lets applications use the same authenticator interface for every scheme.
+     *
+     * @param details reusable route and request details
+     * @param bearerToken parsed bearer token from the Authorization header
+     * @param basicUsername parsed Basic username from the Authorization header
+     * @param basicPassword parsed Basic password from the Authorization header
+     */
+    public ThingifierApiAuthenticationContext(
+            final ThingifierApiRouteAuthDetails details,
+            final String bearerToken,
+            final String basicUsername,
+            final String basicPassword) {
         this.schemeName = details.schemeName();
         this.verb = details.verb();
         this.path = details.path();
@@ -47,6 +69,8 @@ public final class ThingifierApiAuthenticationContext {
         this.headers = details.headers();
         this.requestContext = details.requestContext();
         this.bearerToken = bearerToken == null ? "" : bearerToken;
+        this.basicUsername = basicUsername == null ? "" : basicUsername;
+        this.basicPassword = basicPassword == null ? "" : basicPassword;
         this.targetEntity = details.targetEntity();
         this.targetIdentifier = details.targetIdentifier();
         this.parentEntity = details.parentEntity();
@@ -144,6 +168,24 @@ public final class ThingifierApiAuthenticationContext {
      */
     public String bearerToken() {
         return bearerToken;
+    }
+
+    /**
+     * Returns the parsed Basic username.
+     *
+     * @return Basic username, or an empty string when the enforced scheme is not Basic
+     */
+    public String basicUsername() {
+        return basicUsername;
+    }
+
+    /**
+     * Returns the parsed Basic password.
+     *
+     * @return Basic password, or an empty string when the enforced scheme is not Basic
+     */
+    public String basicPassword() {
+        return basicPassword;
     }
 
     /**

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthenticationResult.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthenticationResult.java
@@ -14,14 +14,17 @@ public final class ThingifierApiAuthenticationResult {
     private final boolean authenticated;
     private final Object principal;
     private final ApiResponse rejectionResponse;
+    private final boolean customRejectionResponse;
 
     private ThingifierApiAuthenticationResult(
             final boolean authenticated,
             final Object principal,
-            final ApiResponse rejectionResponse) {
+            final ApiResponse rejectionResponse,
+            final boolean customRejectionResponse) {
         this.authenticated = authenticated;
         this.principal = principal;
         this.rejectionResponse = rejectionResponse;
+        this.customRejectionResponse = customRejectionResponse;
     }
 
     /**
@@ -31,7 +34,7 @@ public final class ThingifierApiAuthenticationResult {
      * @return successful authentication result
      */
     public static ThingifierApiAuthenticationResult authenticated(final Object principal) {
-        return new ThingifierApiAuthenticationResult(true, principal, null);
+        return new ThingifierApiAuthenticationResult(true, principal, null, false);
     }
 
     /**
@@ -62,17 +65,22 @@ public final class ThingifierApiAuthenticationResult {
      */
     public static ThingifierApiAuthenticationResult rejected(
             final int status, final String message) {
-        return rejected(ApiResponse.error(status, message));
+        return new ThingifierApiAuthenticationResult(
+                false, null, ApiResponse.error(status, message), false);
     }
 
     /**
      * Creates an authentication rejection with a complete response.
      *
+     * <p>Thingifier preserves custom rejection responses exactly. Use this when the application
+     * needs full control over the response body and challenge headers, for example to suppress a
+     * browser Basic auth dialog.
+     *
      * @param response response to return instead of continuing request processing
      * @return rejected authentication result
      */
     public static ThingifierApiAuthenticationResult rejected(final ApiResponse response) {
-        return new ThingifierApiAuthenticationResult(false, null, response);
+        return new ThingifierApiAuthenticationResult(false, null, response, true);
     }
 
     /**
@@ -100,5 +108,14 @@ public final class ThingifierApiAuthenticationResult {
      */
     public ApiResponse rejectionResponse() {
         return rejectionResponse;
+    }
+
+    /**
+     * Reports whether the rejection response was supplied directly by application code.
+     *
+     * @return true when Thingifier should not add default challenge headers
+     */
+    public boolean hasCustomRejectionResponse() {
+        return customRejectionResponse;
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthorizationContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthorizationContext.java
@@ -143,6 +143,24 @@ public final class ThingifierApiAuthorizationContext {
     }
 
     /**
+     * Returns the parsed Basic username from the authentication step.
+     *
+     * @return Basic username, or an empty string when the enforced scheme is not Basic
+     */
+    public String basicUsername() {
+        return authenticationContext.basicUsername();
+    }
+
+    /**
+     * Returns the parsed Basic password from the authentication step.
+     *
+     * @return Basic password, or an empty string when the enforced scheme is not Basic
+     */
+    public String basicPassword() {
+        return authenticationContext.basicPassword();
+    }
+
+    /**
      * Returns the target entity for entity or relationship routes.
      *
      * @return target entity, or null when no entity route matched

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiSecuritySpec.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiSecuritySpec.java
@@ -1,23 +1,30 @@
 package uk.co.compendiumdev.thingifier.api.security;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 
 /**
  * Declares named security schemes used by a Thingifier API specification.
  *
- * <p>The security spec is intentionally small at the moment. It lets API authors give bearer
- * schemes meaningful names, such as {@code cartToken}, so generated OpenAPI documents and runtime
+ * <p>The security spec lets API authors give authentication schemes meaningful names, such as
+ * {@code cartToken} or {@code adminPassword}, so generated OpenAPI documents and runtime
  * enforcement can refer to the same policy without hard-coding application behaviour in Thingifier.
  */
 public final class ThingifierApiSecuritySpec {
 
+    /** Default Basic realm used when a scheme has not configured one. */
+    public static final String DEFAULT_BASIC_REALM = "Thingifier";
+
     private final Set<String> bearerSchemes;
+    private final Map<String, String> basicRealms;
 
     /** Creates an empty security declaration set. */
     public ThingifierApiSecuritySpec() {
         bearerSchemes = new LinkedHashSet<>();
+        basicRealms = new LinkedHashMap<>();
     }
 
     /**
@@ -32,6 +39,32 @@ public final class ThingifierApiSecuritySpec {
     }
 
     /**
+     * Declares a named Basic authentication scheme using the default realm.
+     *
+     * @param schemeName name to use in API spec route rules and OpenAPI security schemes
+     * @return this security spec so declarations can be chained
+     */
+    public ThingifierApiSecuritySpec basic(final String schemeName) {
+        return basic(schemeName, DEFAULT_BASIC_REALM);
+    }
+
+    /**
+     * Declares a named Basic authentication scheme and challenge realm.
+     *
+     * <p>The realm is visible in the {@code WWW-Authenticate} challenge when Thingifier rejects a
+     * missing or malformed Basic header before application authentication runs. Blank realms fall
+     * back to the default so the framework does not emit an empty user-facing prompt.
+     *
+     * @param schemeName name to use in API spec route rules and OpenAPI security schemes
+     * @param realm Basic realm to advertise in default challenges
+     * @return this security spec so declarations can be chained
+     */
+    public ThingifierApiSecuritySpec basic(final String schemeName, final String realm) {
+        basicRealms.put(SecuritySchemeNames.requireValid(schemeName), normalizedRealm(realm));
+        return this;
+    }
+
+    /**
      * Reports whether the named bearer scheme has been declared.
      *
      * @param schemeName security scheme name
@@ -42,11 +75,51 @@ public final class ThingifierApiSecuritySpec {
     }
 
     /**
+     * Reports whether the named Basic scheme has been declared.
+     *
+     * @param schemeName security scheme name
+     * @return true when a matching Basic scheme is known
+     */
+    public boolean hasBasic(final String schemeName) {
+        return basicRealms.containsKey(SecuritySchemeNames.requireValid(schemeName));
+    }
+
+    /**
      * Returns all declared bearer scheme names in declaration order.
      *
      * @return immutable set of bearer scheme names
      */
     public Set<String> bearerSchemes() {
         return Collections.unmodifiableSet(bearerSchemes);
+    }
+
+    /**
+     * Returns all declared Basic scheme names in declaration order.
+     *
+     * @return immutable set of Basic scheme names
+     */
+    public Set<String> basicSchemes() {
+        return Collections.unmodifiableSet(basicRealms.keySet());
+    }
+
+    /**
+     * Returns the Basic realm for a named scheme.
+     *
+     * <p>Routes may enforce a named Basic scheme without an explicit security declaration. In that
+     * case the default realm keeps runtime challenges predictable.
+     *
+     * @param schemeName security scheme name
+     * @return configured realm, or the default realm when no explicit declaration exists
+     */
+    public String basicRealm(final String schemeName) {
+        return basicRealms.getOrDefault(
+                SecuritySchemeNames.requireValid(schemeName), DEFAULT_BASIC_REALM);
+    }
+
+    private String normalizedRealm(final String realm) {
+        if (realm == null || realm.trim().isEmpty()) {
+            return DEFAULT_BASIC_REALM;
+        }
+        return realm.trim();
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiRouteRule.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiRouteRule.java
@@ -30,6 +30,8 @@ public final class ThingifierApiRouteRule {
     private boolean disabled;
     private boolean methodNotAllowed;
     private boolean usesBasicAuth;
+    private String basicAuthSchemeName;
+    private String enforcedBasicAuthSchemeName;
     private boolean usesBearerAuth;
     private String bearerAuthSchemeName;
     private String enforcedBearerAuthSchemeName;
@@ -50,6 +52,8 @@ public final class ThingifierApiRouteRule {
         this.disabled = false;
         this.methodNotAllowed = false;
         this.usesBasicAuth = false;
+        this.basicAuthSchemeName = SecuritySchemeNames.DEFAULT_BASIC_AUTH_SCHEME;
+        this.enforcedBasicAuthSchemeName = null;
         this.usesBearerAuth = false;
         this.bearerAuthSchemeName = SecuritySchemeNames.DEFAULT_BEARER_AUTH_SCHEME;
         this.enforcedBearerAuthSchemeName = null;
@@ -162,10 +166,36 @@ public final class ThingifierApiRouteRule {
     /**
      * Marks the route as requiring Basic authentication in generated documentation.
      *
+     * <p>This historical form is documentation-only. Use {@link #secureWithBasicAuth(String)} when
+     * Thingifier should also enforce a named Basic policy at runtime.
+     *
      * @return this rule so route API configuration can be chained
      */
     public ThingifierApiRouteRule secureWithBasicAuth() {
         usesBasicAuth = true;
+        basicAuthSchemeName = SecuritySchemeNames.DEFAULT_BASIC_AUTH_SCHEME;
+        return this;
+    }
+
+    /**
+     * Marks the route as requiring a named Basic authentication scheme and runtime enforcement.
+     *
+     * <p>The scheme name is used in generated documentation, authenticator lookup, and the
+     * authenticated-principal slot on the request context. The Basic realm is configured on {@link
+     * uk.co.compendiumdev.thingifier.api.security.ThingifierApiSecuritySpec#basic(String, String)}.
+     * If both named Basic and named Bearer auth are configured on one route, the most recent named
+     * call selects the runtime enforcement scheme.
+     *
+     * @param schemeName named Basic scheme, for example {@code adminPassword}
+     * @return this rule so route API configuration can be chained
+     */
+    public ThingifierApiRouteRule secureWithBasicAuth(final String schemeName) {
+        final String normalizedSchemeName = SecuritySchemeNames.requireValid(schemeName);
+        usesBasicAuth = true;
+        usesBearerAuth = false;
+        basicAuthSchemeName = normalizedSchemeName;
+        enforcedBasicAuthSchemeName = normalizedSchemeName;
+        enforcedBearerAuthSchemeName = null;
         return this;
     }
 
@@ -197,8 +227,10 @@ public final class ThingifierApiRouteRule {
      */
     public ThingifierApiRouteRule secureWithBearerAuth(final String schemeName) {
         final String normalizedSchemeName = SecuritySchemeNames.requireValid(schemeName);
+        usesBasicAuth = false;
         usesBearerAuth = true;
         bearerAuthSchemeName = normalizedSchemeName;
+        enforcedBasicAuthSchemeName = null;
         enforcedBearerAuthSchemeName = normalizedSchemeName;
         return this;
     }
@@ -264,6 +296,42 @@ public final class ThingifierApiRouteRule {
      */
     public List<ThingifierApiAuthorizer> authorizers() {
         return List.copyOf(authorizers);
+    }
+
+    /**
+     * Reports whether this route is documented as Basic secured.
+     *
+     * @return true when Basic auth should appear in generated documentation
+     */
+    public boolean isSecuredByBasicAuth() {
+        return usesBasicAuth;
+    }
+
+    /**
+     * Returns the Basic scheme name used in generated documentation.
+     *
+     * @return Basic auth scheme name
+     */
+    public String basicAuthSchemeName() {
+        return basicAuthSchemeName;
+    }
+
+    /**
+     * Reports whether this route should enforce Basic auth at runtime.
+     *
+     * @return true when the route has a named Basic enforcement scheme
+     */
+    public boolean hasBasicAuthEnforcement() {
+        return enforcedBasicAuthSchemeName != null;
+    }
+
+    /**
+     * Returns the Basic scheme name used for runtime enforcement.
+     *
+     * @return Basic enforcement scheme name, or null for documentation-only Basic routes
+     */
+    public String basicAuthEnforcementSchemeName() {
+        return enforcedBasicAuthSchemeName;
     }
 
     /**
@@ -506,7 +574,7 @@ public final class ThingifierApiRouteRule {
             route.replaceStatus(RoutingStatus.returnValue(405));
         }
         if (usesBasicAuth) {
-            route.secureWithBasicAuth();
+            route.secureWithBasicAuth(basicAuthSchemeName);
         }
         if (usesBearerAuth) {
             route.secureWithBearerAuth(bearerAuthSchemeName);

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpec.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpec.java
@@ -107,12 +107,13 @@ public final class ThingifierApiSpec {
     /**
      * Registers an authenticator for a named security scheme.
      *
-     * <p>Registering an authenticator makes a named scheme enforceable at runtime. The scheme is
-     * also declared as a bearer scheme for generated documentation because enforcement without a
-     * published security scheme would mislead API consumers.
+     * <p>Registering an authenticator makes a named scheme enforceable at runtime when a route rule
+     * selects that scheme with named Basic or Bearer auth. The route rule and security declaration
+     * decide which HTTP auth mechanism is documented and parsed; this callback only supplies the
+     * application-specific credential check.
      *
-     * @param schemeName named bearer scheme
-     * @param authenticator callback used to authenticate bearer tokens for the scheme
+     * @param schemeName named security scheme
+     * @param authenticator callback used to authenticate parsed credentials for the scheme
      * @return this spec so API configuration can be chained
      * @throws IllegalArgumentException when the scheme name is blank or the authenticator is null
      */
@@ -122,7 +123,6 @@ public final class ThingifierApiSpec {
         if (authenticator == null) {
             throw new IllegalArgumentException("authenticator is required");
         }
-        securitySpec.bearer(normalizedSchemeName);
         authenticators.put(normalizedSchemeName, authenticator);
         return this;
     }
@@ -380,7 +380,7 @@ public final class ThingifierApiSpec {
     /**
      * Finds the authenticator registered for a named security scheme.
      *
-     * @param schemeName named bearer scheme
+     * @param schemeName named security scheme
      * @return authenticator when configured
      */
     public Optional<ThingifierApiAuthenticator> authenticatorFor(final String schemeName) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/Swaggerizer.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/Swaggerizer.java
@@ -136,6 +136,9 @@ public class Swaggerizer {
         for (String bearerSchemeName : thingifier.apiSpec().security().bearerSchemes()) {
             addHttpSecurityScheme(components, bearerSchemeName, "bearer", null);
         }
+        for (String basicSchemeName : thingifier.apiSpec().security().basicSchemes()) {
+            addHttpSecurityScheme(components, basicSchemeName, "basic", null);
+        }
 
         if (routes != null) {
 
@@ -245,9 +248,10 @@ public class Swaggerizer {
                             }
 
                             if (subroute.isSecuredByBasicAuth()) {
-                                addHttpSecurityScheme(components, "basicAuth", "basic", null);
+                                final String basicSchemeName = subroute.basicAuthSchemeName();
+                                addHttpSecurityScheme(components, basicSchemeName, "basic", null);
                                 operation.addSecurityItem(
-                                        new SecurityRequirement().addList("basicAuth"));
+                                        new SecurityRequirement().addList(basicSchemeName));
                             }
 
                             if (subroute.isSecuredByBearerAuth()) {

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/BasicAuthHeaderParserTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/BasicAuthHeaderParserTest.java
@@ -1,8 +1,7 @@
 package uk.co.compendiumdev.thingifier.api.http.headers.headerparser;
 
-import java.util.ArrayList;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -12,113 +11,120 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 public class BasicAuthHeaderParserTest {
 
-    // admin:password YWRtaW46cGFzc3dvcmQ=
+    @Test
+    void identifiesBasicAuthScheme() {
+        final BasicAuthHeaderParser parser =
+                new BasicAuthHeaderParser("basic " + base64("admin:password"));
+
+        Assertions.assertTrue(parser.isBasicAuth());
+    }
 
     @Test
-    void canParseUsernamePassword() {
+    void identifiesNonBasicAuthScheme() {
         final BasicAuthHeaderParser parser =
-                new BasicAuthHeaderParser("basic YWRtaW46cGFzc3dvcmQ=");
+                new BasicAuthHeaderParser("Bearer " + base64("admin:password"));
+
+        Assertions.assertFalse(parser.isBasicAuth());
+    }
+
+    @Test
+    void validBasicHeaderExposesUsernameAndPassword() {
+        final BasicAuthHeaderParser parser =
+                new BasicAuthHeaderParser("basic " + base64("admin:password"));
+
+        Assertions.assertTrue(parser.isValid());
+        Assertions.assertEquals("admin", parser.username());
+        Assertions.assertEquals("password", parser.password());
+    }
+
+    @Test
+    void validBasicHeaderSplitsCredentialsOnFirstColon() {
+        final BasicAuthHeaderParser parser =
+                new BasicAuthHeaderParser("basic " + base64("admin:pa:ss"));
+
+        Assertions.assertTrue(parser.isValid());
+        Assertions.assertEquals("admin", parser.username());
+        Assertions.assertEquals("pa:ss", parser.password());
+    }
+
+    @Test
+    void validBasicHeaderSpacingDoesNotAffectParsing() {
+        final BasicAuthHeaderParser parser =
+                new BasicAuthHeaderParser("    basic      " + base64("admin:password") + "    ");
+
+        Assertions.assertTrue(parser.isValid());
+        Assertions.assertTrue(parser.matches("admin", "password"));
+    }
+
+    static Stream<Arguments> invalidBasicSyntaxValues() {
+        return Stream.of(
+                Arguments.of("missing header", null),
+                Arguments.of("empty header", ""),
+                Arguments.of("wrong scheme", "Bearer " + base64("admin:password")),
+                Arguments.of("credentials without scheme", base64("admin:password")),
+                Arguments.of("credentials before scheme", base64("admin:password") + " basic"),
+                Arguments.of("missing credentials", "basic"),
+                Arguments.of("extra token", "basic " + base64("admin:password") + " extra"),
+                Arguments.of("malformed base64", "basic not-base64"),
+                Arguments.of("missing colon", "basic " + base64("adminpassword")),
+                Arguments.of("empty username", "basic " + base64(":password")),
+                Arguments.of("empty password", "basic " + base64("admin:")),
+                Arguments.of("empty username and password", "basic " + base64(":")),
+                Arguments.of("empty decoded credentials", "basic " + base64("")));
+    }
+
+    @ParameterizedTest(name = "invalid when {0}")
+    @MethodSource("invalidBasicSyntaxValues")
+    void invalidBasicSyntaxIsNotValid(final String reason, final String header) {
+        final BasicAuthHeaderParser parser = new BasicAuthHeaderParser(header);
+
+        Assertions.assertFalse(parser.isValid());
+    }
+
+    @Test
+    void matchesValidCredentials() {
+        final BasicAuthHeaderParser parser =
+                new BasicAuthHeaderParser("basic " + base64("admin:password"));
 
         Assertions.assertTrue(parser.matches("admin", "password"));
     }
 
-    @Test
-    void canNotMatchIfParseEmpty() {
-        final BasicAuthHeaderParser parser = new BasicAuthHeaderParser("");
-
-        Assertions.assertFalse(parser.matches("admin", "password"));
+    static Stream<Arguments> nonMatchingCredentialValues() {
+        return Stream.of(
+                Arguments.of(null, "password"),
+                Arguments.of("admin", null),
+                Arguments.of(null, null),
+                Arguments.of("", ""),
+                Arguments.of("admin", ""),
+                Arguments.of("", "password"),
+                Arguments.of("wrong", "password"),
+                Arguments.of("admin", "wrong"));
     }
 
-    @Test
-    void canNotMatchIfParseNull() {
-        final BasicAuthHeaderParser parser = new BasicAuthHeaderParser(null);
-
-        Assertions.assertFalse(parser.matches("admin", "password"));
-    }
-
-    @Test
-    void canParseUsernamePasswordSpacingNotAnIssue() {
+    @ParameterizedTest(name = "does not match expected {0}:{1}")
+    @MethodSource("nonMatchingCredentialValues")
+    void matchesRejectsUnexpectedExpectedCredentials(final String username, final String password) {
         final BasicAuthHeaderParser parser =
-                new BasicAuthHeaderParser("    basic      YWRtaW46cGFzc3dvcmQ=    ");
-
-        Assertions.assertTrue(parser.matches("admin", "password"));
-    }
-
-    @Test
-    void canParseUsernamePasswordToFindNoMatch() {
-        final BasicAuthHeaderParser parser =
-                new BasicAuthHeaderParser("basic YWRtaW46cGFzc3dvcmQ=");
-
-        Assertions.assertTrue(parser.matches("admin", "password"));
-    }
-
-    @Test
-    void failsWhenNotBasic() {
-        final BasicAuthHeaderParser parser =
-                new BasicAuthHeaderParser("basics YWRtaW46cGFzc3dvcmQ=");
-
-        Assertions.assertFalse(parser.matches("admin", "password"));
-    }
-
-    static Stream invalidMatchingValues() {
-        List<Arguments> args = new ArrayList<>();
-
-        args.add(Arguments.of(null, "password"));
-        args.add(Arguments.of("admin", null));
-        args.add(Arguments.of(null, null));
-        args.add(Arguments.of("", ""));
-        args.add(Arguments.of("admin", ""));
-        args.add(Arguments.of("", "password"));
-        args.add(Arguments.of("wrong", "password"));
-        args.add(Arguments.of("admin", "wrong"));
-        return args.stream();
-    }
-
-    @ParameterizedTest(name = "invalid when asked to match on {0}:{1} instead of admin:password")
-    @MethodSource("invalidMatchingValues")
-    void failsWhenNoUsernameOrPasswordInMatch(String username, String password) {
-        // admin:password YWRtaW46cGFzc3dvcmQ=
-        final BasicAuthHeaderParser parser =
-                new BasicAuthHeaderParser("basic YWRtaW46cGFzc3dvcmQ=");
+                new BasicAuthHeaderParser("basic " + base64("admin:password"));
 
         Assertions.assertFalse(parser.matches(username, password));
     }
 
-    static Stream invalidHeaderValues() {
-        List<Arguments> args = new ArrayList<>();
-
-        args.add(Arguments.of("not basic", "basics YWRtaW46cGFzc3dvcmQ="));
-        args.add(Arguments.of("no basic", "YWRtaW46cGFzc3dvcmQ="));
-        args.add(Arguments.of("no basic but spaces", "    YWRtaW46cGFzc3dvcmQ="));
-        args.add(Arguments.of("wrong order", "YWRtaW46cGFzc3dvcmQ= basic"));
-        args.add(Arguments.of("basic but wrong password", "basic " + base64("admin:pass")));
-        args.add(Arguments.of("no username", "basic " + base64(":password")));
-        args.add(Arguments.of("no password", "basic " + base64("admin:")));
-        args.add(Arguments.of("no colon", "basic " + base64("adminpassword")));
-        args.add(Arguments.of("no values, just colon", "basic " + base64(":")));
-        args.add(Arguments.of("no values", "basic " + base64("")));
-        args.add(Arguments.of("just basic", "basic"));
-        return args.stream();
-    }
-
-    @ParameterizedTest(name = "invalid when {0}")
-    @MethodSource("invalidHeaderValues")
-    void failsWhenHeaderDoesNotMatch(String reason, String header) {
+    @ParameterizedTest(name = "does not match invalid header when {0}")
+    @MethodSource("invalidBasicSyntaxValues")
+    void matchesRejectsInvalidBasicSyntax(final String reason, final String header) {
         final BasicAuthHeaderParser parser = new BasicAuthHeaderParser(header);
 
         Assertions.assertFalse(parser.matches("admin", "password"));
     }
 
-    // admin:password YWRtaW46cGFzc3dvcmQ=
-    // admin:pass YWRtaW46cGFzcw==
     @Test
     void canTrustBase64Conversion() {
         Assertions.assertEquals("YWRtaW46cGFzc3dvcmQ=", base64("admin:password"));
         Assertions.assertEquals("YWRtaW46cGFzcw==", base64("admin:pass"));
     }
 
-    static String base64(String convertMe) {
-        final Base64.Encoder base64 = Base64.getEncoder();
-        return base64.encodeToString(convertMe.getBytes());
+    static String base64(final String convertMe) {
+        return Base64.getEncoder().encodeToString(convertMe.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthPolicyTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthPolicyTest.java
@@ -2,6 +2,8 @@ package uk.co.compendiumdev.thingifier.api.security;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -58,10 +60,59 @@ class ThingifierApiAuthPolicyTest {
     }
 
     @Test
+    void namedBasicSchemeIsDocumentedOnProtectedGeneratedRoute() {
+        final Thingifier thingifier = todoModel();
+        thingifier.apiSpec().security().basic("adminPassword");
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.POST, "/api/todos")
+                .secureWithBasicAuth("adminPassword");
+        final ThingifierApiDocumentationDefn apiDefn = new ThingifierApiDocumentationDefn();
+        apiDefn.setThingifier(thingifier);
+        apiDefn.setPathPrefix("/api");
+
+        final OpenAPI openApi =
+                new uk.co.compendiumdev.thingifier.swaggerizer.Swaggerizer(apiDefn).swagger();
+
+        final SecurityScheme scheme =
+                openApi.getComponents().getSecuritySchemes().get("adminPassword");
+        Assertions.assertNotNull(scheme);
+        Assertions.assertEquals(SecurityScheme.Type.HTTP, scheme.getType());
+        Assertions.assertEquals("basic", scheme.getScheme());
+        Assertions.assertEquals(
+                "adminPassword",
+                openApi.getPaths()
+                        .get("/api/todos")
+                        .getPost()
+                        .getSecurity()
+                        .get(0)
+                        .keySet()
+                        .iterator()
+                        .next());
+    }
+
+    @Test
     @SuppressWarnings("deprecation")
     void legacyBearerMarkerRemainsDocumentationOnly() {
         final Thingifier thingifier = todoModel();
         thingifier.apiSpec().route(RoutingVerb.POST, "/todos").secureWithBearerAuth();
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"created\"}"),
+                                new HttpHeadersBlock());
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals(1, todoCount(thingifier));
+    }
+
+    @Test
+    void legacyBasicMarkerRemainsDocumentationOnly() {
+        final Thingifier thingifier = todoModel();
+        thingifier.apiSpec().route(RoutingVerb.POST, "/todos").secureWithBasicAuth();
 
         final ApiResponse response =
                 thingifier
@@ -94,6 +145,25 @@ class ThingifierApiAuthPolicyTest {
     }
 
     @Test
+    void directApiMissingBasicCredentialsReturns401WithoutMutation() {
+        final Thingifier thingifier = todoModel();
+        protectTodoPostWithBasic(thingifier);
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"blocked\"}"),
+                                new HttpHeadersBlock());
+
+        Assertions.assertEquals(401, response.getStatusCode());
+        Assertions.assertEquals(
+                "Basic realm=\"Thingifier\"", response.getHeaders().get("WWW-Authenticate"));
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    @Test
     void directApiInvalidBearerTokenReturns401WithoutMutation() {
         final Thingifier thingifier = todoModel();
         protectTodoPost(thingifier);
@@ -108,6 +178,25 @@ class ThingifierApiAuthPolicyTest {
 
         Assertions.assertEquals(401, response.getStatusCode());
         Assertions.assertEquals("Bearer", response.getHeaders().get("WWW-Authenticate"));
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    @Test
+    void directApiInvalidBasicCredentialsReturns401WithoutMutation() {
+        final Thingifier thingifier = todoModel();
+        protectTodoPostWithBasic(thingifier);
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"blocked\"}"),
+                                headersWithBasic("admin", "wrong"));
+
+        Assertions.assertEquals(401, response.getStatusCode());
+        Assertions.assertEquals(
+                "Basic realm=\"Thingifier\"", response.getHeaders().get("WWW-Authenticate"));
         Assertions.assertEquals(0, todoCount(thingifier));
     }
 
@@ -139,6 +228,64 @@ class ThingifierApiAuthPolicyTest {
     }
 
     @Test
+    void bearerHeaderForBasicRouteReturns401BeforeAuthenticator() {
+        final Thingifier thingifier = todoModel();
+        final AtomicReference<Boolean> authenticatorCalled = new AtomicReference<>(false);
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "adminPassword",
+                        context -> {
+                            authenticatorCalled.set(true);
+                            return ThingifierApiAuthenticationResult.authenticated();
+                        });
+        thingifier.apiSpec().route(RoutingVerb.POST, "/todos").secureWithBasicAuth("adminPassword");
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"blocked\"}"),
+                                headersWithBearer("valid-token"));
+
+        Assertions.assertEquals(401, response.getStatusCode());
+        Assertions.assertEquals(
+                "Basic realm=\"Thingifier\"", response.getHeaders().get("WWW-Authenticate"));
+        Assertions.assertFalse(authenticatorCalled.get());
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    @Test
+    void malformedBasicHeaderReturns401BeforeAuthenticator() {
+        final Thingifier thingifier = todoModel();
+        final AtomicReference<Boolean> authenticatorCalled = new AtomicReference<>(false);
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "adminPassword",
+                        context -> {
+                            authenticatorCalled.set(true);
+                            return ThingifierApiAuthenticationResult.authenticated();
+                        });
+        thingifier.apiSpec().route(RoutingVerb.POST, "/todos").secureWithBasicAuth("adminPassword");
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"blocked\"}"),
+                                headersWithAuthorization("Basic not-base64"));
+
+        Assertions.assertEquals(401, response.getStatusCode());
+        Assertions.assertEquals(
+                "Basic realm=\"Thingifier\"", response.getHeaders().get("WWW-Authenticate"));
+        Assertions.assertFalse(authenticatorCalled.get());
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    @Test
     void directApiValidBearerTokenAllowsMutation() {
         final Thingifier thingifier = todoModel();
         protectTodoPost(thingifier);
@@ -156,6 +303,55 @@ class ThingifierApiAuthPolicyTest {
     }
 
     @Test
+    void validBasicSyntaxCallsAuthenticatorWithUsernameAndPassword() {
+        final Thingifier thingifier = todoModel();
+        final AtomicReference<ThingifierApiAuthenticationContext> seenContext =
+                new AtomicReference<>();
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "adminPassword",
+                        context -> {
+                            seenContext.set(context);
+                            return ThingifierApiAuthenticationResult.rejected(403, "checked");
+                        });
+        thingifier.apiSpec().route(RoutingVerb.POST, "/todos").secureWithBasicAuth("adminPassword");
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"blocked\"}"),
+                                headersWithBasic("admin", "password"));
+
+        Assertions.assertEquals(403, response.getStatusCode());
+        Assertions.assertNotNull(seenContext.get());
+        Assertions.assertEquals("adminPassword", seenContext.get().schemeName());
+        Assertions.assertEquals("admin", seenContext.get().basicUsername());
+        Assertions.assertEquals("password", seenContext.get().basicPassword());
+        Assertions.assertEquals("", seenContext.get().bearerToken());
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    @Test
+    void directApiValidBasicCredentialsAllowMutation() {
+        final Thingifier thingifier = todoModel();
+        protectTodoPostWithBasic(thingifier);
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"created\"}"),
+                                headersWithBasic("admin", "password"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals(1, todoCount(thingifier));
+    }
+
+    @Test
     void directApiMissingBearerTokenReturns401ForProtectedRead() {
         final Thingifier thingifier = todoModel();
         createTodo(thingifier, "existing");
@@ -167,6 +363,27 @@ class ThingifierApiAuthPolicyTest {
 
         Assertions.assertEquals(401, response.getStatusCode());
         Assertions.assertEquals("Bearer", response.getHeaders().get("WWW-Authenticate"));
+    }
+
+    @Test
+    void basicChallengeUsesConfiguredRealm() {
+        final Thingifier thingifier = todoModel();
+        thingifier.apiSpec().security().basic("adminPassword", "User Visible Realm");
+        protectTodoPostWithBasic(thingifier);
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"blocked\"}"),
+                                new HttpHeadersBlock());
+
+        Assertions.assertEquals(401, response.getStatusCode());
+        Assertions.assertEquals(
+                "Basic realm=\"User Visible Realm\"",
+                response.getHeaders().get("WWW-Authenticate"));
+        Assertions.assertEquals(0, todoCount(thingifier));
     }
 
     @Test
@@ -211,6 +428,110 @@ class ThingifierApiAuthPolicyTest {
     }
 
     @Test
+    void basicAuthorizerReceivesAuthenticatedPrincipal() {
+        final Thingifier thingifier = todoModel();
+        final AtomicReference<Object> seenPrincipal = new AtomicReference<>();
+        protectTodoPostWithBasic(thingifier)
+                .authorizeWith(
+                        context -> {
+                            seenPrincipal.set(context.principal());
+                            return ThingifierApiAuthorizationResult.authorized();
+                        });
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"created\"}"),
+                                headersWithBasic("admin", "password"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals("basic-principal", seenPrincipal.get());
+    }
+
+    @Test
+    void basicAuthorizerCanReadParsedCredentials() {
+        final Thingifier thingifier = todoModel();
+        final AtomicReference<String> seenUsername = new AtomicReference<>();
+        final AtomicReference<String> seenPassword = new AtomicReference<>();
+        protectTodoPostWithBasic(thingifier)
+                .authorizeWith(
+                        context -> {
+                            seenUsername.set(context.basicUsername());
+                            seenPassword.set(context.basicPassword());
+                            return ThingifierApiAuthorizationResult.authorized();
+                        });
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"created\"}"),
+                                headersWithBasic("admin", "password"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals("admin", seenUsername.get());
+        Assertions.assertEquals("password", seenPassword.get());
+    }
+
+    @Test
+    void basicAuthenticatorCustom401CanOmitChallengeAndBody() {
+        final Thingifier thingifier = todoModel();
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "adminPassword",
+                        context ->
+                                ThingifierApiAuthenticationResult.rejected(new ApiResponse(401)));
+        thingifier.apiSpec().route(RoutingVerb.POST, "/todos").secureWithBasicAuth("adminPassword");
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"blocked\"}"),
+                                headersWithBasic("admin", "password"));
+
+        Assertions.assertEquals(401, response.getStatusCode());
+        Assertions.assertEquals("", response.getHeaders().get("WWW-Authenticate"));
+        Assertions.assertFalse(response.hasABody());
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    @Test
+    void basicAuthenticatorCustom403PreservesHeadersAndBody() {
+        final Thingifier thingifier = todoModel();
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "adminPassword",
+                        context -> {
+                            final ApiResponse response =
+                                    new ApiResponse(403).setHeader("X-Auth-Reason", "locked");
+                            response.setBody("custom forbidden");
+                            return ThingifierApiAuthenticationResult.rejected(response);
+                        });
+        thingifier.apiSpec().route(RoutingVerb.POST, "/todos").secureWithBasicAuth("adminPassword");
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"blocked\"}"),
+                                headersWithBasic("admin", "password"));
+
+        Assertions.assertEquals(403, response.getStatusCode());
+        Assertions.assertEquals("locked", response.getHeaders().get("X-Auth-Reason"));
+        Assertions.assertEquals("", response.getHeaders().get("WWW-Authenticate"));
+        Assertions.assertEquals("custom forbidden", response.getBody());
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    @Test
     void httpApiMissingBearerTokenReturns401WithoutMutation() {
         final Thingifier thingifier = todoModel();
         thingifier.apiConfig().setFrom(new ThingifierApiConfig("/api"));
@@ -226,6 +547,22 @@ class ThingifierApiAuthPolicyTest {
     }
 
     @Test
+    void httpApiMissingBasicCredentialsReturns401WithoutMutation() {
+        final Thingifier thingifier = todoModel();
+        thingifier.apiConfig().setFrom(new ThingifierApiConfig("/api"));
+        protectPrefixedTodoPostWithBasic(thingifier);
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .post(jsonPostRequest("/api/todos", "{\"title\":\"blocked\"}"));
+
+        Assertions.assertEquals(401, response.getStatusCode());
+        Assertions.assertEquals(
+                "Basic realm=\"Thingifier\"", response.getHeaders().get("WWW-Authenticate"));
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    @Test
     void httpApiValidBearerTokenAllowsMutation() {
         final Thingifier thingifier = todoModel();
         thingifier.apiConfig().setFrom(new ThingifierApiConfig("/api"));
@@ -236,6 +573,24 @@ class ThingifierApiAuthPolicyTest {
                         .post(
                                 jsonPostRequest("/api/todos", "{\"title\":\"created\"}")
                                         .addHeader("Authorization", "Bearer valid-token"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals(1, todoCount(thingifier));
+    }
+
+    @Test
+    void httpApiValidBasicCredentialsAllowMutation() {
+        final Thingifier thingifier = todoModel();
+        thingifier.apiConfig().setFrom(new ThingifierApiConfig("/api"));
+        protectPrefixedTodoPostWithBasic(thingifier);
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .post(
+                                jsonPostRequest("/api/todos", "{\"title\":\"created\"}")
+                                        .addHeader(
+                                                "Authorization",
+                                                basicAuthorization("admin", "password")));
 
         Assertions.assertEquals(201, response.getStatusCode());
         Assertions.assertEquals(1, todoCount(thingifier));
@@ -320,6 +675,14 @@ class ThingifierApiAuthPolicyTest {
                 .secureWithBearerAuth("cartToken");
     }
 
+    private ThingifierApiRouteRule protectTodoPostWithBasic(final Thingifier thingifier) {
+        thingifier.apiSpec().authenticator("adminPassword", this::validBasicAuthenticator);
+        return thingifier
+                .apiSpec()
+                .route(RoutingVerb.POST, "/todos")
+                .secureWithBasicAuth("adminPassword");
+    }
+
     private void protectPrefixedTodoPost(final Thingifier thingifier) {
         thingifier.apiSpec().authenticator("cartToken", this::validTokenAuthenticator);
         thingifier
@@ -328,12 +691,28 @@ class ThingifierApiAuthPolicyTest {
                 .secureWithBearerAuth("cartToken");
     }
 
+    private void protectPrefixedTodoPostWithBasic(final Thingifier thingifier) {
+        thingifier.apiSpec().authenticator("adminPassword", this::validBasicAuthenticator);
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.POST, "/api/todos")
+                .secureWithBasicAuth("adminPassword");
+    }
+
     private ThingifierApiAuthenticationResult validTokenAuthenticator(
             final ThingifierApiAuthenticationContext context) {
         if ("valid-token".equals(context.bearerToken())) {
             return ThingifierApiAuthenticationResult.authenticated("valid-principal");
         }
         return ThingifierApiAuthenticationResult.rejected("Invalid bearer token");
+    }
+
+    private ThingifierApiAuthenticationResult validBasicAuthenticator(
+            final ThingifierApiAuthenticationContext context) {
+        if ("admin".equals(context.basicUsername()) && "password".equals(context.basicPassword())) {
+            return ThingifierApiAuthenticationResult.authenticated("basic-principal");
+        }
+        return ThingifierApiAuthenticationResult.rejected("Invalid basic credentials");
     }
 
     private Thingifier todoModel() {
@@ -378,6 +757,16 @@ class ThingifierApiAuthPolicyTest {
 
     private HttpHeadersBlock headersWithBearer(final String token) {
         return headersWithAuthorization("Bearer " + token);
+    }
+
+    private HttpHeadersBlock headersWithBasic(final String username, final String password) {
+        return headersWithAuthorization(basicAuthorization(username, password));
+    }
+
+    private String basicAuthorization(final String username, final String password) {
+        final String credentials = username + ":" + password;
+        return "Basic "
+                + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
     }
 
     private HttpHeadersBlock headersWithAuthorization(final String authorization) {

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpecTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpecTest.java
@@ -19,6 +19,7 @@ import uk.co.compendiumdev.thingifier.api.http.ThingifierHttpApi;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.BodyParser;
 import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
+import uk.co.compendiumdev.thingifier.api.security.ThingifierApiSecuritySpec;
 import uk.co.compendiumdev.thingifier.apiconfig.ThingifierApiConfig;
 import uk.co.compendiumdev.thingifier.core.EntityRelModel;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.Cardinality;
@@ -63,6 +64,59 @@ class ThingifierApiSpecTest {
         Assertions.assertTrue(route.isSecuredByBearerAuth());
         Assertions.assertEquals("create a task through the project API", route.getDocumentation());
         Assertions.assertEquals("create_todo", route.getRequestPayload());
+    }
+
+    @Test
+    void namedBasicRouteRecordsDocumentationAndRuntimeEnforcement() {
+        final Thingifier thingifier = model();
+        final ThingifierApiRouteRule rule =
+                thingifier
+                        .apiSpec()
+                        .route(RoutingVerb.POST, "/api/todos")
+                        .secureWithBasicAuth("adminPassword");
+
+        Assertions.assertTrue(rule.isSecuredByBasicAuth());
+        Assertions.assertEquals("adminPassword", rule.basicAuthSchemeName());
+        Assertions.assertTrue(rule.hasBasicAuthEnforcement());
+        Assertions.assertEquals("adminPassword", rule.basicAuthEnforcementSchemeName());
+    }
+
+    @Test
+    void basicSecuritySpecStoresConfiguredRealm() {
+        final ThingifierApiSecuritySpec securitySpec = new ThingifierApiSecuritySpec();
+
+        securitySpec.basic("adminPassword", "User Visible Realm");
+
+        Assertions.assertTrue(securitySpec.hasBasic("adminPassword"));
+        Assertions.assertEquals("User Visible Realm", securitySpec.basicRealm("adminPassword"));
+    }
+
+    @Test
+    void namedBasicAuthClearsBearerEnforcementOnRoute() {
+        final Thingifier thingifier = model();
+        final ThingifierApiRouteRule rule =
+                thingifier
+                        .apiSpec()
+                        .route(RoutingVerb.POST, "/api/todos")
+                        .secureWithBearerAuth("cartToken")
+                        .secureWithBasicAuth("adminPassword");
+
+        Assertions.assertTrue(rule.hasBasicAuthEnforcement());
+        Assertions.assertFalse(rule.hasBearerAuthEnforcement());
+    }
+
+    @Test
+    void namedBearerAuthClearsBasicEnforcementOnRoute() {
+        final Thingifier thingifier = model();
+        final ThingifierApiRouteRule rule =
+                thingifier
+                        .apiSpec()
+                        .route(RoutingVerb.POST, "/api/todos")
+                        .secureWithBasicAuth("adminPassword")
+                        .secureWithBearerAuth("cartToken");
+
+        Assertions.assertFalse(rule.hasBasicAuthEnforcement());
+        Assertions.assertTrue(rule.hasBearerAuthEnforcement());
     }
 
     @Test

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerSecurityTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerSecurityTest.java
@@ -50,6 +50,39 @@ class SwaggerizerSecurityTest {
     }
 
     @Test
+    void basicSecuredRoutesAddHttpBasicSecuritySchemeAndOperationRequirement() {
+        final ThingifierApiDocumentationDefn apiDefn = new ThingifierApiDocumentationDefn();
+        apiDefn.addRouteToDocumentation(
+                new RoutingDefinition(
+                                RoutingVerb.POST,
+                                "/shop/login",
+                                RoutingStatus.returnedFromCall(),
+                                null)
+                        .addDocumentation("login")
+                        .addPossibleStatuses(200, 401, 403)
+                        .secureWithBasicAuth());
+
+        final OpenAPI openApi = new Swaggerizer(apiDefn).swagger();
+
+        final SecurityScheme basicAuth =
+                openApi.getComponents().getSecuritySchemes().get("basicAuth");
+        Assertions.assertNotNull(basicAuth);
+        Assertions.assertEquals(SecurityScheme.Type.HTTP, basicAuth.getType());
+        Assertions.assertEquals("basic", basicAuth.getScheme());
+        Assertions.assertNull(basicAuth.getBearerFormat());
+        Assertions.assertEquals(
+                "basicAuth",
+                openApi.getPaths()
+                        .get("/shop/login")
+                        .getPost()
+                        .getSecurity()
+                        .get(0)
+                        .keySet()
+                        .iterator()
+                        .next());
+    }
+
+    @Test
     void bearerSecuredGeneratedRoutesAddOperationRequirement() {
         final Thingifier thingifier = relationshipModel();
         thingifier


### PR DESCRIPTION
## Summary
- Add first-class runtime enforcement for named Basic auth schemes alongside existing Bearer auth.
- Keep legacy no-arg `secureWithBasicAuth()` as documentation-only behavior.
- Add Basic realm configuration, stricter Basic credential parsing, auth context accessors, and OpenAPI output for named Basic schemes.
- Preserve custom authenticator rejection responses exactly when callers return their own response.

## Verification
- Full `mvn clean verify` passed in the pre-commit hook.
- Installed the updated `1.5.6-SNAPSHOT` artifacts to the local Maven repository for API Challenges.

Closes #148
