### PR TITLE
Add fixed identifier route mapping

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/FixedRouteResourcePreparer.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/FixedRouteResourcePreparer.java
@@ -1,0 +1,100 @@
+package uk.co.compendiumdev.thingifier.adapter.http.apihandlers;
+
+import java.util.List;
+import java.util.Optional;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.InstanceRoute;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
+import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
+import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
+import uk.co.compendiumdev.thingifier.api.spec.FixedResourcePolicy;
+import uk.co.compendiumdev.thingifier.api.spec.ThingifierApiRouteRule;
+import uk.co.compendiumdev.thingifier.application.ThingCommandResult;
+import uk.co.compendiumdev.thingifier.application.command.CreateThingCommand;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+
+/**
+ * Prepares fixed-instance route targets before normal command/query handling.
+ *
+ * <p>The default fixed route policy deliberately does nothing and lets generated instance-route
+ * handling return 404. When a route opts into {@link FixedResourcePolicy#ENSURE_EXISTS}, this
+ * helper creates the fixed target through the normal command service after authentication has
+ * selected the active data scope and before validators or lifecycle action hooks run.
+ */
+public final class FixedRouteResourcePreparer {
+
+    private final ThingifierApiRuntime runtime;
+
+    /**
+     * Creates a preparer backed by the active runtime.
+     *
+     * @param runtime runtime services used to resolve route policy and create instances
+     */
+    public FixedRouteResourcePreparer(final ThingifierApiRuntime runtime) {
+        this.runtime = runtime;
+    }
+
+    /**
+     * Ensures the fixed route target exists when the route policy asks for it.
+     *
+     * @param verb routing verb being processed
+     * @param path public route path
+     * @param route resolved internal route
+     * @param context active request context and store
+     * @return error response when the fixed resource cannot be prepared, otherwise null
+     */
+    public ApiResponse prepare(
+            final RoutingVerb verb,
+            final String path,
+            final ThingRoute route,
+            final ThingifierRequestContext context) {
+        final Optional<ThingifierApiRouteRule> rule =
+                runtime.apiSpec()
+                        .fixedRouteRuleFor(verb, path, runtime.apiConfig().getApiEndPointPrefix());
+        if (rule.isEmpty()
+                || rule.get().fixedResourcePolicy() != FixedResourcePolicy.ENSURE_EXISTS) {
+            return null;
+        }
+        if (!(route instanceof InstanceRoute)) {
+            return ApiResponse.error(
+                    500, "Fixed resource route " + path + " did not resolve to an instance");
+        }
+
+        final InstanceRoute instanceRoute = (InstanceRoute) route;
+        final EntityDefinition entity =
+                runtime.schema().definitionWithSingularOrPluralNamed(instanceRoute.entity().name());
+        if (entity == null) {
+            return ApiResponse.error(
+                    500,
+                    String.format(
+                            "Fixed resource route %s maps to unknown entity %s",
+                            path, instanceRoute.entity().name()));
+        }
+        if (!entity.hasPrimaryKeyField()) {
+            return ApiResponse.error(
+                    500,
+                    String.format(
+                            "Fixed resource route %s maps to %s but the entity has no primary key",
+                            path, entity.getName()));
+        }
+        if (context.hasEntityInstanceWithIdentifier(entity, instanceRoute.identifier())) {
+            return null;
+        }
+
+        final CreateThingCommand create =
+                new CreateThingCommand(
+                        entity.getName(), instanceRoute.identifier(), List.of(), List.of(), false);
+        final ThingCommandResult result = runtime.commandService(context).execute(create);
+        if (result.isSuccessful()) {
+            return null;
+        }
+        return ApiResponse.error(
+                500,
+                String.format(
+                        "Fixed resource route %s could not create %s(%s): %s",
+                        path,
+                        entity.getName(),
+                        instanceRoute.identifier(),
+                        result.getCombinedErrorMessage()));
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/RouteAuthPolicy.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/RouteAuthPolicy.java
@@ -6,7 +6,6 @@ import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.InstanceRou
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.RelationshipCollectionRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.RelationshipInstanceRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
-import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRouteMapper;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
 import uk.co.compendiumdev.thingifier.api.http.headers.headerparser.BasicAuthHeaderParser;
@@ -62,7 +61,7 @@ public final class RouteAuthPolicy {
      */
     public ApiResponse rejectIfNotAuthorized(
             final RoutingVerb verb, final String path, final ThingifierRequestContext context) {
-        final ThingRoute route = new ThingRouteMapper(runtime.schema()).map(path);
+        final ThingRoute route = runtime.routeFor(verb, path);
         return rejectIfNotAuthorized(verb, path, context, route);
     }
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/ThingReadRequestMapper.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/ThingReadRequestMapper.java
@@ -29,8 +29,9 @@ public final class ThingReadRequestMapper {
         if (route instanceof InstanceRoute) {
             InstanceRoute instance = (InstanceRoute) route;
             String identifierCandidate = instance.identifier();
-            if (schema.hasRelationshipNamed(identifierCandidate)
-                    || entityForTerm(identifierCandidate) != null) {
+            if (!instance.hasFixedIdentifier()
+                    && (schema.hasRelationshipNamed(identifierCandidate)
+                            || entityForTerm(identifierCandidate) != null)) {
                 return notFound(route.originalPath());
             }
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/ThingifierApiRuntime.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/ThingifierApiRuntime.java
@@ -2,6 +2,9 @@ package uk.co.compendiumdev.thingifier.adapter.http.apihandlers;
 
 import java.util.List;
 import java.util.Optional;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRouteResolver;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
 import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
 import uk.co.compendiumdev.thingifier.api.security.DataScopeCreationPolicy;
@@ -20,6 +23,22 @@ public interface ThingifierApiRuntime {
     ThingifierApiSpec apiSpec();
 
     List<String> thingNames();
+
+    /**
+     * Resolves a public request path to the internal route shape handlers should process.
+     *
+     * <p>This is the shared entry point for generated routes and fixed-instance route mappings so
+     * auth, lifecycle, validation, and command/query handling agree on the same target entity and
+     * identifier.
+     *
+     * @param verb routing verb for the request
+     * @param path public request path
+     * @return resolved route
+     */
+    default ThingRoute routeFor(final RoutingVerb verb, final String path) {
+        return new ThingRouteResolver(schema(), apiSpec(), apiConfig().getApiEndPointPrefix())
+                .map(verb, path);
+    }
 
     ThingifierRequestContext contextFrom(HttpHeadersBlock requestHeaders);
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/route/InstanceRoute.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/route/InstanceRoute.java
@@ -2,22 +2,61 @@ package uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route;
 
 import uk.co.compendiumdev.thingifier.application.schema.EntityTypeRef;
 
+/**
+ * Route mapping for a request that targets one entity instance.
+ *
+ * <p>Generated routes obtain the identifier from the URL. Fixed-instance routes obtain the
+ * identifier from API-spec configuration, so handlers need to know when the identifier was trusted
+ * configuration rather than a path segment that might really be another route.
+ */
 public final class InstanceRoute extends ThingRoute {
 
     private final EntityTypeRef entity;
     private final String identifier;
+    private final boolean fixedIdentifier;
 
     InstanceRoute(final String originalPath, final EntityTypeRef entity, final String identifier) {
+        this(originalPath, entity, identifier, false);
+    }
+
+    InstanceRoute(
+            final String originalPath,
+            final EntityTypeRef entity,
+            final String identifier,
+            final boolean fixedIdentifier) {
         super(originalPath);
         this.entity = entity;
         this.identifier = identifier;
+        this.fixedIdentifier = fixedIdentifier;
     }
 
+    /**
+     * Returns the entity whose instance is targeted.
+     *
+     * @return entity type reference
+     */
     public EntityTypeRef entity() {
         return entity;
     }
 
+    /**
+     * Returns the instance identifier to use for reads and writes.
+     *
+     * @return route or configured identifier
+     */
     public String identifier() {
         return identifier;
+    }
+
+    /**
+     * Reports whether the identifier came from fixed-route configuration.
+     *
+     * <p>Generated route reads still apply route-shape ambiguity checks, but fixed identifiers are
+     * already an explicit application decision and should be used as supplied.
+     *
+     * @return true when the identifier was configured with {@code withFixedIdentifier}
+     */
+    public boolean hasFixedIdentifier() {
+        return fixedIdentifier;
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/route/ThingRouteResolver.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/route/ThingRouteResolver.java
@@ -1,0 +1,66 @@
+package uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route;
+
+import java.util.Optional;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.SchemaCatalog;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
+import uk.co.compendiumdev.thingifier.api.spec.ThingifierApiRouteRule;
+import uk.co.compendiumdev.thingifier.api.spec.ThingifierApiSpec;
+import uk.co.compendiumdev.thingifier.application.schema.EntityTypeRef;
+
+/**
+ * Resolves public API paths into the internal route model used by Thingifier handlers.
+ *
+ * <p>Most requests map directly from the generated URL shape. Fixed-instance routes are different:
+ * their public URL has no identifier, but the API spec declares the entity and identifier that
+ * should be used internally. Centralising that decision keeps auth, lifecycle hooks, write policy,
+ * and command/query mapping aligned.
+ */
+public final class ThingRouteResolver {
+
+    private final SchemaCatalog schema;
+    private final ThingifierApiSpec apiSpec;
+    private final String apiPathPrefix;
+    private final ThingRouteMapper generatedRouteMapper;
+
+    /**
+     * Creates a route resolver for one API runtime.
+     *
+     * @param schema schema catalogue used to resolve entity names
+     * @param apiSpec route policy and fixed-route declarations
+     * @param apiPathPrefix configured API prefix used when matching route rules
+     */
+    public ThingRouteResolver(
+            final SchemaCatalog schema,
+            final ThingifierApiSpec apiSpec,
+            final String apiPathPrefix) {
+        this.schema = schema;
+        this.apiSpec = apiSpec;
+        this.apiPathPrefix = apiPathPrefix == null ? "" : apiPathPrefix;
+        this.generatedRouteMapper = new ThingRouteMapper(schema);
+    }
+
+    /**
+     * Maps a public path to the route shape handlers should process.
+     *
+     * @param verb routing verb for the request
+     * @param path public request path
+     * @return fixed internal instance route when configured, otherwise the generated route mapping
+     */
+    public ThingRoute map(final RoutingVerb verb, final String path) {
+        Optional<ThingifierApiRouteRule> fixedRoute =
+                apiSpec.fixedRouteRuleFor(verb, path, apiPathPrefix);
+        if (fixedRoute.isPresent()) {
+            return fixedInstanceRoute(path, fixedRoute.get());
+        }
+        return generatedRouteMapper.map(path);
+    }
+
+    private ThingRoute fixedInstanceRoute(
+            final String path, final ThingifierApiRouteRule fixedRoute) {
+        EntityTypeRef entity = schema.entityWithSingularOrPluralName(fixedRoute.fixedEntityName());
+        if (entity == null) {
+            return new UnmatchedRoute(path, ThingRouteMapper.parts(path));
+        }
+        return new InstanceRoute(path, entity, fixedRoute.fixedIdentifier(), true);
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/ThingifierRestAPIHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/ThingifierRestAPIHandler.java
@@ -3,8 +3,10 @@ package uk.co.compendiumdev.thingifier.api;
 import java.util.function.Supplier;
 import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.DefaultThingifierApiRuntime;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.FixedRouteResourcePreparer;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.RouteAuthPolicy;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierApiRuntime;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleContext;
 import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleHookRegistry;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
@@ -126,8 +128,9 @@ public class ThingifierRestAPIHandler {
     public ApiResponse get(
             final ApiRequestEnvelope request, final ThingifierApiLifecycleContext lifecycle) {
         ThingifierRequestContext context = contextFrom(request.headers(), lifecycle);
+        final RoutingVerb verb = lifecycle == null ? RoutingVerb.GET : lifecycle.routingVerb();
         return withAuthorizedResponsePolicy(
-                RoutingVerb.GET,
+                verb,
                 request.path(),
                 context,
                 lifecycle,
@@ -151,7 +154,8 @@ public class ThingifierRestAPIHandler {
                 context,
                 null,
                 () -> {
-                    final ApiResponse response = get.handle(url, queryParams, context);
+                    final ApiResponse response =
+                            get.handle(RoutingVerb.HEAD, url, queryParams, context);
                     response.clearBody();
                     return response;
                 });
@@ -528,6 +532,13 @@ public class ThingifierRestAPIHandler {
                 lifecycle == null ? authPolicy.rejectIfNotAuthorized(verb, url, context) : null;
         if (authResponse != null) {
             return withResponsePolicy(verb, url, authResponse, context);
+        }
+        final ThingRoute route =
+                lifecycle == null ? runtime.routeFor(verb, url) : lifecycle.route();
+        final ApiResponse fixedResourceResponse =
+                new FixedRouteResourcePreparer(runtime).prepare(verb, url, route, context);
+        if (fixedResourceResponse != null) {
+            return withResponsePolicy(verb, url, fixedResourceResponse, context);
         }
         return withResponsePolicy(verb, url, action.get(), context);
     }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/ApiRoutingDefinitionDocGenerator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/ApiRoutingDefinitionDocGenerator.java
@@ -76,7 +76,7 @@ public class ApiRoutingDefinitionDocGenerator {
             // e.g. set a field as 'usedForIndividualRouting'
             Field uniqueIdField = getUniqueIdField(entityDefn);
             if (uniqueIdField != null) {
-                uniqueIdentifier = uniqueReferenceText.get(uniqueIdField.getType());
+                uniqueIdentifier = uniqueReferenceText.getOrDefault(uniqueIdField.getType(), ":id");
                 uniqueIdFieldName = uniqueIdField.getName();
             }
 
@@ -377,6 +377,7 @@ public class ApiRoutingDefinitionDocGenerator {
             }
         }
 
+        thingifier.apiSpec().addFixedRouteDefinitionsTo(defn, apiPathPrefix);
         new WriteMethodRoutePolicy(thingifier).applyTo(defn, apiPathPrefix);
         thingifier.apiSpec().applyTo(defn, apiPathPrefix);
         return defn;
@@ -426,7 +427,7 @@ public class ApiRoutingDefinitionDocGenerator {
 
         Field uniqueIdField = getUniqueIdField(thingDefn);
         if (uniqueIdField != null) {
-            uniqueIdentifier = uniqueReferenceText.get(uniqueIdField.getType());
+            uniqueIdentifier = uniqueReferenceText.getOrDefault(uniqueIdField.getType(), ":id");
             uniqueIdFieldName = uniqueIdField.getName();
         }
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/RoutingDefinition.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/RoutingDefinition.java
@@ -7,6 +7,7 @@ import java.util.List;
 import uk.co.compendiumdev.thingifier.api.http.headers.headerparser.ContentTypeHeaderParser;
 import uk.co.compendiumdev.thingifier.api.response.ResponseHeader;
 import uk.co.compendiumdev.thingifier.api.security.SecuritySchemeNames;
+import uk.co.compendiumdev.thingifier.api.spec.FixedResourcePolicy;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.Field;
 
@@ -40,6 +41,9 @@ public class RoutingDefinition {
     private boolean disabled = false;
     private String requestEntityViewName;
     private HashMap<Integer, String> responseEntityViewNames;
+    private String fixedEntityName;
+    private String fixedIdentifier;
+    private FixedResourcePolicy fixedResourcePolicy;
 
     /**
      * Creates route metadata for one verb and path.
@@ -72,6 +76,9 @@ public class RoutingDefinition {
         responseHeaders = new HashMap<>();
         requestEntityViewName = null;
         responseEntityViewNames = new HashMap<>();
+        fixedEntityName = null;
+        fixedIdentifier = null;
+        fixedResourcePolicy = FixedResourcePolicy.RETURN_404;
     }
 
     /**
@@ -474,6 +481,61 @@ public class RoutingDefinition {
      */
     public String getResponseEntityViewFor(final int statusCode) {
         return responseEntityViewNames.get(statusCode);
+    }
+
+    /**
+     * Marks this public route as mapping to one fixed entity instance.
+     *
+     * <p>Documentation generators keep the public URL exactly as declared, while runtime route
+     * resolution uses this metadata to process the request as an internal instance route.
+     *
+     * @param entityName singular or plural target entity name
+     * @param identifier fixed entity instance identifier
+     * @param policy behaviour when the target instance is missing
+     * @return this definition so route metadata can be chained
+     */
+    public RoutingDefinition mapToFixedEntity(
+            final String entityName, final String identifier, final FixedResourcePolicy policy) {
+        fixedEntityName = entityName;
+        fixedIdentifier = identifier;
+        fixedResourcePolicy = policy == null ? FixedResourcePolicy.RETURN_404 : policy;
+        return this;
+    }
+
+    /**
+     * Reports whether this route maps to a fixed entity instance.
+     *
+     * @return true when fixed route metadata is present
+     */
+    public boolean hasFixedIdentifierMapping() {
+        return fixedEntityName != null && fixedIdentifier != null;
+    }
+
+    /**
+     * Returns the fixed route's target entity name.
+     *
+     * @return singular or plural entity name, or null when not fixed
+     */
+    public String fixedEntityName() {
+        return fixedEntityName;
+    }
+
+    /**
+     * Returns the fixed route's target entity identifier.
+     *
+     * @return fixed identifier, or null when not fixed
+     */
+    public String fixedIdentifier() {
+        return fixedIdentifier;
+    }
+
+    /**
+     * Returns the fixed route's missing-instance policy.
+     *
+     * @return configured fixed resource policy
+     */
+    public FixedResourcePolicy fixedResourcePolicy() {
+        return fixedResourcePolicy;
     }
 
     /**

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/WriteMethodRoutePolicy.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/WriteMethodRoutePolicy.java
@@ -9,7 +9,7 @@ import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.InstanceRou
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.RelationshipCollectionRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.RelationshipInstanceRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
-import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRouteMapper;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRouteResolver;
 import uk.co.compendiumdev.thingifier.apiconfig.ApiConfigValidationReport;
 import uk.co.compendiumdev.thingifier.apiconfig.EntityPatchUpdateStyle;
 import uk.co.compendiumdev.thingifier.apiconfig.EntityWriteOperation;
@@ -28,9 +28,11 @@ public final class WriteMethodRoutePolicy {
 
     public void applyTo(final ApiRoutingDefinition routingDefinition, final String apiPathPrefix) {
         rejectInvalidApiConfig();
+        ThingRouteResolver resolver =
+                new ThingRouteResolver(schema, thingifier.apiSpec(), apiPathPrefix);
         for (RoutingDefinition route : routingDefinition.definitions()) {
             ThingRoute thingRoute =
-                    new ThingRouteMapper(schema).map(removePrefix(route.url(), apiPathPrefix));
+                    resolver.map(route.verb(), removePrefix(route.url(), apiPathPrefix));
             applyTo(route, thingRoute, apiPathPrefix);
         }
         updateAcceptPatchHeaders(routingDefinition, apiPathPrefix);
@@ -258,13 +260,15 @@ public final class WriteMethodRoutePolicy {
 
     private void updateAcceptPatchHeaders(
             final ApiRoutingDefinition routingDefinition, final String apiPathPrefix) {
+        ThingRouteResolver resolver =
+                new ThingRouteResolver(schema, thingifier.apiSpec(), apiPathPrefix);
         for (RoutingDefinition route : routingDefinition.definitions()) {
             if (route.verb() != RoutingVerb.OPTIONS) {
                 continue;
             }
 
             ThingRoute thingRoute =
-                    new ThingRouteMapper(schema).map(removePrefix(route.url(), apiPathPrefix));
+                    resolver.map(route.verb(), removePrefix(route.url(), apiPathPrefix));
             if (!(thingRoute instanceof InstanceRoute)) {
                 continue;
             }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
@@ -12,15 +12,12 @@ import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.adapter.hooks.ScopedHook;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.DefaultThingifierApiRuntime;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.RouteAuthPolicy;
-import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.SchemaCatalog;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierApiRuntime;
-import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierSchemaCatalog;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.CollectionRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.InstanceRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.RelationshipCollectionRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.RelationshipInstanceRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
-import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRouteMapper;
 import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleContext;
 import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleHookRegistry;
 import uk.co.compendiumdev.thingifier.adapter.http.messagehooks.HttpApiHookRegistry;
@@ -264,7 +261,9 @@ public final class ThingifierHttpApi {
             if (lifecycle != null) {
                 ApiRequestEnvelope parsedEnvelope =
                         ApiRequestEnvelope.from(
-                                request, effectiveVerb, xmlEntityNamesFor(request.getPath()));
+                                request,
+                                effectiveVerb,
+                                xmlEntityNamesFor(request.getPath(), effectiveVerb));
                 lifecycle.applyParsedEnvelope(parsedEnvelope);
                 lifecycleHooks.runBodyParsedHooks(lifecycle);
                 if (lifecycle.shouldShortCircuit()) {
@@ -293,7 +292,7 @@ public final class ThingifierHttpApi {
     private ThingifierApiLifecycleContext lifecycleContextFor(
             final HttpApiRequest request, final HttpVerb effectiveVerb) {
         ThingifierApiRuntime runtime = new DefaultThingifierApiRuntime(thingifier);
-        ThingRoute route = new ThingRouteMapper(runtime.schema()).map(request.getPath());
+        ThingRoute route = runtime.routeFor(routingVerbFor(effectiveVerb), request.getPath());
         return new ThingifierApiLifecycleContext(
                 runtime,
                 request,
@@ -342,7 +341,7 @@ public final class ThingifierHttpApi {
                         apiResponse,
                         jsonThing,
                         thingifier.apiConfig(),
-                        xmlEntityNamesFor(request.getPath()));
+                        xmlEntityNamesFor(request.getPath(), effectiveVerb));
 
         if (effectiveVerb == HttpVerb.HEAD) {
             final int bodyLength = httpResponse.getBody().getBytes(StandardCharsets.UTF_8).length;
@@ -354,7 +353,7 @@ public final class ThingifierHttpApi {
                             apiResponse,
                             jsonThing,
                             thingifier.apiConfig(),
-                            xmlEntityNamesFor(request.getPath()));
+                            xmlEntityNamesFor(request.getPath(), effectiveVerb));
         }
         return httpResponse;
     }
@@ -403,7 +402,7 @@ public final class ThingifierHttpApi {
                 ApiResponse.error404("Could not find any instances with " + request.getPath()),
                 jsonThing,
                 thingifier.apiConfig(),
-                xmlEntityNamesFor(request.getPath()));
+                xmlEntityNamesFor(request.getPath(), HttpVerb.GET));
     }
 
     /**
@@ -418,7 +417,7 @@ public final class ThingifierHttpApi {
 
         final HttpApiRequestValidator requestValidator =
                 new HttpApiRequestValidator(
-                        thingifier.apiConfig(), xmlEntityNamesFor(request.getPath()));
+                        thingifier.apiConfig(), xmlEntityNamesFor(request.getPath(), verb));
 
         HttpApiResponse httpResponse = null;
 
@@ -430,7 +429,7 @@ public final class ThingifierHttpApi {
                             requestValidator.getErrorApiResponse(),
                             jsonThing,
                             thingifier.apiConfig(),
-                            xmlEntityNamesFor(request.getPath()));
+                            xmlEntityNamesFor(request.getPath(), verb));
         }
 
         return httpResponse;
@@ -450,7 +449,7 @@ public final class ThingifierHttpApi {
 
         ApiResponse apiResponse = null;
         ApiRequestEnvelope envelope =
-                ApiRequestEnvelope.from(request, verb, xmlEntityNamesFor(request.getPath()));
+                ApiRequestEnvelope.from(request, verb, xmlEntityNamesFor(request.getPath(), verb));
 
         switch (verb) {
             case GET:
@@ -547,7 +546,7 @@ public final class ThingifierHttpApi {
             return null;
         }
 
-        final EntityDefinition entity = targetEntityFor(request.getPath());
+        final EntityDefinition entity = targetEntityFor(request.getPath(), routingVerbFor(verb));
         if (entity == null) {
             return null;
         }
@@ -575,7 +574,7 @@ public final class ThingifierHttpApi {
                                     viewName, entity.getName())),
                     jsonThing,
                     thingifier.apiConfig(),
-                    xmlEntityNamesFor(request.getPath()));
+                    xmlEntityNamesFor(request.getPath(), verb));
         }
 
         final EntityViewDefinition view = entity.getViewNamed(viewName);
@@ -599,7 +598,7 @@ public final class ThingifierHttpApi {
                                 viewName, String.join(", ", disallowedFields))),
                 jsonThing,
                 thingifier.apiConfig(),
-                xmlEntityNamesFor(request.getPath()));
+                xmlEntityNamesFor(request.getPath(), verb));
     }
 
     /**
@@ -620,7 +619,7 @@ public final class ThingifierHttpApi {
             return patchInputFields(request, entity, lifecycle);
         }
 
-        return ApiRequestEnvelope.from(request, verb, xmlEntityNamesFor(request.getPath()))
+        return ApiRequestEnvelope.from(request, verb, xmlEntityNamesFor(request.getPath(), verb))
                 .bodyFields()
                 .topLevelFields();
     }
@@ -759,7 +758,8 @@ public final class ThingifierHttpApi {
             return Optional.empty();
         }
 
-        final EntityInstance instance = targetInstanceFor(request, entity, lifecycle);
+        final EntityInstance instance =
+                targetInstanceFor(request, entity, RoutingVerb.PATCH, lifecycle);
         if (instance == null) {
             return Optional.empty();
         }
@@ -836,9 +836,13 @@ public final class ThingifierHttpApi {
     private EntityInstance targetInstanceFor(
             final HttpApiRequest request,
             final EntityDefinition entity,
+            final RoutingVerb verb,
             final ThingifierApiLifecycleContext lifecycle) {
-        final SchemaCatalog schema = new ThingifierSchemaCatalog(thingifier);
-        final ThingRoute route = new ThingRouteMapper(schema).map(request.getPath());
+        final ThingRoute route =
+                lifecycle == null
+                        ? new DefaultThingifierApiRuntime(thingifier)
+                                .routeFor(verb, request.getPath())
+                        : lifecycle.route();
         if (!(route instanceof InstanceRoute)) {
             return null;
         }
@@ -952,27 +956,29 @@ public final class ThingifierHttpApi {
     }
 
     /**
-     * Resolves the entity targeted by a generated route path.
+     * Resolves the entity targeted by a generated or fixed route path.
      *
-     * @param path generated API path
+     * @param path public API path
+     * @param verb routing verb used to check fixed-route declarations
      * @return target or related entity, or null when the path does not map to a Thingifier entity
      */
-    private EntityDefinition targetEntityFor(final String path) {
-        final SchemaCatalog schema = new ThingifierSchemaCatalog(thingifier);
-        final ThingRoute route = new ThingRouteMapper(schema).map(path);
+    private EntityDefinition targetEntityFor(final String path, final RoutingVerb verb) {
+        final ThingifierApiRuntime runtime = new DefaultThingifierApiRuntime(thingifier);
+        final ThingRoute route = runtime.routeFor(verb, path);
         if (route instanceof CollectionRoute) {
-            return schema.definitionWithSingularOrPluralNamed(
-                    ((CollectionRoute) route).entity().name());
+            return runtime.schema()
+                    .definitionWithSingularOrPluralNamed(((CollectionRoute) route).entity().name());
         }
         if (route instanceof InstanceRoute) {
-            return schema.definitionWithSingularOrPluralNamed(
-                    ((InstanceRoute) route).entity().name());
+            return runtime.schema()
+                    .definitionWithSingularOrPluralNamed(((InstanceRoute) route).entity().name());
         }
         if (route instanceof RelationshipCollectionRoute) {
             final RelationshipCollectionRoute relationship = (RelationshipCollectionRoute) route;
             for (RelationshipSpec spec : relationship.parentEntity().relationships()) {
                 if (spec.name().equals(relationship.relationshipName())) {
-                    return schema.definitionWithSingularOrPluralNamed(spec.toEntityName());
+                    return runtime.schema()
+                            .definitionWithSingularOrPluralNamed(spec.toEntityName());
                 }
             }
         }
@@ -980,7 +986,8 @@ public final class ThingifierHttpApi {
             final RelationshipInstanceRoute relationship = (RelationshipInstanceRoute) route;
             for (RelationshipSpec spec : relationship.parentEntity().relationships()) {
                 if (spec.name().equals(relationship.relationshipName())) {
-                    return schema.definitionWithSingularOrPluralNamed(spec.toEntityName());
+                    return runtime.schema()
+                            .definitionWithSingularOrPluralNamed(spec.toEntityName());
                 }
             }
         }
@@ -990,11 +997,12 @@ public final class ThingifierHttpApi {
     /**
      * Returns XML entity names that should be accepted or emitted for a path.
      *
-     * @param path generated API path
+     * @param path public API path
+     * @param verb HTTP verb used to check fixed-route declarations
      * @return singular and plural entity names, or an empty list when no entity route matches
      */
-    private List<String> xmlEntityNamesFor(final String path) {
-        final EntityDefinition entity = targetEntityFor(path);
+    private List<String> xmlEntityNamesFor(final String path, final HttpVerb verb) {
+        final EntityDefinition entity = targetEntityFor(path, routingVerbFor(verb));
         if (entity == null) {
             return List.of();
         }
@@ -1093,7 +1101,7 @@ public final class ThingifierHttpApi {
                             apiResponse,
                             jsonThing,
                             thingifier.apiConfig(),
-                            xmlEntityNamesFor(request.getPath()));
+                            xmlEntityNamesFor(request.getPath(), HttpVerb.GET));
         }
 
         return runTheHttpApiResponseHooksOn(request, httpResponse, HttpVerb.GET);

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiDeleteHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiDeleteHandler.java
@@ -7,7 +7,6 @@ import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingWriteRequest
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierApiRuntime;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.WriteMethodPolicy;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
-import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRouteMapper;
 import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleContext;
 import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleHookRegistry;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
@@ -92,7 +91,7 @@ public class RestApiDeleteHandler {
             final String url,
             final ThingifierRequestContext context,
             final ThingifierApiLifecycleContext lifecycle) {
-        ThingRoute route = new ThingRouteMapper(runtime.schema()).map(url);
+        ThingRoute route = routeFor(url, lifecycle);
         ApiResponse policyResponse =
                 new WriteMethodPolicy(runtime)
                         .rejectIfNotAllowed(
@@ -110,5 +109,9 @@ public class RestApiDeleteHandler {
                 mapping,
                 context,
                 () -> new ThingWriteRequestMapper(runtime.schema()).mapDelete(route));
+    }
+
+    private ThingRoute routeFor(final String url, final ThingifierApiLifecycleContext lifecycle) {
+        return lifecycle == null ? runtime.routeFor(RoutingVerb.DELETE, url) : lifecycle.route();
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiGetHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiGetHandler.java
@@ -9,9 +9,9 @@ import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierApiRunt
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.CollectionRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.RelationshipCollectionRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
-import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRouteMapper;
 import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleContext;
 import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleHookRegistry;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierHttpApi;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
 import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
@@ -90,7 +90,27 @@ public class RestApiGetHandler {
             final String url,
             final QueryFilterParams queryParams,
             final ThingifierRequestContext context) {
-        return handle(url, queryParams, context, null);
+        return handle(RoutingVerb.GET, url, queryParams, context, null);
+    }
+
+    /**
+     * Handles a GET-compatible request using an explicit routing verb.
+     *
+     * <p>HEAD uses the same repository lookup as GET but may have a different route rule, so direct
+     * callers can supply the verb that selected the public route.
+     *
+     * @param verb routing verb used to resolve route rules
+     * @param url generated or fixed public API path
+     * @param queryParams query filters to apply
+     * @param context request context containing the active store
+     * @return API response for the read
+     */
+    public ApiResponse handle(
+            final RoutingVerb verb,
+            final String url,
+            final QueryFilterParams queryParams,
+            final ThingifierRequestContext context) {
+        return handle(verb, url, queryParams, context, null);
     }
 
     /**
@@ -107,9 +127,19 @@ public class RestApiGetHandler {
             final QueryFilterParams queryParams,
             final ThingifierRequestContext context,
             final ThingifierApiLifecycleContext lifecycle) {
+        final RoutingVerb verb = lifecycle == null ? RoutingVerb.GET : lifecycle.routingVerb();
+        return handle(verb, url, queryParams, context, lifecycle);
+    }
+
+    private ApiResponse handle(
+            final RoutingVerb verb,
+            final String url,
+            final QueryFilterParams queryParams,
+            final ThingifierRequestContext context,
+            final ThingifierApiLifecycleContext lifecycle) {
         ThingReadResultApiMapper apiMapper = new ThingReadResultApiMapper(runtime.apiConfig());
 
-        ThingRoute route = new ThingRouteMapper(runtime.schema()).map(url);
+        ThingRoute route = lifecycle == null ? runtime.routeFor(verb, url) : lifecycle.route();
         EffectiveQueryParams effectiveQueryParams =
                 EffectiveQueryParams.forGet(runtime.apiConfig(), route, queryParams, url);
         if (effectiveQueryParams.isError()) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPatchHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPatchHandler.java
@@ -10,7 +10,6 @@ import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierApiRunt
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.WriteMethodPolicy;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.InstanceRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
-import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRouteMapper;
 import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleContext;
 import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleHookRegistry;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
@@ -94,7 +93,7 @@ public class RestApiPatchHandler {
             final HttpHeadersBlock requestHeaders,
             final ThingifierRequestContext context,
             final ThingifierApiLifecycleContext lifecycle) {
-        ThingRoute route = new ThingRouteMapper(runtime.schema()).map(url);
+        ThingRoute route = routeFor(url, lifecycle);
         WriteMethodPolicy policy = new WriteMethodPolicy(runtime);
         ApiResponse policyResponse =
                 policy.rejectIfNotAllowed(
@@ -130,6 +129,10 @@ public class RestApiPatchHandler {
                 () ->
                         new EntityPatchDocumentMapper(runtime.schema())
                                 .map(patchStyle(requestHeaders), route, lifecycle.rawBody()));
+    }
+
+    private ThingRoute routeFor(final String url, final ThingifierApiLifecycleContext lifecycle) {
+        return lifecycle == null ? runtime.routeFor(RoutingVerb.PATCH, url) : lifecycle.route();
     }
 
     /**

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPostHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPostHandler.java
@@ -7,7 +7,6 @@ import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingWriteRequest
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierApiRuntime;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.WriteMethodPolicy;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
-import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRouteMapper;
 import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleContext;
 import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleHookRegistry;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
@@ -114,7 +113,7 @@ public class RestApiPostHandler {
             final ApiBodyFields bodyFields,
             final ThingifierRequestContext context,
             final ThingifierApiLifecycleContext lifecycle) {
-        ThingRoute route = new ThingRouteMapper(runtime.schema()).map(url);
+        ThingRoute route = routeFor(url, lifecycle);
         WriteMethodPolicy writePolicy = new WriteMethodPolicy(runtime);
         ApiResponse policyResponse =
                 writePolicy.rejectIfNotAllowed(RoutingVerb.POST, route, bodyFields, context);
@@ -136,5 +135,9 @@ public class RestApiPostHandler {
                 mapping,
                 context,
                 () -> mapper.mapPost(route, lifecycle.bodyFields()));
+    }
+
+    private ThingRoute routeFor(final String url, final ThingifierApiLifecycleContext lifecycle) {
+        return lifecycle == null ? runtime.routeFor(RoutingVerb.POST, url) : lifecycle.route();
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPutHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPutHandler.java
@@ -7,7 +7,6 @@ import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingWriteRequest
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierApiRuntime;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.WriteMethodPolicy;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
-import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRouteMapper;
 import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleContext;
 import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleHookRegistry;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
@@ -114,7 +113,7 @@ public class RestApiPutHandler {
             final ApiBodyFields bodyFields,
             final ThingifierRequestContext context,
             final ThingifierApiLifecycleContext lifecycle) {
-        ThingRoute route = new ThingRouteMapper(runtime.schema()).map(url);
+        ThingRoute route = routeFor(url, lifecycle);
         ApiResponse policyResponse =
                 new WriteMethodPolicy(runtime)
                         .rejectIfNotAllowed(RoutingVerb.PUT, route, bodyFields, context);
@@ -137,5 +136,9 @@ public class RestApiPutHandler {
                                         runtime.schema(),
                                         runtime.apiConfig().writeMethods().entities())
                                 .mapPut(route, lifecycle.bodyFields()));
+    }
+
+    private ThingRoute routeFor(final String url, final ThingifierApiLifecycleContext lifecycle) {
+        return lifecycle == null ? runtime.routeFor(RoutingVerb.PUT, url) : lifecycle.route();
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandler.java
@@ -10,7 +10,6 @@ import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.InstanceRou
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.RelationshipCollectionRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.RelationshipInstanceRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
-import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRouteMapper;
 import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleContext;
 import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleHookRegistry;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
@@ -118,7 +117,7 @@ public final class RestApiQueryHandler {
             final ThingifierRequestContext context,
             final ThingifierApiLifecycleContext lifecycle) {
         ThingReadResultApiMapper apiMapper = new ThingReadResultApiMapper(runtime.apiConfig());
-        ThingRoute route = new ThingRouteMapper(runtime.schema()).map(url);
+        ThingRoute route = routeFor(url, lifecycle);
 
         if (route instanceof InstanceRoute) {
             return methodNotAllowed("OPTIONS, GET, HEAD, POST, PUT, DELETE");
@@ -201,6 +200,10 @@ public final class RestApiQueryHandler {
                             apiMapper));
         }
         return lifecycle.apiResponse();
+    }
+
+    private ThingRoute routeFor(final String url, final ThingifierApiLifecycleContext lifecycle) {
+        return lifecycle == null ? runtime.routeFor(RoutingVerb.QUERY, url) : lifecycle.route();
     }
 
     /**

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/FixedResourcePolicy.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/FixedResourcePolicy.java
@@ -1,0 +1,28 @@
+package uk.co.compendiumdev.thingifier.api.spec;
+
+/**
+ * Controls what a fixed-instance route does when its configured target instance is missing.
+ *
+ * <p>Fixed-instance routes are public API paths that do not expose an identifier in the URL, but
+ * still route to one known Thingifier entity instance. The policy makes the missing-instance
+ * behaviour explicit so applications do not accidentally create data when a read-only singleton
+ * style route was intended.
+ */
+public enum FixedResourcePolicy {
+    /**
+     * Leave missing targets to normal entity handling.
+     *
+     * <p>For instance-shaped routes this normally means GET, HEAD, POST, PATCH, PUT, and DELETE
+     * surface the same not-found response they would for a generated {@code /entities/{id}} route.
+     */
+    RETURN_404,
+
+    /**
+     * Create the fixed target instance when it is missing before normal route handling continues.
+     *
+     * <p>The instance is created through Thingifier's normal command service using only the fixed
+     * identifier. If the entity cannot be created without additional required fields, the route
+     * reports a configuration error rather than inserting invalid data.
+     */
+    ENSURE_EXISTS
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiRouteRule.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiRouteRule.java
@@ -41,6 +41,9 @@ public final class ThingifierApiRouteRule {
     private String requestEntityView;
     private String defaultEntityView;
     private Map<Integer, String> responseEntityViews;
+    private String mappedEntityName;
+    private String fixedIdentifier;
+    private FixedResourcePolicy fixedResourcePolicy;
     private EnumSet<EntityWriteOperation> entityWriteOperations;
     private EnumSet<EntityPatchUpdateStyle> entityPatchUpdateStyles;
     private EnumSet<RelationshipWriteOperation> relationshipWriteOperations;
@@ -63,6 +66,9 @@ public final class ThingifierApiRouteRule {
         this.requestEntityView = null;
         this.defaultEntityView = null;
         this.responseEntityViews = new HashMap<>();
+        this.mappedEntityName = null;
+        this.fixedIdentifier = null;
+        this.fixedResourcePolicy = FixedResourcePolicy.RETURN_404;
         this.entityWriteOperations = null;
         this.entityPatchUpdateStyles = null;
         this.relationshipWriteOperations = null;
@@ -383,6 +389,76 @@ public final class ThingifierApiRouteRule {
     }
 
     /**
+     * Sets the default response entity view for successful responses on this route.
+     *
+     * <p>This is the response-only counterpart to {@link #entityView(String)}. It is useful for
+     * fixed instance routes where the public response shape should be constrained but writes may
+     * still accept a different request view.
+     *
+     * @param viewName entity view name used for successful responses
+     * @return this rule so route API configuration can be chained
+     */
+    public ThingifierApiRouteRule defaultEntityView(final String viewName) {
+        this.defaultEntityView = viewName;
+        return this;
+    }
+
+    /**
+     * Declares the model entity that a non-generated public route should target.
+     *
+     * <p>Use this with {@link #withFixedIdentifier(String)} when a route such as {@code
+     * /secret/note} should be processed as a Thingifier-managed entity instance without putting the
+     * identifier in the public URL.
+     *
+     * @param entityName singular or plural model entity name
+     * @return this rule so route API configuration can be chained
+     * @throws IllegalArgumentException when the entity name is blank
+     */
+    public ThingifierApiRouteRule mapsToEntity(final String entityName) {
+        this.mappedEntityName = requireText(entityName, "entity name");
+        return this;
+    }
+
+    /**
+     * Maps this public route to one fixed entity identifier.
+     *
+     * <p>The fixed identifier is a trusted server-side route decision, not a value read from the
+     * client URL. Runtime processing resolves the public route to an internal instance route while
+     * keeping the public path available for documentation, hooks, and error messages.
+     *
+     * @param identifier identifier of the target entity instance
+     * @return this rule so route API configuration can be chained
+     * @throws IllegalArgumentException when the identifier is blank or the route path has URL
+     *     parameters
+     */
+    public ThingifierApiRouteRule withFixedIdentifier(final String identifier) {
+        return withFixedIdentifier(identifier, FixedResourcePolicy.RETURN_404);
+    }
+
+    /**
+     * Maps this public route to one fixed entity identifier with explicit missing-instance policy.
+     *
+     * @param identifier identifier of the target entity instance
+     * @param policy behaviour when the target instance is missing
+     * @return this rule so route API configuration can be chained
+     * @throws IllegalArgumentException when the identifier is blank, the policy is null, or the
+     *     route path has URL parameters
+     */
+    public ThingifierApiRouteRule withFixedIdentifier(
+            final String identifier, final FixedResourcePolicy policy) {
+        if (hasPathParameter(pathPattern)) {
+            throw new IllegalArgumentException(
+                    "fixed identifier routes must not contain path parameters");
+        }
+        this.fixedIdentifier = requireText(identifier, "fixed identifier");
+        if (policy == null) {
+            throw new IllegalArgumentException("fixed resource policy is required");
+        }
+        this.fixedResourcePolicy = policy;
+        return this;
+    }
+
+    /**
      * Restricts which entity write operations this generated route may perform.
      *
      * <p>The route may still be generated; the runtime chooses 405 when the concrete write
@@ -556,6 +632,42 @@ public final class ThingifierApiRouteRule {
     }
 
     /**
+     * Reports whether this rule maps a public path to a fixed entity instance.
+     *
+     * @return true when both entity and identifier are configured
+     */
+    public boolean hasFixedIdentifierMapping() {
+        return mappedEntityName != null && fixedIdentifier != null;
+    }
+
+    /**
+     * Returns the entity name configured for a fixed identifier route.
+     *
+     * @return singular or plural entity name, or null when not configured
+     */
+    public String fixedEntityName() {
+        return mappedEntityName;
+    }
+
+    /**
+     * Returns the fixed identifier configured for this route.
+     *
+     * @return fixed entity instance identifier, or null when not configured
+     */
+    public String fixedIdentifier() {
+        return fixedIdentifier;
+    }
+
+    /**
+     * Returns the configured missing-instance policy for this fixed route.
+     *
+     * @return fixed resource policy, defaulting to {@link FixedResourcePolicy#RETURN_404}
+     */
+    public FixedResourcePolicy fixedResourcePolicy() {
+        return fixedResourcePolicy;
+    }
+
+    /**
      * Applies this API-spec rule to a generated route definition.
      *
      * <p>Documentation route metadata is updated here, while runtime policy is resolved separately
@@ -605,6 +717,9 @@ public final class ThingifierApiRouteRule {
                 }
             }
         }
+        if (hasFixedIdentifierMapping()) {
+            route.mapToFixedEntity(mappedEntityName, fixedIdentifier, fixedResourcePolicy);
+        }
     }
 
     /**
@@ -650,5 +765,25 @@ public final class ThingifierApiRouteRule {
             Collections.addAll(selected, operations);
         }
         return selected;
+    }
+
+    private String requireText(final String value, final String label) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(label + " is required");
+        }
+        return value.trim();
+    }
+
+    private boolean hasPathParameter(final String path) {
+        final String normalized = path == null ? "" : path.trim();
+        if (normalized.contains("{") || normalized.contains("}")) {
+            return true;
+        }
+        for (String segment : normalized.split("/")) {
+            if (segment.startsWith(":") && segment.length() > 1) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpec.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpec.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 import java.util.Set;
 import uk.co.compendiumdev.thingifier.api.docgen.ApiRoutingDefinition;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingDefinition;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingStatus;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.api.security.SecuritySchemeNames;
 import uk.co.compendiumdev.thingifier.api.security.ThingifierApiAuthenticator;
@@ -290,6 +291,7 @@ public final class ThingifierApiSpec {
      * @param apiPathPrefix configured API prefix used when matching paths
      */
     public void applyTo(final ApiRoutingDefinition routingDefinition, final String apiPathPrefix) {
+        addFixedRouteDefinitionsTo(routingDefinition, apiPathPrefix);
         for (RoutingDefinition route : routingDefinition.definitions()) {
             ruleFor(route.verb(), route.url(), apiPathPrefix)
                     .ifPresent(rule -> rule.applyTo(route));
@@ -375,6 +377,24 @@ public final class ThingifierApiSpec {
                                 ApiRoutePathMatcher.pathsMatch(
                                         rule.pathPattern(), path, apiPathPrefix))
                 .findFirst();
+    }
+
+    /**
+     * Finds a fixed-instance mapping for a verb and public request path.
+     *
+     * <p>Fixed mappings are route rules that turn a public path with no URL identifier into an
+     * internal entity instance target. Runtime routing asks for this before falling back to the
+     * normal generated route mapper.
+     *
+     * @param verb routing verb
+     * @param path request path
+     * @param apiPathPrefix configured API prefix used when matching paths
+     * @return matching fixed route rule when configured
+     */
+    public Optional<ThingifierApiRouteRule> fixedRouteRuleFor(
+            final RoutingVerb verb, final String path, final String apiPathPrefix) {
+        return ruleFor(verb, path, apiPathPrefix)
+                .filter(ThingifierApiRouteRule::hasFixedIdentifierMapping);
     }
 
     /**
@@ -711,6 +731,127 @@ public final class ThingifierApiSpec {
                     .flatMap(this::defaultResponseEntityViewFor)
                     .ifPresent(viewName -> route.responseEntityView(statusCode, viewName));
         }
+    }
+
+    /**
+     * Adds route definitions for fixed-instance route rules.
+     *
+     * <p>Generated route rules normally modify routes that already exist. Fixed-instance rules are
+     * different because their public path intentionally does not follow the generated {@code
+     * /entities/{id}} shape. This method creates those public routes before normal rule application
+     * so documentation, server registration, and runtime policy all see the same route.
+     *
+     * @param routingDefinition generated route definition set to augment
+     * @param apiPathPrefix configured API prefix
+     */
+    public void addFixedRouteDefinitionsTo(
+            final ApiRoutingDefinition routingDefinition, final String apiPathPrefix) {
+        for (ThingifierApiRouteRule rule : routeRules) {
+            if (!rule.hasFixedIdentifierMapping()) {
+                continue;
+            }
+            final String routeUrl = publicRouteUrl(rule.pathPattern(), apiPathPrefix);
+            if (hasRoute(routingDefinition, rule.verb(), routeUrl)) {
+                continue;
+            }
+            final EntityDefinition entity =
+                    routingDefinition
+                            .objectSchemaNamed(rule.fixedEntityName())
+                            .orElseThrow(
+                                    () ->
+                                            new IllegalStateException(
+                                                    String.format(
+                                                            "Fixed route %s maps to unknown entity %s",
+                                                            rule.pathPattern(),
+                                                            rule.fixedEntityName())));
+            RoutingDefinition route =
+                    routingDefinition
+                            .addRouting(
+                                    fixedRouteDocumentation(rule, entity),
+                                    rule.verb(),
+                                    routeUrl,
+                                    RoutingStatus.returnedFromCall())
+                            .mapToFixedEntity(
+                                    entity.getName(),
+                                    rule.fixedIdentifier(),
+                                    rule.fixedResourcePolicy());
+            applyFixedRoutePayloads(route, entity);
+        }
+    }
+
+    private boolean hasRoute(
+            final ApiRoutingDefinition routingDefinition,
+            final RoutingVerb verb,
+            final String routeUrl) {
+        for (RoutingDefinition route : routingDefinition.definitions()) {
+            if (route.verb() == verb && samePathPattern(route.url(), routeUrl)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String fixedRouteDocumentation(
+            final ThingifierApiRouteRule rule, final EntityDefinition entity) {
+        return String.format(
+                "map %s to fixed %s instance %s",
+                rule.pathPattern(), entity.getName(), rule.fixedIdentifier());
+    }
+
+    private void applyFixedRoutePayloads(
+            final RoutingDefinition route, final EntityDefinition entity) {
+        switch (route.verb()) {
+            case GET:
+                route.addPossibleStatus(
+                                RoutingStatus.returnValue(
+                                        200, String.format("A specific %s", entity.getName())))
+                        .returnPayload(200, entity.getName())
+                        .addPossibleStatus(RoutingStatus.returnValue(404));
+                break;
+            case HEAD:
+                route.addPossibleStatus(RoutingStatus.returnValue(200))
+                        .addPossibleStatus(RoutingStatus.returnValue(404));
+                break;
+            case POST:
+            case PATCH:
+                route.addPossibleStatus(
+                                RoutingStatus.returnValue(
+                                        200,
+                                        String.format("Updated the fixed %s", entity.getName())))
+                        .returnPayload(200, entity.getName())
+                        .requestPayload(entity.getName())
+                        .addPossibleStatus(RoutingStatus.returnValue(404))
+                        .addPossibleStatus(RoutingStatus.returnValue(422))
+                        .addPossibleStatus(RoutingStatus.returnValue(409));
+                break;
+            case PUT:
+                route.addPossibleStatus(RoutingStatus.returnValue(200))
+                        .returnPayload(200, entity.getName())
+                        .addPossibleStatus(RoutingStatus.returnValue(201))
+                        .returnPayload(201, entity.getName())
+                        .requestPayload(entity.getName())
+                        .addPossibleStatus(RoutingStatus.returnValue(404))
+                        .addPossibleStatus(RoutingStatus.returnValue(422))
+                        .addPossibleStatus(RoutingStatus.returnValue(409));
+                break;
+            case DELETE:
+                route.addPossibleStatus(RoutingStatus.returnValue(204))
+                        .addPossibleStatus(RoutingStatus.returnValue(404));
+                break;
+            default:
+                break;
+        }
+    }
+
+    private String publicRouteUrl(final String pathPattern, final String apiPathPrefix) {
+        final String normalizedPath = normalize(pathPattern);
+        final String normalizedPrefix = normalize(apiPathPrefix);
+        if (normalizedPrefix.isEmpty()
+                || normalizedPath.equals(normalizedPrefix)
+                || normalizedPath.startsWith(normalizedPrefix + "/")) {
+            return normalizedPath;
+        }
+        return normalizedPrefix + "/" + normalizedPath;
     }
 
     /**

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiFixedRouteTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiFixedRouteTest.java
@@ -1,0 +1,439 @@
+package uk.co.compendiumdev.thingifier.api.spec;
+
+import static uk.co.compendiumdev.thingifier.apiconfig.EntityWriteOperation.UPDATE;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleHookRegistry;
+import uk.co.compendiumdev.thingifier.api.docgen.ApiRoutingDefinition;
+import uk.co.compendiumdev.thingifier.api.docgen.ApiRoutingDefinitionDocGenerator;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingDefinition;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
+import uk.co.compendiumdev.thingifier.api.docgen.ThingifierApiDocumentationDefn;
+import uk.co.compendiumdev.thingifier.api.http.HttpApiRequest;
+import uk.co.compendiumdev.thingifier.api.http.HttpApiResponse;
+import uk.co.compendiumdev.thingifier.api.http.ThingifierHttpApi;
+import uk.co.compendiumdev.thingifier.api.security.ThingifierApiAuthenticationContext;
+import uk.co.compendiumdev.thingifier.api.security.ThingifierApiAuthenticationResult;
+import uk.co.compendiumdev.thingifier.api.security.ThingifierApiAuthorizationResult;
+import uk.co.compendiumdev.thingifier.core.EntityRelModel;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.Field;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldType;
+import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
+import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstanceDraft;
+import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
+import uk.co.compendiumdev.thingifier.swaggerizer.Swaggerizer;
+
+class ThingifierApiFixedRouteTest {
+
+    @Test
+    void fixedRouteDefinitionUsesPublicPathWithoutUrlParameter() {
+        final Thingifier thingifier = secretModel();
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.GET, "/secret/note")
+                .mapsToEntity("secretnote")
+                .withFixedIdentifier("note")
+                .defaultEntityView("SecretNoteResponse");
+
+        final ApiRoutingDefinition definition =
+                new ApiRoutingDefinitionDocGenerator(thingifier).generate("");
+        final RoutingDefinition route = route(definition, RoutingVerb.GET, "secret/note");
+
+        Assertions.assertTrue(route.hasFixedIdentifierMapping());
+        Assertions.assertEquals("secretnote", route.fixedEntityName());
+        Assertions.assertEquals("note", route.fixedIdentifier());
+        Assertions.assertFalse(route.hasRequestUrlParams());
+        Assertions.assertEquals("SecretNoteResponse", route.getReturnPayloadFor(200));
+    }
+
+    @Test
+    void fixedRouteDefinitionKeepsConfiguredApiPrefix() {
+        final Thingifier thingifier = secretModel();
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.GET, "/secret/note")
+                .mapsToEntity("secretnote")
+                .withFixedIdentifier("note");
+
+        final ApiRoutingDefinition definition =
+                new ApiRoutingDefinitionDocGenerator(thingifier).generate("/api");
+
+        Assertions.assertNotNull(route(definition, RoutingVerb.GET, "api/secret/note"));
+    }
+
+    @Test
+    void openApiDocumentsFixedRouteWithoutIdentifierParameter() {
+        final Thingifier thingifier = secretModel();
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.GET, "/secret/note")
+                .mapsToEntity("secretnote")
+                .withFixedIdentifier("note");
+        final ThingifierApiDocumentationDefn apiDefn = new ThingifierApiDocumentationDefn();
+        apiDefn.setThingifier(thingifier);
+        apiDefn.setPathPrefix("/api");
+
+        final OpenAPI openApi = new Swaggerizer(apiDefn).swagger();
+        final PathItem path = openApi.getPaths().get("/api/secret/note");
+
+        Assertions.assertNotNull(path);
+        final Operation get = path.getGet();
+        Assertions.assertTrue(path.getParameters() == null || path.getParameters().isEmpty());
+        Assertions.assertTrue(get.getParameters() == null || get.getParameters().isEmpty());
+    }
+
+    @Test
+    void getFixedRouteReturnsConfiguredInstance() {
+        final Thingifier thingifier = secretModel();
+        getSecretNoteRoute(thingifier);
+        createSecretNote(thingifier, "note", "stored text", "internal-token");
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier).get(jsonRequest("/secret/note"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(
+                "note", response.apiResponse().getReturnedInstance().getPrimaryKeyValue());
+        Assertions.assertTrue(response.getBody().contains("stored text"));
+    }
+
+    @Test
+    void routeResponseViewHidesInternalFieldsForFixedRoute() {
+        final Thingifier thingifier = secretModel();
+        getSecretNoteRoute(thingifier).defaultEntityView("SecretNoteResponse");
+        createSecretNote(thingifier, "note", "visible text", "internal-token");
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier).get(jsonRequest("/secret/note"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertTrue(response.getBody().contains("visible text"));
+        Assertions.assertFalse(response.getBody().contains("internal"));
+        Assertions.assertFalse(response.getBody().contains("internal-token"));
+    }
+
+    @Test
+    void getFixedRouteCanUseIdentifierThatMatchesAnotherEntityName() {
+        final Thingifier thingifier = secretModel();
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.GET, "/secret/token")
+                .mapsToEntity("secretnote")
+                .withFixedIdentifier("token");
+        createSecretNote(thingifier, "token", "token-shaped note", "internal-token");
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier).get(jsonRequest("/secret/token"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(
+                "token", response.apiResponse().getReturnedInstance().getPrimaryKeyValue());
+        Assertions.assertTrue(response.getBody().contains("token-shaped note"));
+    }
+
+    @Test
+    void headFixedRouteUsesConfiguredInstance() {
+        final Thingifier thingifier = secretModel();
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.HEAD, "/secret/note")
+                .mapsToEntity("secretnote")
+                .withFixedIdentifier("note");
+        createSecretNote(thingifier, "note", "stored text", "internal-token");
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier).head(jsonRequest("/secret/note"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals("", response.getBody());
+        Assertions.assertFalse(response.getHeaders().get("Content-Length").isEmpty());
+    }
+
+    @Test
+    void missingFixedRouteReturns404ByDefault() {
+        final Thingifier thingifier = secretModel();
+        getSecretNoteRoute(thingifier);
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier).get(jsonRequest("/secret/note"));
+
+        Assertions.assertEquals(404, response.getStatusCode());
+    }
+
+    @Test
+    void postFixedRouteUpdatesConfiguredInstance() {
+        final Thingifier thingifier = secretModel();
+        postSecretNoteRoute(thingifier);
+        createSecretNote(thingifier, "note", "before", "internal-token");
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .post(jsonPost("/secret/note", "{\"text\":\"after\"}"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(
+                "after", secretNote(thingifier, "note").getFieldValue("text").asString());
+    }
+
+    @Test
+    void postMissingFixedRouteReturns404ByDefault() {
+        final Thingifier thingifier = secretModel();
+        postSecretNoteRoute(thingifier);
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .post(jsonPost("/secret/note", "{\"text\":\"after\"}"));
+
+        Assertions.assertEquals(404, response.getStatusCode());
+        Assertions.assertNull(secretNote(thingifier, "note"));
+    }
+
+    @Test
+    void postFixedRouteRejectsConflictingIdentifier() {
+        final Thingifier thingifier = secretModel();
+        postSecretNoteRoute(thingifier);
+        createSecretNote(thingifier, "note", "before", "internal-token");
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .post(jsonPost("/secret/note", "{\"id\":\"token\",\"text\":\"after\"}"));
+
+        Assertions.assertEquals(422, response.getStatusCode());
+        Assertions.assertEquals(
+                "before", secretNote(thingifier, "note").getFieldValue("text").asString());
+    }
+
+    @Test
+    void fixedRouteHonoursAuthSelectedDataScope() {
+        final Thingifier thingifier = secretModel();
+        createSecretNote(thingifier, "note", "default text", "default-token");
+        createSecretNote(thingifier, "challenger", "note", "tenant text", "tenant-token");
+        thingifier.apiSpec().authenticator("secretNoteToken", this::tenantTokenAuthenticator);
+        getSecretNoteRoute(thingifier).secureWithBearerAuth("secretNoteToken");
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .get(
+                                jsonRequest("/secret/note")
+                                        .addHeader("Authorization", "Bearer valid-token"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertTrue(response.getBody().contains("tenant text"));
+        Assertions.assertFalse(response.getBody().contains("default text"));
+    }
+
+    @Test
+    void authorizerReceivesFixedTargetDetails() {
+        final Thingifier thingifier = secretModel();
+        createSecretNote(thingifier, "challenger", "note", "tenant text", "tenant-token");
+        final AtomicReference<String> seenEntity = new AtomicReference<>();
+        final AtomicReference<String> seenIdentifier = new AtomicReference<>();
+        final AtomicReference<String> seenDataScope = new AtomicReference<>();
+        thingifier.apiSpec().authenticator("secretNoteToken", this::tenantTokenAuthenticator);
+        getSecretNoteRoute(thingifier)
+                .secureWithBearerAuth("secretNoteToken")
+                .authorizeWith(
+                        context -> {
+                            seenEntity.set(context.targetEntity().getName());
+                            seenIdentifier.set(context.targetIdentifier());
+                            seenDataScope.set(context.dataScopeName());
+                            return ThingifierApiAuthorizationResult.authorized();
+                        });
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .get(
+                                jsonRequest("/secret/note")
+                                        .addHeader("Authorization", "Bearer valid-token"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals("secretnote", seenEntity.get());
+        Assertions.assertEquals("note", seenIdentifier.get());
+        Assertions.assertEquals("challenger", seenDataScope.get());
+    }
+
+    @Test
+    void bodyParsedHookReceivesFixedRouteDetails() {
+        final Thingifier thingifier = secretModel();
+        postSecretNoteRoute(thingifier);
+        createSecretNote(thingifier, "note", "before", "internal-token");
+        final AtomicReference<String> seenEntity = new AtomicReference<>();
+        final AtomicReference<String> seenIdentifier = new AtomicReference<>();
+        final ThingifierApiLifecycleHookRegistry hooks = new ThingifierApiLifecycleHookRegistry();
+        hooks.registerBodyParsedHook(
+                context -> {
+                    seenEntity.set(context.targetEntity().getName());
+                    seenIdentifier.set(context.targetIdentifier());
+                });
+
+        final HttpApiResponse response =
+                ThingifierHttpApi.withHookRegistries(thingifier, null, hooks)
+                        .post(jsonPost("/secret/note", "{\"text\":\"after\"}"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals("secretnote", seenEntity.get());
+        Assertions.assertEquals("note", seenIdentifier.get());
+    }
+
+    @Test
+    void ensureExistsCreatesMissingFixedResource() {
+        final Thingifier thingifier = secretModel();
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.GET, "/secret/note")
+                .mapsToEntity("secretnote")
+                .withFixedIdentifier("note", FixedResourcePolicy.ENSURE_EXISTS);
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier).get(jsonRequest("/secret/note"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals("note", secretNote(thingifier, "note").getPrimaryKeyValue());
+    }
+
+    @Test
+    void generatedInstanceRouteStillWorksAlongsideFixedRoute() {
+        final Thingifier thingifier = secretModel();
+        getSecretNoteRoute(thingifier);
+        createSecretNote(thingifier, "note", "generated route text", "internal-token");
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier).get(jsonRequest("/secretnotes/note"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertTrue(response.getBody().contains("generated route text"));
+    }
+
+    @Test
+    void fixedIdentifierRejectsParameterizedRoutePaths() {
+        final Thingifier thingifier = secretModel();
+
+        final IllegalArgumentException thrown =
+                Assertions.assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                thingifier
+                                        .apiSpec()
+                                        .route(RoutingVerb.GET, "/secret/{kind}")
+                                        .mapsToEntity("secretnote")
+                                        .withFixedIdentifier("note"));
+
+        Assertions.assertEquals(
+                "fixed identifier routes must not contain path parameters", thrown.getMessage());
+    }
+
+    private ThingifierApiRouteRule getSecretNoteRoute(final Thingifier thingifier) {
+        return thingifier
+                .apiSpec()
+                .route(RoutingVerb.GET, "/secret/note")
+                .mapsToEntity("secretnote")
+                .withFixedIdentifier("note");
+    }
+
+    private ThingifierApiRouteRule postSecretNoteRoute(final Thingifier thingifier) {
+        return thingifier
+                .apiSpec()
+                .route(RoutingVerb.POST, "/secret/note")
+                .mapsToEntity("secretnote")
+                .withFixedIdentifier("note")
+                .entityCan(UPDATE);
+    }
+
+    private ThingifierApiAuthenticationResult tenantTokenAuthenticator(
+            final ThingifierApiAuthenticationContext context) {
+        if ("valid-token".equals(context.bearerToken())) {
+            return ThingifierApiAuthenticationResult.authenticated("tenant-principal")
+                    .useDataScope("challenger");
+        }
+        return ThingifierApiAuthenticationResult.rejected("Invalid bearer token");
+    }
+
+    private Thingifier secretModel() {
+        final Thingifier thingifier = new Thingifier();
+
+        final EntityDefinition note = thingifier.defineThing("secretnote", "secretnotes", 10);
+        note.addAsPrimaryKeyField(Field.is("id", FieldType.STRING));
+        note.addField(Field.is("text", FieldType.STRING));
+        note.addField(Field.is("internal", FieldType.STRING));
+        note.defineView("SecretNoteResponse").hideResponseFields("internal");
+
+        final EntityDefinition token = thingifier.defineThing("token", "tokens", 10);
+        token.addAsPrimaryKeyField(Field.is("id", FieldType.STRING));
+        token.addField(Field.is("value", FieldType.STRING));
+
+        return thingifier;
+    }
+
+    private EntityInstance createSecretNote(
+            final Thingifier thingifier,
+            final String id,
+            final String text,
+            final String internal) {
+        return createSecretNote(
+                thingifier, EntityRelModel.DEFAULT_DATABASE_NAME, id, text, internal);
+    }
+
+    private EntityInstance createSecretNote(
+            final Thingifier thingifier,
+            final String dataScopeName,
+            final String id,
+            final String text,
+            final String internal) {
+        ensureDataScopeExists(thingifier, dataScopeName);
+        final EntityDefinition note = thingifier.getDefinitionNamed("secretnote");
+        return storeFor(thingifier, dataScopeName)
+                .entities()
+                .create(
+                        EntityInstanceDraft.forEntity(note)
+                                .withField("id", id)
+                                .withField("text", text)
+                                .withField("internal", internal));
+    }
+
+    private EntityInstance secretNote(final Thingifier thingifier, final String id) {
+        return secretNote(thingifier, EntityRelModel.DEFAULT_DATABASE_NAME, id);
+    }
+
+    private EntityInstance secretNote(
+            final Thingifier thingifier, final String dataScopeName, final String id) {
+        return storeFor(thingifier, dataScopeName)
+                .entityQueries()
+                .findByPrimaryKey(thingifier.getDefinitionNamed("secretnote"), id);
+    }
+
+    private ThingStore storeFor(final Thingifier thingifier, final String dataScopeName) {
+        return thingifier.getStore(dataScopeName);
+    }
+
+    private void ensureDataScopeExists(final Thingifier thingifier, final String dataScopeName) {
+        thingifier.getERmodel().createInstanceDatabaseIfNotExisting(dataScopeName);
+    }
+
+    private HttpApiRequest jsonRequest(final String path) {
+        return new HttpApiRequest(path).addHeader("Accept", "application/json");
+    }
+
+    private HttpApiRequest jsonPost(final String path, final String body) {
+        return new HttpApiRequest(path)
+                .setVerb("POST")
+                .addHeader("Content-Type", "application/json")
+                .addHeader("Accept", "application/json")
+                .setBody(body);
+    }
+
+    private RoutingDefinition route(
+            final ApiRoutingDefinition definition, final RoutingVerb verb, final String url) {
+        return definition.definitions().stream()
+                .filter(route -> route.verb() == verb)
+                .filter(route -> route.url().equals(url))
+                .findFirst()
+                .orElseThrow();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds fixed-identifier route mapping so public routes such as `/secret/note` can map to a configured entity instance identifier without exposing `{id}` in the URL.
- Resolves fixed routes through the shared runtime route flow so auth, authorizers, lifecycle hooks, request handlers, response views, and auth-selected data scopes all see the same target.
- Adds `FixedResourcePolicy` with default `RETURN_404` and optional `ENSURE_EXISTS` handling.
- Documents fixed public routes exactly as declared in the API spec/OpenAPI output.

## Verification
- Full `mvn clean verify` passed via the pre-commit hook.
- `mvn install -DskipTests -DskipITs` previously installed `1.5.6-SNAPSHOT` locally for API Challenges testing.

Closes #152