### PR TITLE
Implement auth-selected data scopes

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/DefaultThingifierApiRuntime.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/DefaultThingifierApiRuntime.java
@@ -1,13 +1,16 @@
 package uk.co.compendiumdev.thingifier.adapter.http.apihandlers;
 
 import java.util.List;
+import java.util.Optional;
 import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
 import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
+import uk.co.compendiumdev.thingifier.api.security.DataScopeCreationPolicy;
 import uk.co.compendiumdev.thingifier.api.spec.ThingifierApiSpec;
 import uk.co.compendiumdev.thingifier.apiconfig.ThingifierApiConfig;
 import uk.co.compendiumdev.thingifier.application.ThingCommandService;
 import uk.co.compendiumdev.thingifier.application.ThingQueryService;
+import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
 
 public final class DefaultThingifierApiRuntime implements ThingifierApiRuntime {
 
@@ -44,6 +47,27 @@ public final class DefaultThingifierApiRuntime implements ThingifierApiRuntime {
     @Override
     public ThingifierRequestContext contextFrom(final HttpHeadersBlock requestHeaders) {
         return ThingifierRequestContext.from(thingifier, requestHeaders);
+    }
+
+    @Override
+    public Optional<ThingStore> storeForDataScope(
+            final String dataScopeName, final DataScopeCreationPolicy creationPolicy) {
+        final DataScopeCreationPolicy policy =
+                creationPolicy == null ? DataScopeCreationPolicy.USE_EXISTING_ONLY : creationPolicy;
+
+        switch (policy) {
+            case ENSURE_EXISTS:
+                thingifier.getERmodel().createInstanceDatabaseIfNotExisting(dataScopeName);
+                break;
+            case ENSURE_CREATED_AND_POPULATED:
+                thingifier.ensureCreatedAndPopulatedInstanceDatabaseNamed(dataScopeName);
+                break;
+            case USE_EXISTING_ONLY:
+            default:
+                break;
+        }
+
+        return Optional.ofNullable(thingifier.getStore(dataScopeName));
     }
 
     @Override

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/RouteAuthPolicy.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/RouteAuthPolicy.java
@@ -12,18 +12,21 @@ import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
 import uk.co.compendiumdev.thingifier.api.http.headers.headerparser.BasicAuthHeaderParser;
 import uk.co.compendiumdev.thingifier.api.http.headers.headerparser.BearerAuthHeaderParser;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
+import uk.co.compendiumdev.thingifier.api.security.DataScopeCreationPolicy;
 import uk.co.compendiumdev.thingifier.api.security.ThingifierApiAuthenticationContext;
 import uk.co.compendiumdev.thingifier.api.security.ThingifierApiAuthenticationResult;
 import uk.co.compendiumdev.thingifier.api.security.ThingifierApiAuthenticator;
 import uk.co.compendiumdev.thingifier.api.security.ThingifierApiAuthorizationContext;
 import uk.co.compendiumdev.thingifier.api.security.ThingifierApiAuthorizationResult;
 import uk.co.compendiumdev.thingifier.api.security.ThingifierApiAuthorizer;
+import uk.co.compendiumdev.thingifier.api.security.ThingifierApiDataScopeSelection;
 import uk.co.compendiumdev.thingifier.api.security.ThingifierApiRouteAuthDetails;
 import uk.co.compendiumdev.thingifier.api.spec.ApiRoutePathMatcher;
 import uk.co.compendiumdev.thingifier.api.spec.ThingifierApiRouteRule;
 import uk.co.compendiumdev.thingifier.application.schema.EntityTypeRef;
 import uk.co.compendiumdev.thingifier.application.schema.RelationshipSpec;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
 
 /**
  * Enforces route-level authentication and authorization configured in the API spec.
@@ -208,7 +211,63 @@ public final class RouteAuthPolicy {
         }
 
         context.setAuthenticatedPrincipal(schemeName, authentication.principal());
+        final ApiResponse dataScopeResponse = applyDataScopeSelection(context, authentication);
+        if (dataScopeResponse != null) {
+            return dataScopeResponse;
+        }
         return rejectIfUnauthorizedByAuthorizer(rule, authenticationContext, authentication);
+    }
+
+    /**
+     * Applies a trusted data-scope selection returned by the authenticator.
+     *
+     * <p>This runs before authorizers so permission checks, validators, handlers, lifecycle hooks,
+     * and rendering all use the same selected request store. No selection preserves the context
+     * chosen before auth, including the historical session-header behavior.
+     *
+     * @param context active request context to update
+     * @param authentication successful authentication result
+     * @return error response when the selected scope cannot be resolved, otherwise null
+     */
+    private ApiResponse applyDataScopeSelection(
+            final ThingifierRequestContext context,
+            final ThingifierApiAuthenticationResult authentication) {
+        if (authentication.dataScopeSelection().isEmpty()) {
+            return null;
+        }
+
+        final ThingifierApiDataScopeSelection selection = authentication.dataScopeSelection().get();
+        if (requiresPreExistingScope(context, selection)) {
+            return ApiResponse.error404("Could not find data scope " + selection.dataScopeName());
+        }
+
+        final Optional<ThingStore> selectedStore =
+                runtime.storeForDataScope(selection.dataScopeName(), selection.creationPolicy());
+        if (selectedStore.isEmpty()) {
+            return ApiResponse.error404("Could not find data scope " + selection.dataScopeName());
+        }
+
+        if (requiresEmptyScopeAfterHeaderCreation(context, selection)) {
+            selectedStore.get().administration().clearAllData();
+        }
+        context.useDataScope(selection.dataScopeName(), selectedStore.get());
+        return null;
+    }
+
+    private boolean requiresPreExistingScope(
+            final ThingifierRequestContext context,
+            final ThingifierApiDataScopeSelection selection) {
+        return selection.creationPolicy() == DataScopeCreationPolicy.USE_EXISTING_ONLY
+                && selection.dataScopeName().equals(context.dataScopeName())
+                && context.wasDataScopeCreatedWhenContextCreated();
+    }
+
+    private boolean requiresEmptyScopeAfterHeaderCreation(
+            final ThingifierRequestContext context,
+            final ThingifierApiDataScopeSelection selection) {
+        return selection.creationPolicy() == DataScopeCreationPolicy.ENSURE_EXISTS
+                && selection.dataScopeName().equals(context.dataScopeName())
+                && context.wasDataScopeCreatedWhenContextCreated();
     }
 
     /**

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/ThingifierApiRuntime.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/ThingifierApiRuntime.java
@@ -1,12 +1,15 @@
 package uk.co.compendiumdev.thingifier.adapter.http.apihandlers;
 
 import java.util.List;
+import java.util.Optional;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
 import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
+import uk.co.compendiumdev.thingifier.api.security.DataScopeCreationPolicy;
 import uk.co.compendiumdev.thingifier.api.spec.ThingifierApiSpec;
 import uk.co.compendiumdev.thingifier.apiconfig.ThingifierApiConfig;
 import uk.co.compendiumdev.thingifier.application.ThingCommandService;
 import uk.co.compendiumdev.thingifier.application.ThingQueryService;
+import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
 
 public interface ThingifierApiRuntime {
 
@@ -19,6 +22,20 @@ public interface ThingifierApiRuntime {
     List<String> thingNames();
 
     ThingifierRequestContext contextFrom(HttpHeadersBlock requestHeaders);
+
+    /**
+     * Resolves the store backing a trusted auth-selected data scope.
+     *
+     * <p>The runtime owns this because different Thingifier deployments can back data scopes with
+     * different store providers. Auth policy supplies only the trusted scope name and creation
+     * policy returned by application authentication code.
+     *
+     * @param dataScopeName trusted data-scope name
+     * @param creationPolicy policy for missing data scopes
+     * @return resolved store, or empty when the policy requires an existing scope and none exists
+     */
+    Optional<ThingStore> storeForDataScope(
+            String dataScopeName, DataScopeCreationPolicy creationPolicy);
 
     ThingCommandService commandService(ThingifierRequestContext context);
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/ThingifierApiLifecycleContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/ThingifierApiLifecycleContext.java
@@ -255,6 +255,11 @@ public final class ThingifierApiLifecycleContext
     }
 
     @Override
+    public String dataScopeName() {
+        return requestContext().dataScopeName();
+    }
+
+    @Override
     public ThingStore store() {
         return requestContext().store();
     }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/ThingifierApiLifecycleContextView.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/lifecycle/ThingifierApiLifecycleContextView.java
@@ -166,6 +166,16 @@ public interface ThingifierApiLifecycleContextView {
     ThingifierRequestContext requestContext();
 
     /**
+     * Returns the active data scope for this request.
+     *
+     * <p>When an authenticator selects a data scope, hooks that run after auth see the trusted
+     * selected scope here.
+     *
+     * @return active data-scope name
+     */
+    String dataScopeName();
+
+    /**
      * Returns the active Thingifier store for the request.
      *
      * @return active store

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
@@ -254,7 +254,7 @@ public final class ThingifierHttpApi {
         }
 
         if (httpResponse == null) {
-            httpResponse = validateEntityViewInput(request, effectiveVerb);
+            httpResponse = validateEntityViewInput(request, effectiveVerb, lifecycle);
         }
 
         // TODO: consider 'processing' hooks which can be used to override the generic processing
@@ -536,10 +536,13 @@ public final class ThingifierHttpApi {
      *
      * @param request HTTP API request
      * @param verb effective HTTP API verb
+     * @param lifecycle lifecycle context carrying any auth-selected data scope
      * @return error response when disallowed input fields are present, otherwise null
      */
     private HttpApiResponse validateEntityViewInput(
-            final HttpApiRequest request, final HttpVerb verb) {
+            final HttpApiRequest request,
+            final HttpVerb verb,
+            final ThingifierApiLifecycleContext lifecycle) {
         if (verb != HttpVerb.POST && verb != HttpVerb.PUT && verb != HttpVerb.PATCH) {
             return null;
         }
@@ -577,7 +580,7 @@ public final class ThingifierHttpApi {
 
         final EntityViewDefinition view = entity.getViewNamed(viewName);
         final List<String> disallowedFields = new ArrayList<>();
-        for (ApiBodyField field : entityViewInputFields(request, verb, entity)) {
+        for (ApiBodyField field : entityViewInputFields(request, verb, entity, lifecycle)) {
             if (entity.hasFieldNameDefined(field.name()) && !view.isInputAllowed(field.name())) {
                 disallowedFields.add(field.name());
             }
@@ -605,12 +608,16 @@ public final class ThingifierHttpApi {
      * @param request HTTP API request
      * @param verb effective HTTP API verb
      * @param entity target entity definition
+     * @param lifecycle lifecycle context carrying any auth-selected data scope
      * @return fields that may be checked against the input view
      */
     private List<ApiBodyField> entityViewInputFields(
-            final HttpApiRequest request, final HttpVerb verb, final EntityDefinition entity) {
+            final HttpApiRequest request,
+            final HttpVerb verb,
+            final EntityDefinition entity,
+            final ThingifierApiLifecycleContext lifecycle) {
         if (verb == HttpVerb.PATCH) {
-            return patchInputFields(request, entity);
+            return patchInputFields(request, entity, lifecycle);
         }
 
         return ApiRequestEnvelope.from(request, verb, xmlEntityNamesFor(request.getPath()))
@@ -623,10 +630,13 @@ public final class ThingifierHttpApi {
      *
      * @param request HTTP API request
      * @param entity target entity definition
+     * @param lifecycle lifecycle context carrying any auth-selected data scope
      * @return fields touched by the patch document
      */
     private List<ApiBodyField> patchInputFields(
-            final HttpApiRequest request, final EntityDefinition entity) {
+            final HttpApiRequest request,
+            final EntityDefinition entity,
+            final ThingifierApiLifecycleContext lifecycle) {
         final Optional<EntityPatchUpdateStyle> style =
                 EntityPatchUpdateStyle.fromContentType(request.getContentTypeHeader());
         if (style.isEmpty()) {
@@ -634,7 +644,7 @@ public final class ThingifierHttpApi {
         }
 
         if (style.get() == EntityPatchUpdateStyle.JSON_PATCH_RFC6902) {
-            return jsonPatchInputFields(request, entity);
+            return jsonPatchInputFields(request, entity, lifecycle);
         }
 
         return objectPatchInputFields(request.getBody());
@@ -663,10 +673,13 @@ public final class ThingifierHttpApi {
      *
      * @param request HTTP API request
      * @param entity target entity definition
+     * @param lifecycle lifecycle context carrying any auth-selected data scope
      * @return fields referenced or produced by the patch document
      */
     private List<ApiBodyField> jsonPatchInputFields(
-            final HttpApiRequest request, final EntityDefinition entity) {
+            final HttpApiRequest request,
+            final EntityDefinition entity,
+            final ThingifierApiLifecycleContext lifecycle) {
         final List<ApiBodyField> inputFields = new ArrayList<>();
         final JsonNode operations;
         try {
@@ -689,7 +702,8 @@ public final class ThingifierHttpApi {
             addRootReplacementFields(inputFields, operation);
         }
 
-        rootResultFieldsForJsonPatch(request, entity, operations).ifPresent(inputFields::addAll);
+        rootResultFieldsForJsonPatch(request, entity, operations, lifecycle)
+                .ifPresent(inputFields::addAll);
 
         return inputFields;
     }
@@ -733,17 +747,19 @@ public final class ThingifierHttpApi {
      * @param request HTTP API request
      * @param entity target entity definition
      * @param operations JSON Patch operation array
+     * @param lifecycle lifecycle context carrying any auth-selected data scope
      * @return resulting top-level fields when they can be calculated
      */
     private Optional<List<ApiBodyField>> rootResultFieldsForJsonPatch(
             final HttpApiRequest request,
             final EntityDefinition entity,
-            final JsonNode operations) {
+            final JsonNode operations,
+            final ThingifierApiLifecycleContext lifecycle) {
         if (!hasRootReplacementOperation(operations)) {
             return Optional.empty();
         }
 
-        final EntityInstance instance = targetInstanceFor(request, entity);
+        final EntityInstance instance = targetInstanceFor(request, entity, lifecycle);
         if (instance == null) {
             return Optional.empty();
         }
@@ -814,17 +830,24 @@ public final class ThingifierHttpApi {
      *
      * @param request HTTP API request
      * @param entity target entity definition
+     * @param lifecycle lifecycle context carrying any auth-selected data scope
      * @return matching instance, or null when the route is not an instance route
      */
     private EntityInstance targetInstanceFor(
-            final HttpApiRequest request, final EntityDefinition entity) {
+            final HttpApiRequest request,
+            final EntityDefinition entity,
+            final ThingifierApiLifecycleContext lifecycle) {
         final SchemaCatalog schema = new ThingifierSchemaCatalog(thingifier);
         final ThingRoute route = new ThingRouteMapper(schema).map(request.getPath());
         if (!(route instanceof InstanceRoute)) {
             return null;
         }
 
-        return ThingifierRequestContext.from(thingifier, request.getHeaders())
+        final ThingifierRequestContext requestContext =
+                lifecycle == null
+                        ? ThingifierRequestContext.from(thingifier, request.getHeaders())
+                        : lifecycle.requestContext();
+        return requestContext
                 .store()
                 .entityQueries()
                 .findByQueryIdentifier(entity, ((InstanceRoute) route).identifier());

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierRequestContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierRequestContext.java
@@ -24,10 +24,11 @@ import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
  */
 public final class ThingifierRequestContext {
 
-    private final String databaseName;
-    private final ThingStore store;
+    private String databaseName;
+    private ThingStore store;
     private final HttpHeadersBlock headers;
     private final Map<String, Object> authenticatedPrincipals;
+    private boolean dataScopeCreatedWhenContextCreated;
 
     /**
      * Creates a request context for one selected store.
@@ -37,11 +38,15 @@ public final class ThingifierRequestContext {
      * @param headers request headers used to create the context
      */
     private ThingifierRequestContext(
-            final String databaseName, final ThingStore store, final HttpHeadersBlock headers) {
+            final String databaseName,
+            final ThingStore store,
+            final HttpHeadersBlock headers,
+            final boolean dataScopeCreatedWhenContextCreated) {
         this.databaseName = databaseName;
         this.store = store;
         this.headers = headers;
         this.authenticatedPrincipals = new HashMap<>();
+        this.dataScopeCreatedWhenContextCreated = dataScopeCreatedWhenContextCreated;
     }
 
     /**
@@ -59,9 +64,10 @@ public final class ThingifierRequestContext {
         HttpHeadersBlock safeHeaders =
                 requestHeaders == null ? new HttpHeadersBlock() : requestHeaders;
         String databaseName = databaseNameFrom(safeHeaders);
+        boolean dataScopeCreated = thingifier.getStore(databaseName) == null;
         thingifier.ensureCreatedAndPopulatedInstanceDatabaseNamed(databaseName);
         return new ThingifierRequestContext(
-                databaseName, thingifier.getStore(databaseName), safeHeaders);
+                databaseName, thingifier.getStore(databaseName), safeHeaders, dataScopeCreated);
     }
 
     /**
@@ -85,6 +91,54 @@ public final class ThingifierRequestContext {
      */
     public String databaseName() {
         return databaseName;
+    }
+
+    /**
+     * Returns the active data-scope name for the request.
+     *
+     * <p>This is the public auth and lifecycle wording for the same isolation boundary historically
+     * exposed as {@link #databaseName()}. Auth-selected data scopes update this value before
+     * authorizers and generated handlers continue.
+     *
+     * @return active data-scope name
+     */
+    public String dataScopeName() {
+        return databaseName;
+    }
+
+    /**
+     * Switches the request to a trusted data scope selected by authentication.
+     *
+     * <p>The context object is shared by direct handlers, HTTP lifecycle hooks, authorizers, and
+     * response rendering. Updating it in place makes the selected scope visible to every later
+     * phase without losing headers or already authenticated principals.
+     *
+     * @param dataScopeName trusted data-scope name
+     * @param store store backing the selected scope
+     * @throws IllegalArgumentException when the name is blank or the store is missing
+     */
+    public void useDataScope(final String dataScopeName, final ThingStore store) {
+        if (dataScopeName == null || dataScopeName.trim().isEmpty()) {
+            throw new IllegalArgumentException("dataScopeName is required");
+        }
+        if (store == null) {
+            throw new IllegalArgumentException("store is required");
+        }
+        this.databaseName = dataScopeName.trim();
+        this.store = store;
+        this.dataScopeCreatedWhenContextCreated = false;
+    }
+
+    /**
+     * Reports whether the initial request context had to create the selected scope.
+     *
+     * <p>Auth-selected scope enforcement uses this to avoid treating an untrusted header-created
+     * store as pre-existing when the authenticator requested {@code USE_EXISTING_ONLY}.
+     *
+     * @return true when context creation created the initial data scope
+     */
+    public boolean wasDataScopeCreatedWhenContextCreated() {
+        return dataScopeCreatedWhenContextCreated;
     }
 
     /**

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/DataScopeCreationPolicy.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/DataScopeCreationPolicy.java
@@ -1,0 +1,30 @@
+package uk.co.compendiumdev.thingifier.api.security;
+
+/**
+ * Controls how Thingifier resolves an auth-selected data scope.
+ *
+ * <p>Authenticators use this policy after they have validated credentials and decided which
+ * application-owned data scope should handle the request. The public API says "data scope" because
+ * callers are choosing an isolation boundary; internally Thingifier may back that scope with a
+ * database, session store, in-memory store, or another {@code ThingStoreProvider} implementation.
+ */
+public enum DataScopeCreationPolicy {
+    /**
+     * Use only a store that already exists.
+     *
+     * <p>This is the safest default because authentication selects a scope without implicitly
+     * provisioning storage.
+     */
+    USE_EXISTING_ONLY,
+
+    /** Create an empty store when the selected data scope does not already exist. */
+    ENSURE_EXISTS,
+
+    /**
+     * Create and populate the selected data scope when it does not already exist.
+     *
+     * <p>Population uses the Thingifier model's configured data generator. Application-specific
+     * synchronization still belongs in application code before returning the auth result.
+     */
+    ENSURE_CREATED_AND_POPULATED
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthenticationContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthenticationContext.java
@@ -153,6 +153,19 @@ public final class ThingifierApiAuthenticationContext {
     }
 
     /**
+     * Returns the active data scope for this request.
+     *
+     * <p>During authentication this is the context selected before the authenticator returned. When
+     * the authentication result selects a different data scope, authorizers and later lifecycle
+     * phases see the updated value through the same request context.
+     *
+     * @return active data-scope name
+     */
+    public String dataScopeName() {
+        return requestContext.dataScopeName();
+    }
+
+    /**
      * Returns the active Thingifier store.
      *
      * @return request store

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthenticationResult.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthenticationResult.java
@@ -1,5 +1,6 @@
 package uk.co.compendiumdev.thingifier.api.security;
 
+import java.util.Optional;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
 
 /**
@@ -8,6 +9,10 @@ import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
  * <p>The result either supplies a principal for later authorization or an API response explaining
  * why the credentials cannot be accepted. Thingifier supplies the standard missing and malformed
  * bearer-token responses before invoking authenticators.
+ *
+ * <p>Successful authenticators may also choose a data scope for the rest of the request. That
+ * selection is trusted because it is returned only after application code has validated the
+ * credential.
  */
 public final class ThingifierApiAuthenticationResult {
 
@@ -15,16 +20,19 @@ public final class ThingifierApiAuthenticationResult {
     private final Object principal;
     private final ApiResponse rejectionResponse;
     private final boolean customRejectionResponse;
+    private final ThingifierApiDataScopeSelection dataScopeSelection;
 
     private ThingifierApiAuthenticationResult(
             final boolean authenticated,
             final Object principal,
             final ApiResponse rejectionResponse,
-            final boolean customRejectionResponse) {
+            final boolean customRejectionResponse,
+            final ThingifierApiDataScopeSelection dataScopeSelection) {
         this.authenticated = authenticated;
         this.principal = principal;
         this.rejectionResponse = rejectionResponse;
         this.customRejectionResponse = customRejectionResponse;
+        this.dataScopeSelection = dataScopeSelection;
     }
 
     /**
@@ -34,7 +42,7 @@ public final class ThingifierApiAuthenticationResult {
      * @return successful authentication result
      */
     public static ThingifierApiAuthenticationResult authenticated(final Object principal) {
-        return new ThingifierApiAuthenticationResult(true, principal, null, false);
+        return new ThingifierApiAuthenticationResult(true, principal, null, false, null);
     }
 
     /**
@@ -66,7 +74,7 @@ public final class ThingifierApiAuthenticationResult {
     public static ThingifierApiAuthenticationResult rejected(
             final int status, final String message) {
         return new ThingifierApiAuthenticationResult(
-                false, null, ApiResponse.error(status, message), false);
+                false, null, ApiResponse.error(status, message), false, null);
     }
 
     /**
@@ -80,7 +88,52 @@ public final class ThingifierApiAuthenticationResult {
      * @return rejected authentication result
      */
     public static ThingifierApiAuthenticationResult rejected(final ApiResponse response) {
-        return new ThingifierApiAuthenticationResult(false, null, response, true);
+        return new ThingifierApiAuthenticationResult(false, null, response, true, null);
+    }
+
+    /**
+     * Selects a named data scope for the authenticated request.
+     *
+     * <p>The selected scope replaces any request-header/session-selected scope before authorizers,
+     * validators, handlers, and response rendering continue. Missing scopes are not created unless
+     * a creation policy is supplied through {@link #useDataScope(String, DataScopeCreationPolicy)}.
+     *
+     * @param dataScopeName data scope chosen by trusted authentication code
+     * @return new authentication result with a data-scope selection
+     * @throws IllegalStateException when called on a rejected authentication result
+     */
+    public ThingifierApiAuthenticationResult useDataScope(final String dataScopeName) {
+        return useDataScope(dataScopeName, DataScopeCreationPolicy.USE_EXISTING_ONLY);
+    }
+
+    /**
+     * Selects a named data scope and missing-scope policy for the authenticated request.
+     *
+     * @param dataScopeName data scope chosen by trusted authentication code
+     * @param creationPolicy policy used when the scope does not exist
+     * @return new authentication result with a data-scope selection
+     * @throws IllegalStateException when called on a rejected authentication result
+     */
+    public ThingifierApiAuthenticationResult useDataScope(
+            final String dataScopeName, final DataScopeCreationPolicy creationPolicy) {
+        requireAuthenticatedForDataScopeSelection();
+        return withDataScopeSelection(
+                ThingifierApiDataScopeSelection.named(dataScopeName, creationPolicy));
+    }
+
+    /**
+     * Explicitly selects the model's default data scope for the authenticated request.
+     *
+     * <p>This is different from returning no data-scope selection. No selection preserves existing
+     * request context behaviour, while this method intentionally overrides any session/header
+     * selected scope.
+     *
+     * @return new authentication result selecting the default data scope
+     * @throws IllegalStateException when called on a rejected authentication result
+     */
+    public ThingifierApiAuthenticationResult useDefaultDataScope() {
+        requireAuthenticatedForDataScopeSelection();
+        return withDataScopeSelection(ThingifierApiDataScopeSelection.defaultDataScope());
     }
 
     /**
@@ -117,5 +170,27 @@ public final class ThingifierApiAuthenticationResult {
      */
     public boolean hasCustomRejectionResponse() {
         return customRejectionResponse;
+    }
+
+    /**
+     * Returns the data scope selected by trusted authentication code.
+     *
+     * @return selected data scope, or empty when current request-context behaviour should remain
+     */
+    public Optional<ThingifierApiDataScopeSelection> dataScopeSelection() {
+        return Optional.ofNullable(dataScopeSelection);
+    }
+
+    private ThingifierApiAuthenticationResult withDataScopeSelection(
+            final ThingifierApiDataScopeSelection selection) {
+        return new ThingifierApiAuthenticationResult(
+                authenticated, principal, rejectionResponse, customRejectionResponse, selection);
+    }
+
+    private void requireAuthenticatedForDataScopeSelection() {
+        if (!authenticated) {
+            throw new IllegalStateException(
+                    "data scopes can only be selected by authenticated results");
+        }
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthorizationContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthorizationContext.java
@@ -125,6 +125,18 @@ public final class ThingifierApiAuthorizationContext {
     }
 
     /**
+     * Returns the active data scope selected for the authorized request.
+     *
+     * <p>If the authenticator returned a data-scope selection, this value reflects that trusted
+     * post-auth decision rather than any earlier session/header-selected scope.
+     *
+     * @return active data-scope name
+     */
+    public String dataScopeName() {
+        return authenticationContext.dataScopeName();
+    }
+
+    /**
      * Returns the active Thingifier store.
      *
      * @return request store

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiDataScopeSelection.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiDataScopeSelection.java
@@ -1,0 +1,111 @@
+package uk.co.compendiumdev.thingifier.api.security;
+
+import uk.co.compendiumdev.thingifier.core.EntityRelModel;
+
+/**
+ * Trusted data-scope decision returned by an authenticator.
+ *
+ * <p>Thingifier never infers this from arbitrary request input. An authenticator may inspect
+ * headers, route parameters, tokens, claims, or credentials, but this object is only created after
+ * application code has decided that those inputs identify a scope the request may use.
+ */
+public final class ThingifierApiDataScopeSelection {
+
+    private final String dataScopeName;
+    private final DataScopeCreationPolicy creationPolicy;
+    private final boolean explicit;
+
+    private ThingifierApiDataScopeSelection(
+            final String dataScopeName,
+            final DataScopeCreationPolicy creationPolicy,
+            final boolean explicit) {
+        this.dataScopeName = dataScopeName;
+        this.creationPolicy =
+                creationPolicy == null ? DataScopeCreationPolicy.USE_EXISTING_ONLY : creationPolicy;
+        this.explicit = explicit;
+    }
+
+    /**
+     * Creates an explicit selection for the named data scope.
+     *
+     * @param dataScopeName data scope name chosen by trusted application auth code
+     * @param creationPolicy missing-scope handling policy
+     * @return immutable data-scope selection
+     * @throws IllegalArgumentException when the name is blank or not portable across store
+     *     providers
+     */
+    public static ThingifierApiDataScopeSelection named(
+            final String dataScopeName, final DataScopeCreationPolicy creationPolicy) {
+        return new ThingifierApiDataScopeSelection(
+                requireValidDataScopeName(dataScopeName), creationPolicy, true);
+    }
+
+    /**
+     * Creates an explicit selection for the model's default data scope.
+     *
+     * <p>This intentionally overrides any request header or session-selected scope.
+     *
+     * @return immutable default data-scope selection
+     */
+    public static ThingifierApiDataScopeSelection defaultDataScope() {
+        return new ThingifierApiDataScopeSelection(
+                EntityRelModel.DEFAULT_DATABASE_NAME,
+                DataScopeCreationPolicy.USE_EXISTING_ONLY,
+                true);
+    }
+
+    /**
+     * Returns the selected data scope name.
+     *
+     * @return selected scope name
+     */
+    public String dataScopeName() {
+        return dataScopeName;
+    }
+
+    /**
+     * Returns the missing-scope policy requested by the authenticator.
+     *
+     * @return creation policy
+     */
+    public DataScopeCreationPolicy creationPolicy() {
+        return creationPolicy;
+    }
+
+    /**
+     * Reports whether application code explicitly selected this scope.
+     *
+     * @return true when an authenticator chose the data scope
+     */
+    public boolean isExplicit() {
+        return explicit;
+    }
+
+    private static String requireValidDataScopeName(final String dataScopeName) {
+        if (dataScopeName == null || dataScopeName.trim().isEmpty()) {
+            throw new IllegalArgumentException("dataScopeName is required");
+        }
+
+        final String normalized = dataScopeName.trim();
+        for (int index = 0; index < normalized.length(); index++) {
+            if (!isPortableDataScopeNameCharacter(normalized.charAt(index))) {
+                throw new IllegalArgumentException(
+                        "dataScopeName may only contain letters, numbers, '.', '_' and '-'");
+            }
+        }
+        return normalized;
+    }
+
+    private static boolean isPortableDataScopeNameCharacter(final char character) {
+        return isAsciiLetterOrDigit(character)
+                || character == '.'
+                || character == '_'
+                || character == '-';
+    }
+
+    private static boolean isAsciiLetterOrDigit(final char character) {
+        return (character >= 'A' && character <= 'Z')
+                || (character >= 'a' && character <= 'z')
+                || (character >= '0' && character <= '9');
+    }
+}

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthPolicyTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthPolicyTest.java
@@ -8,6 +8,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleHookRegistry;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.api.docgen.ThingifierApiDocumentationDefn;
 import uk.co.compendiumdev.thingifier.api.http.HttpApiRequest;
@@ -25,6 +26,8 @@ import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.F
 import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
 import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstanceDraft;
 import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
+import uk.co.compendiumdev.thingifier.core.reporting.ValidationReport;
+import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
 
 class ThingifierApiAuthPolicyTest {
 
@@ -651,6 +654,338 @@ class ThingifierApiAuthPolicyTest {
     }
 
     @Test
+    void bearerAuthenticatorSelectsDataScopeForWrite() {
+        final Thingifier thingifier = todoModel();
+        ensureDataScopeExists(thingifier, "tenant-one");
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "tenantToken",
+                        context ->
+                                ThingifierApiAuthenticationResult.authenticated("tenant-principal")
+                                        .useDataScope("tenant-one"));
+        thingifier.apiSpec().route(RoutingVerb.POST, "/todos").secureWithBearerAuth("tenantToken");
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"tenant todo\"}"),
+                                headersWithBearer("valid-token"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals(
+                0, todoCountInScope(thingifier, EntityRelModel.DEFAULT_DATABASE_NAME));
+        Assertions.assertEquals(1, todoCountInScope(thingifier, "tenant-one"));
+    }
+
+    @Test
+    void basicAuthenticatorSelectsDataScopeForWrite() {
+        final Thingifier thingifier = todoModel();
+        ensureDataScopeExists(thingifier, "tenant-one");
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "adminPassword",
+                        context ->
+                                ThingifierApiAuthenticationResult.authenticated("basic-principal")
+                                        .useDataScope("tenant-one"));
+        thingifier.apiSpec().route(RoutingVerb.POST, "/todos").secureWithBasicAuth("adminPassword");
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"tenant todo\"}"),
+                                headersWithBasic("admin", "password"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals(
+                0, todoCountInScope(thingifier, EntityRelModel.DEFAULT_DATABASE_NAME));
+        Assertions.assertEquals(1, todoCountInScope(thingifier, "tenant-one"));
+    }
+
+    @Test
+    void authorizerReceivesAuthSelectedDataScope() {
+        final Thingifier thingifier = todoModel();
+        ensureDataScopeExists(thingifier, "tenant-one");
+        final AtomicReference<String> seenDataScope = new AtomicReference<>();
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "tenantToken",
+                        context ->
+                                ThingifierApiAuthenticationResult.authenticated("tenant-principal")
+                                        .useDataScope("tenant-one"));
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.POST, "/todos")
+                .secureWithBearerAuth("tenantToken")
+                .authorizeWith(
+                        context -> {
+                            seenDataScope.set(context.dataScopeName());
+                            return ThingifierApiAuthorizationResult.authorized();
+                        });
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"tenant todo\"}"),
+                                headersWithBearer("valid-token"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals("tenant-one", seenDataScope.get());
+    }
+
+    @Test
+    void explicitDefaultDataScopeOverridesSessionHeader() {
+        final Thingifier thingifier = todoModel();
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "tenantToken",
+                        context ->
+                                ThingifierApiAuthenticationResult.authenticated("tenant-principal")
+                                        .useDefaultDataScope());
+        thingifier.apiSpec().route(RoutingVerb.POST, "/todos").secureWithBearerAuth("tenantToken");
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"default todo\"}"),
+                                headersWithSessionAndBearer("tenant-one", "valid-token"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals(
+                1, todoCountInScope(thingifier, EntityRelModel.DEFAULT_DATABASE_NAME));
+        Assertions.assertEquals(0, todoCountInScope(thingifier, "tenant-one"));
+    }
+
+    @Test
+    void useExistingOnlyRejectsMissingDataScope() {
+        final Thingifier thingifier = todoModel();
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "tenantToken",
+                        context ->
+                                ThingifierApiAuthenticationResult.authenticated("tenant-principal")
+                                        .useDataScope("missing-tenant"));
+        thingifier.apiSpec().route(RoutingVerb.POST, "/todos").secureWithBearerAuth("tenantToken");
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"blocked\"}"),
+                                headersWithBearer("valid-token"));
+
+        Assertions.assertEquals(404, response.getStatusCode());
+        Assertions.assertEquals(
+                0, todoCountInScope(thingifier, EntityRelModel.DEFAULT_DATABASE_NAME));
+        Assertions.assertNull(thingifier.getStore("missing-tenant"));
+    }
+
+    @Test
+    void useExistingOnlyRejectsHeaderCreatedDataScope() {
+        final Thingifier thingifier = todoModel();
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "tenantToken",
+                        context ->
+                                ThingifierApiAuthenticationResult.authenticated("tenant-principal")
+                                        .useDataScope("header-tenant"));
+        thingifier.apiSpec().route(RoutingVerb.POST, "/todos").secureWithBearerAuth("tenantToken");
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"blocked\"}"),
+                                headersWithSessionAndBearer("header-tenant", "valid-token"));
+
+        Assertions.assertEquals(404, response.getStatusCode());
+        Assertions.assertEquals(0, todoCountInScope(thingifier, "header-tenant"));
+    }
+
+    @Test
+    void ensureExistsCreatesUnpopulatedDataScope() {
+        final Thingifier thingifier = todoModel();
+        setSeedDataGenerator(thingifier, "seed todo");
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "tenantToken",
+                        context ->
+                                ThingifierApiAuthenticationResult.authenticated("tenant-principal")
+                                        .useDataScope(
+                                                "tenant-one",
+                                                DataScopeCreationPolicy.ENSURE_EXISTS));
+        thingifier.apiSpec().route(RoutingVerb.POST, "/todos").secureWithBearerAuth("tenantToken");
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"created todo\"}"),
+                                headersWithBearer("valid-token"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals(1, todoCountInScope(thingifier, "tenant-one"));
+        Assertions.assertEquals("created todo", firstTodoTitleInScope(thingifier, "tenant-one"));
+    }
+
+    @Test
+    void ensureCreatedAndPopulatedCreatesSeededDataScope() {
+        final Thingifier thingifier = todoModel();
+        setSeedDataGenerator(thingifier, "seed todo");
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "tenantToken",
+                        context ->
+                                ThingifierApiAuthenticationResult.authenticated("tenant-principal")
+                                        .useDataScope(
+                                                "tenant-one",
+                                                DataScopeCreationPolicy
+                                                        .ENSURE_CREATED_AND_POPULATED));
+        thingifier.apiSpec().route(RoutingVerb.GET, "/todos").secureWithBearerAuth("tenantToken");
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .get("todos", new QueryFilterParams(), headersWithBearer("valid-token"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(1, response.getReturnedInstanceCollection().size());
+        Assertions.assertEquals(
+                "seed todo",
+                response.getReturnedInstanceCollection().get(0).getFieldValue("title").asString());
+    }
+
+    @Test
+    void validatorReceivesAuthSelectedStore() {
+        final Thingifier thingifier = todoModel();
+        ensureDataScopeExists(thingifier, "tenant-one");
+        final AtomicReference<ThingStore> seenStore = new AtomicReference<>();
+        thingifier
+                .getDefinitionNamed("todo")
+                .withDomainValidation(
+                        context -> {
+                            seenStore.set(context.store());
+                            return new ValidationReport();
+                        });
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "tenantToken",
+                        context ->
+                                ThingifierApiAuthenticationResult.authenticated("tenant-principal")
+                                        .useDataScope("tenant-one"));
+        thingifier.apiSpec().route(RoutingVerb.POST, "/todos").secureWithBearerAuth("tenantToken");
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"tenant todo\"}"),
+                                headersWithBearer("valid-token"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertSame(thingifier.getStore("tenant-one"), seenStore.get());
+    }
+
+    @Test
+    void bodyParsedHookReceivesAuthSelectedDataScope() {
+        final Thingifier thingifier = todoModel();
+        thingifier.apiConfig().setFrom(new ThingifierApiConfig("/api"));
+        ensureDataScopeExists(thingifier, "tenant-one");
+        final AtomicReference<String> seenDataScope = new AtomicReference<>();
+        final ThingifierApiLifecycleHookRegistry hooks = new ThingifierApiLifecycleHookRegistry();
+        hooks.registerBodyParsedHook(context -> seenDataScope.set(context.dataScopeName()));
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "tenantToken",
+                        context ->
+                                ThingifierApiAuthenticationResult.authenticated("tenant-principal")
+                                        .useDataScope("tenant-one"));
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.POST, "/api/todos")
+                .secureWithBearerAuth("tenantToken");
+
+        final HttpApiResponse response =
+                ThingifierHttpApi.withHookRegistries(thingifier, null, hooks)
+                        .post(
+                                jsonPostRequest("/api/todos", "{\"title\":\"tenant todo\"}")
+                                        .addHeader("Authorization", "Bearer valid-token"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals("tenant-one", seenDataScope.get());
+    }
+
+    @Test
+    void sessionHeaderScopeAppliesWhenAuthenticationDoesNotSelectScope() {
+        final Thingifier thingifier = todoModel();
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "tenantToken",
+                        context ->
+                                ThingifierApiAuthenticationResult.authenticated(
+                                        "tenant-principal"));
+        thingifier.apiSpec().route(RoutingVerb.POST, "/todos").secureWithBearerAuth("tenantToken");
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"tenant todo\"}"),
+                                headersWithSessionAndBearer("tenant-one", "valid-token"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals(
+                0, todoCountInScope(thingifier, EntityRelModel.DEFAULT_DATABASE_NAME));
+        Assertions.assertEquals(1, todoCountInScope(thingifier, "tenant-one"));
+    }
+
+    @Test
+    void rejectedAuthenticationLeavesTargetScopeUnused() {
+        final Thingifier thingifier = todoModel();
+        ensureDataScopeExists(thingifier, "tenant-one");
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "tenantToken",
+                        context -> ThingifierApiAuthenticationResult.rejected(403, "Forbidden"));
+        thingifier.apiSpec().route(RoutingVerb.POST, "/todos").secureWithBearerAuth("tenantToken");
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"blocked\"}"),
+                                headersWithBearer("valid-token"));
+
+        Assertions.assertEquals(403, response.getStatusCode());
+        Assertions.assertEquals(0, todoCountInScope(thingifier, "tenant-one"));
+    }
+
+    @Test
     void missingAuthenticatorReturnsConfigurationError() {
         final Thingifier thingifier = todoModel();
         thingifier.apiSpec().route(RoutingVerb.POST, "/todos").secureWithBearerAuth("cartToken");
@@ -747,6 +1082,31 @@ class ThingifierApiAuthPolicyTest {
                 .create(EntityInstanceDraft.forEntity(todo).withField("title", title));
     }
 
+    private void ensureDataScopeExists(final Thingifier thingifier, final String dataScopeName) {
+        thingifier.getERmodel().createInstanceDatabaseIfNotExisting(dataScopeName);
+    }
+
+    private void setSeedDataGenerator(final Thingifier thingifier, final String title) {
+        thingifier.setDataGenerator(
+                (schema, store) -> {
+                    final EntityDefinition todo = schema.getEntityDefinitionNamed("todo");
+                    store.entities()
+                            .create(EntityInstanceDraft.forEntity(todo).withField("title", title));
+                });
+    }
+
+    private int todoCountInScope(final Thingifier thingifier, final String dataScopeName) {
+        return thingifier.listThingInstancesNamed("todos", dataScopeName).size();
+    }
+
+    private String firstTodoTitleInScope(final Thingifier thingifier, final String dataScopeName) {
+        return thingifier
+                .listThingInstancesNamed("todos", dataScopeName)
+                .get(0)
+                .getFieldValue("title")
+                .asString();
+    }
+
     private BodyParser parser(final Thingifier thingifier, final String body) {
         return new BodyParser(
                 new HttpApiRequest("/request")
@@ -761,6 +1121,13 @@ class ThingifierApiAuthPolicyTest {
 
     private HttpHeadersBlock headersWithBasic(final String username, final String password) {
         return headersWithAuthorization(basicAuthorization(username, password));
+    }
+
+    private HttpHeadersBlock headersWithSessionAndBearer(
+            final String dataScopeName, final String token) {
+        final HttpHeadersBlock headers = headersWithBearer(token);
+        headers.put(ThingifierHttpApi.HTTP_SESSION_HEADER_NAME, dataScopeName);
+        return headers;
     }
 
     private String basicAuthorization(final String username, final String password) {

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthenticationResultTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthenticationResultTest.java
@@ -1,0 +1,84 @@
+package uk.co.compendiumdev.thingifier.api.security;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import uk.co.compendiumdev.thingifier.core.EntityRelModel;
+
+class ThingifierApiAuthenticationResultTest {
+
+    @Test
+    void authenticatedResultHasNoDataScopeSelectionByDefault() {
+        final ThingifierApiAuthenticationResult result =
+                ThingifierApiAuthenticationResult.authenticated("principal");
+
+        Assertions.assertTrue(result.dataScopeSelection().isEmpty());
+    }
+
+    @Test
+    void namedDataScopeUsesExistingOnlyPolicyByDefault() {
+        final ThingifierApiAuthenticationResult result =
+                ThingifierApiAuthenticationResult.authenticated("principal")
+                        .useDataScope("tenant-one");
+
+        final ThingifierApiDataScopeSelection selection = result.dataScopeSelection().get();
+        Assertions.assertEquals("tenant-one", selection.dataScopeName());
+        Assertions.assertEquals(
+                DataScopeCreationPolicy.USE_EXISTING_ONLY, selection.creationPolicy());
+        Assertions.assertTrue(selection.isExplicit());
+    }
+
+    @Test
+    void namedDataScopeRecordsCreationPolicy() {
+        final ThingifierApiAuthenticationResult result =
+                ThingifierApiAuthenticationResult.authenticated("principal")
+                        .useDataScope(
+                                "tenant-one", DataScopeCreationPolicy.ENSURE_CREATED_AND_POPULATED);
+
+        Assertions.assertEquals(
+                DataScopeCreationPolicy.ENSURE_CREATED_AND_POPULATED,
+                result.dataScopeSelection().get().creationPolicy());
+    }
+
+    @Test
+    void defaultDataScopeExplicitlySelectsDefaultStore() {
+        final ThingifierApiAuthenticationResult result =
+                ThingifierApiAuthenticationResult.authenticated("principal").useDefaultDataScope();
+
+        final ThingifierApiDataScopeSelection selection = result.dataScopeSelection().get();
+        Assertions.assertEquals(EntityRelModel.DEFAULT_DATABASE_NAME, selection.dataScopeName());
+        Assertions.assertEquals(
+                DataScopeCreationPolicy.USE_EXISTING_ONLY, selection.creationPolicy());
+        Assertions.assertTrue(selection.isExplicit());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(
+            strings = {
+                " ",
+                "\t",
+                "tenant one",
+                "tenant/one",
+                "tenant\\one",
+                "tenant\none",
+                "tenanté"
+            })
+    void namedDataScopeRejectsUnsafeNames(final String dataScopeName) {
+        final ThingifierApiAuthenticationResult result =
+                ThingifierApiAuthenticationResult.authenticated("principal");
+
+        Assertions.assertThrows(
+                IllegalArgumentException.class, () -> result.useDataScope(dataScopeName));
+    }
+
+    @Test
+    void rejectedResultCannotSelectDataScope() {
+        final ThingifierApiAuthenticationResult result =
+                ThingifierApiAuthenticationResult.rejected(403, "Forbidden");
+
+        Assertions.assertThrows(IllegalStateException.class, result::useDefaultDataScope);
+    }
+}


### PR DESCRIPTION
Summary
- Added auth-selected data scope selection to authentication results.
- Applied selected scopes before authorizers, validators, lifecycle hooks, handlers, and response rendering.
- Preserved existing session-header, Basic auth, and Bearer auth behavior when no scope is selected.
- Added coverage for scope API validation, Basic/Bearer runtime selection, creation policies, hooks, validators, and legacy session behavior.

Verification
- mvn -pl thingifier "-Dtest=ThingifierApiAuthenticationResultTest,ThingifierApiAuthPolicyTest" test
- mvn clean verify
- mvn install -DskipTests

Closes #150