### PR TITLE
Add request-aware API operation validators

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/ApiOperationValidationPolicy.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/ApiOperationValidationPolicy.java
@@ -1,0 +1,229 @@
+package uk.co.compendiumdev.thingifier.adapter.http.apihandlers;
+
+import java.util.Optional;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.CollectionRoute;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.InstanceRoute;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.RelationshipCollectionRoute;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.RelationshipInstanceRoute;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
+import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
+import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields;
+import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
+import uk.co.compendiumdev.thingifier.api.spec.ThingifierApiRouteRule;
+import uk.co.compendiumdev.thingifier.api.validation.ApiOperationValidationContext;
+import uk.co.compendiumdev.thingifier.api.validation.ApiOperationValidationResult;
+import uk.co.compendiumdev.thingifier.api.validation.ApiOperationValidatorDefinition;
+import uk.co.compendiumdev.thingifier.application.schema.EntityTypeRef;
+import uk.co.compendiumdev.thingifier.application.schema.RelationshipSpec;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
+
+/**
+ * Executes route-level API operation validators for a resolved request.
+ *
+ * <p>The policy sits between Thingifier's request/route/write mapping checks and repository model
+ * validation. That makes it suitable for request-aware API rules while preserving the existing
+ * field, instance, domain, and global validation pipeline for entity consistency.
+ */
+public final class ApiOperationValidationPolicy {
+
+    private final ThingifierApiRuntime runtime;
+
+    /**
+     * Creates an operation validation policy for one API runtime.
+     *
+     * @param runtime runtime services used to resolve route rules and entity metadata
+     */
+    public ApiOperationValidationPolicy(final ThingifierApiRuntime runtime) {
+        this.runtime = runtime;
+    }
+
+    /**
+     * Rejects a request when one of the route's operation validators rejects it.
+     *
+     * <p>Validators run in declaration order. Later validators, lifecycle validation hooks, model
+     * validators, and mutation are skipped after the first rejection.
+     *
+     * @param verb routing verb being processed
+     * @param publicPath public API path requested by the caller
+     * @param route resolved Thingifier route target
+     * @param context active request context after auth and data-scope selection
+     * @param bodyFields parsed request body fields
+     * @param rawBody raw request body text
+     * @param queryParams parsed query parameters
+     * @param operationType resolved operation type label
+     * @return rejection response, or null when validation accepts the operation
+     */
+    public ApiResponse rejectIfInvalid(
+            final RoutingVerb verb,
+            final String publicPath,
+            final ThingRoute route,
+            final ThingifierRequestContext context,
+            final ApiBodyFields bodyFields,
+            final String rawBody,
+            final QueryFilterParams queryParams,
+            final String operationType) {
+        Optional<ThingifierApiRouteRule> routeRule = routeRuleFor(verb, route, publicPath);
+        if (routeRule.isEmpty() || !routeRule.get().hasApiOperationValidators()) {
+            return null;
+        }
+
+        ApiOperationValidationContext validationContext =
+                validationContextFor(
+                        verb,
+                        publicPath,
+                        route,
+                        context,
+                        bodyFields,
+                        rawBody,
+                        queryParams,
+                        operationType);
+
+        for (ApiOperationValidatorDefinition definition :
+                routeRule.get().apiOperationValidators()) {
+            ApiOperationValidationResult result =
+                    definition.validator().validate(validationContext);
+            if (result != null && result.rejected()) {
+                return ApiResponse.error(result.statusCode(), result.message());
+            }
+        }
+        return null;
+    }
+
+    private Optional<ThingifierApiRouteRule> routeRuleFor(
+            final RoutingVerb verb, final ThingRoute route, final String publicPath) {
+        final String path = route == null ? publicPath : route.originalPath();
+        return runtime.apiSpec().ruleFor(verb, path, runtime.apiConfig().getApiEndPointPrefix());
+    }
+
+    private ApiOperationValidationContext validationContextFor(
+            final RoutingVerb verb,
+            final String publicPath,
+            final ThingRoute route,
+            final ThingifierRequestContext context,
+            final ApiBodyFields bodyFields,
+            final String rawBody,
+            final QueryFilterParams queryParams,
+            final String operationType) {
+        EntityDefinition targetEntity = targetEntityFor(route);
+        String targetEntityName = targetEntity == null ? null : targetEntity.getName();
+        String targetIdentifier = targetIdentifierFor(route);
+        String requestView = requestEntityViewFor(verb, route, targetEntity);
+        String responseView = responseEntityViewFor(verb, route, targetEntity, operationType);
+
+        return new ApiOperationValidationContext(
+                verb,
+                publicPath,
+                route,
+                targetEntityName,
+                targetIdentifier,
+                operationType,
+                context,
+                context == null ? null : context.headers(),
+                queryParams,
+                bodyFields,
+                rawBody,
+                requestView,
+                responseView);
+    }
+
+    private EntityDefinition targetEntityFor(final ThingRoute route) {
+        if (route instanceof CollectionRoute) {
+            return entityNamed(((CollectionRoute) route).entity().name());
+        }
+        if (route instanceof InstanceRoute) {
+            return entityNamed(((InstanceRoute) route).entity().name());
+        }
+        if (route instanceof RelationshipCollectionRoute) {
+            RelationshipCollectionRoute relationship = (RelationshipCollectionRoute) route;
+            return targetEntityForRelationship(
+                    relationship.parentEntity(), relationship.relationshipName());
+        }
+        if (route instanceof RelationshipInstanceRoute) {
+            RelationshipInstanceRoute relationship = (RelationshipInstanceRoute) route;
+            return targetEntityForRelationship(
+                    relationship.parentEntity(), relationship.relationshipName());
+        }
+        return null;
+    }
+
+    private String targetIdentifierFor(final ThingRoute route) {
+        if (route instanceof InstanceRoute) {
+            return ((InstanceRoute) route).identifier();
+        }
+        if (route instanceof RelationshipInstanceRoute) {
+            return ((RelationshipInstanceRoute) route).childIdentifier();
+        }
+        return null;
+    }
+
+    private EntityDefinition targetEntityForRelationship(
+            final EntityTypeRef parentEntity, final String relationshipName) {
+        if (parentEntity == null) {
+            return null;
+        }
+        for (RelationshipSpec spec : parentEntity.relationships()) {
+            if (spec.name().equals(relationshipName)) {
+                return entityNamed(spec.toEntityName());
+            }
+        }
+        return null;
+    }
+
+    private EntityDefinition entityNamed(final String entityName) {
+        return runtime.schema().definitionWithSingularOrPluralNamed(entityName);
+    }
+
+    private String requestEntityViewFor(
+            final RoutingVerb verb, final ThingRoute route, final EntityDefinition targetEntity) {
+        if (route == null) {
+            return null;
+        }
+        Optional<ThingifierApiRouteRule> rule = routeRuleFor(verb, route, route.originalPath());
+        if (targetEntity == null) {
+            return rule.filter(ThingifierApiRouteRule::hasRequestEntityView)
+                    .map(ThingifierApiRouteRule::getRequestEntityView)
+                    .orElse(null);
+        }
+        return runtime.apiSpec()
+                .requestEntityViewFor(
+                        verb,
+                        route.originalPath(),
+                        runtime.apiConfig().getApiEndPointPrefix(),
+                        targetEntity)
+                .orElse(null);
+    }
+
+    private String responseEntityViewFor(
+            final RoutingVerb verb,
+            final ThingRoute route,
+            final EntityDefinition targetEntity,
+            final String operationType) {
+        if (route == null || targetEntity == null) {
+            return null;
+        }
+        return runtime.apiSpec()
+                .responseEntityViewFor(
+                        verb,
+                        route.originalPath(),
+                        runtime.apiConfig().getApiEndPointPrefix(),
+                        targetEntity,
+                        successStatusFor(verb, operationType))
+                .orElse(null);
+    }
+
+    private int successStatusFor(final RoutingVerb verb, final String operationType) {
+        if (verb == RoutingVerb.DELETE
+                || "DELETE".equals(operationType)
+                || "DISCONNECT".equals(operationType)) {
+            return 204;
+        }
+        if ("CREATE".equals(operationType)
+                || "CREATE_AND_CONNECT".equals(operationType)
+                || "CONNECT_EXISTING".equals(operationType)) {
+            return 201;
+        }
+        return 200;
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/EntityPatchDocumentMapper.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/EntityPatchDocumentMapper.java
@@ -44,6 +44,28 @@ public final class EntityPatchDocumentMapper {
                 ApiMappingError.withMessage(400, "Unsupported PATCH update style"));
     }
 
+    /**
+     * Returns parsed body fields for operation validators when the PATCH style has fields.
+     *
+     * <p>JSON Merge Patch and JSON Patch are document operations, so validators should inspect
+     * {@code rawBody()} for those. Partial JSON update is field-shaped, so exposing parsed fields
+     * keeps operation validators aligned with POST and PUT body validators.
+     *
+     * @param style selected PATCH update style
+     * @param route mapped route
+     * @param rawBody raw patch body
+     * @return parsed fields for partial JSON update, otherwise an empty field set
+     */
+    public ApiBodyFields bodyFieldsForContext(
+            final EntityPatchUpdateStyle style, final ThingRoute route, final String rawBody) {
+        if (!(route instanceof InstanceRoute)
+                || style != EntityPatchUpdateStyle.PARTIAL_JSON_UPDATE) {
+            return ApiBodyFields.empty();
+        }
+        ParseResult parsed = parseJsonObject(rawBody, true);
+        return parsed.error == null ? parsed.bodyFields() : ApiBodyFields.empty();
+    }
+
     private ThingWriteRequestMapping mapPartialJsonUpdate(
             final InstanceRoute route, final String rawBody) {
         ParseResult parsed = parseJsonObject(rawBody, true);

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/WriteMethodPolicy.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/WriteMethodPolicy.java
@@ -408,6 +408,51 @@ public final class WriteMethodPolicy {
     }
 
     /**
+     * Resolves the concrete write operation represented by the current route and payload.
+     *
+     * <p>Operation validators receive this value so they can reason about the public API operation
+     * after Thingifier has applied the same create/update/connect intent rules used by write-policy
+     * enforcement.
+     *
+     * @param verb routing verb being processed
+     * @param route mapped generated route
+     * @param bodyFields parsed request body fields
+     * @param context request context used to inspect existing data when needed
+     * @return operation label such as CREATE, UPDATE, CREATE_AND_CONNECT, DISCONNECT, or DELETE
+     */
+    public String operationTypeFor(
+            final RoutingVerb verb,
+            final ThingRoute route,
+            final ApiBodyFields bodyFields,
+            final ThingifierRequestContext context) {
+        if (route instanceof CollectionRoute || route instanceof InstanceRoute) {
+            if (verb == RoutingVerb.DELETE && route instanceof InstanceRoute) {
+                return "DELETE";
+            }
+            EntityWriteOperation operation = entityOperationFor(verb, route, bodyFields, context);
+            if (operation != null) {
+                return operation.name();
+            }
+        }
+
+        if (route instanceof RelationshipCollectionRoute
+                || route instanceof RelationshipInstanceRoute) {
+            RelationshipWriteOperation operation =
+                    relationshipOperationFor(
+                            verb,
+                            route,
+                            bodyFields,
+                            context,
+                            relationshipOperationsFor(verb, route));
+            if (operation != null) {
+                return operation.name();
+            }
+        }
+
+        return verb.name();
+    }
+
+    /**
      * Builds an Allow header while excluding a rejected entity write operation.
      *
      * @param route mapped entity route

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/ThingifierRestAPIHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/ThingifierRestAPIHandler.java
@@ -267,7 +267,7 @@ public class ThingifierRestAPIHandler {
                 request.path(),
                 context,
                 lifecycle,
-                () -> delete.handle(request.path(), context, lifecycle));
+                () -> delete.handle(request.path(), request.queryParams(), context, lifecycle));
     }
 
     /**
@@ -285,7 +285,14 @@ public class ThingifierRestAPIHandler {
                 url,
                 context,
                 null,
-                () -> post.handle(url, args.bodyFields(), context));
+                () ->
+                        post.handle(
+                                url,
+                                args.bodyFields(),
+                                args.rawBody(),
+                                new QueryFilterParams(),
+                                context,
+                                null));
     }
 
     /**
@@ -313,7 +320,14 @@ public class ThingifierRestAPIHandler {
                 request.path(),
                 context,
                 lifecycle,
-                () -> post.handle(request.path(), request.bodyFields(), context, lifecycle));
+                () ->
+                        post.handle(
+                                request.path(),
+                                request.bodyFields(),
+                                request.body(),
+                                request.queryParams(),
+                                context,
+                                lifecycle));
     }
 
     /**
@@ -347,7 +361,14 @@ public class ThingifierRestAPIHandler {
                 url,
                 context,
                 null,
-                () -> put.handle(url, args.bodyFields(), context));
+                () ->
+                        put.handle(
+                                url,
+                                args.bodyFields(),
+                                args.rawBody(),
+                                new QueryFilterParams(),
+                                context,
+                                null));
     }
 
     /**
@@ -375,7 +396,14 @@ public class ThingifierRestAPIHandler {
                 request.path(),
                 context,
                 lifecycle,
-                () -> put.handle(request.path(), request.bodyFields(), context, lifecycle));
+                () ->
+                        put.handle(
+                                request.path(),
+                                request.bodyFields(),
+                                request.body(),
+                                request.queryParams(),
+                                context,
+                                lifecycle));
     }
 
     /**
@@ -460,6 +488,7 @@ public class ThingifierRestAPIHandler {
                                 request.path(),
                                 request.body(),
                                 request.headers(),
+                                request.queryParams(),
                                 context,
                                 lifecycle));
     }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiDeleteHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiDeleteHandler.java
@@ -1,7 +1,9 @@
 package uk.co.compendiumdev.thingifier.api.restapihandlers;
 
 import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ApiOperationValidationPolicy;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.DefaultThingifierApiRuntime;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingCommandResultApiMapper;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingWriteRequestMapper;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingWriteRequestMapping;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierApiRuntime;
@@ -14,6 +16,7 @@ import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields;
 import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
+import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
 
 /**
  * Handles generated Thingifier DELETE routes.
@@ -76,7 +79,7 @@ public class RestApiDeleteHandler {
      * @return API response for the DELETE
      */
     public ApiResponse handle(final String url, final ThingifierRequestContext context) {
-        return handle(url, context, null);
+        return handle(url, new QueryFilterParams(), context, null);
     }
 
     /**
@@ -91,17 +94,58 @@ public class RestApiDeleteHandler {
             final String url,
             final ThingifierRequestContext context,
             final ThingifierApiLifecycleContext lifecycle) {
+        return handle(
+                url,
+                lifecycle == null ? new QueryFilterParams() : lifecycle.queryParams(),
+                context,
+                lifecycle);
+    }
+
+    /**
+     * Handles a DELETE request with full request data for operation validation.
+     *
+     * @param url generated API path
+     * @param queryParams parsed query parameters
+     * @param context request context containing the active store
+     * @param lifecycle lifecycle context, or null for direct processing
+     * @return API response for the DELETE
+     */
+    public ApiResponse handle(
+            final String url,
+            final QueryFilterParams queryParams,
+            final ThingifierRequestContext context,
+            final ThingifierApiLifecycleContext lifecycle) {
         ThingRoute route = routeFor(url, lifecycle);
+        WriteMethodPolicy writePolicy = new WriteMethodPolicy(runtime);
         ApiResponse policyResponse =
-                new WriteMethodPolicy(runtime)
-                        .rejectIfNotAllowed(
-                                RoutingVerb.DELETE, route, ApiBodyFields.empty(), context);
+                writePolicy.rejectIfNotAllowed(
+                        RoutingVerb.DELETE, route, ApiBodyFields.empty(), context);
         if (policyResponse != null) {
             return policyResponse;
         }
 
         ThingWriteRequestMapping mapping =
                 new ThingWriteRequestMapper(runtime.schema()).mapDelete(route);
+        if (mapping.isError()) {
+            return new ThingCommandResultApiMapper(runtime.apiConfig()).map(mapping.getError());
+        }
+
+        ApiResponse operationValidationResponse =
+                new ApiOperationValidationPolicy(runtime)
+                        .rejectIfInvalid(
+                                RoutingVerb.DELETE,
+                                url,
+                                route,
+                                context,
+                                ApiBodyFields.empty(),
+                                "",
+                                queryParams,
+                                writePolicy.operationTypeFor(
+                                        RoutingVerb.DELETE, route, ApiBodyFields.empty(), context));
+        if (operationValidationResponse != null) {
+            return operationValidationResponse;
+        }
+
         return LifecycleWriteSupport.execute(
                 runtime,
                 lifecycleHooks,

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiGetHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiGetHandler.java
@@ -1,6 +1,7 @@
 package uk.co.compendiumdev.thingifier.api.restapihandlers;
 
 import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ApiOperationValidationPolicy;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.DefaultThingifierApiRuntime;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingReadRequestMapper;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingReadRequestMapping;
@@ -14,6 +15,7 @@ import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecy
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierHttpApi;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
+import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields;
 import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
 import uk.co.compendiumdev.thingifier.application.query.ThingReadQuery;
@@ -153,6 +155,21 @@ public class RestApiGetHandler {
             return apiMapper.map(mapping.getError());
         }
 
+        ApiResponse operationValidationResponse =
+                new ApiOperationValidationPolicy(runtime)
+                        .rejectIfInvalid(
+                                verb,
+                                url,
+                                route,
+                                context,
+                                ApiBodyFields.empty(),
+                                "",
+                                effectiveQueryParams.queryParams(),
+                                readOperationType(verb));
+        if (operationValidationResponse != null) {
+            return operationValidationResponse;
+        }
+
         if (lifecycle == null) {
             RepositoryQueryResult queryResults =
                     runtime.queryService().execute(mapping.getQuery(), context.store());
@@ -237,5 +254,9 @@ public class RestApiGetHandler {
                     ThingifierHttpApi.SUPPORTED_QUERY_CONTENT_TYPES);
         }
         return response;
+    }
+
+    private String readOperationType(final RoutingVerb verb) {
+        return verb == RoutingVerb.QUERY ? "QUERY" : "READ";
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPatchHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPatchHandler.java
@@ -3,8 +3,10 @@ package uk.co.compendiumdev.thingifier.api.restapihandlers;
 import java.util.Optional;
 import java.util.Set;
 import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ApiOperationValidationPolicy;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.DefaultThingifierApiRuntime;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.EntityPatchDocumentMapper;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingCommandResultApiMapper;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingWriteRequestMapping;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierApiRuntime;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.WriteMethodPolicy;
@@ -14,9 +16,11 @@ import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecy
 import uk.co.compendiumdev.thingifier.adapter.http.lifecycle.ThingifierApiLifecycleHookRegistry;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
+import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields;
 import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
 import uk.co.compendiumdev.thingifier.apiconfig.EntityPatchUpdateStyle;
+import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
 
 /**
  * Handles generated Thingifier PATCH routes.
@@ -74,7 +78,7 @@ public class RestApiPatchHandler {
             final String rawBody,
             final HttpHeadersBlock requestHeaders,
             final ThingifierRequestContext context) {
-        return handle(url, rawBody, requestHeaders, context, null);
+        return handle(url, rawBody, requestHeaders, new QueryFilterParams(), context, null);
     }
 
     /**
@@ -93,14 +97,37 @@ public class RestApiPatchHandler {
             final HttpHeadersBlock requestHeaders,
             final ThingifierRequestContext context,
             final ThingifierApiLifecycleContext lifecycle) {
+        return handle(
+                url,
+                rawBody,
+                requestHeaders,
+                lifecycle == null ? new QueryFilterParams() : lifecycle.queryParams(),
+                context,
+                lifecycle);
+    }
+
+    /**
+     * Handles a PATCH request with full request data for operation validation.
+     *
+     * @param url generated API path
+     * @param rawBody raw patch body
+     * @param requestHeaders request headers used for content type policy
+     * @param queryParams parsed query parameters
+     * @param context request context containing the active store
+     * @param lifecycle lifecycle context, or null for direct processing
+     * @return API response for the PATCH
+     */
+    public ApiResponse handle(
+            final String url,
+            final String rawBody,
+            final HttpHeadersBlock requestHeaders,
+            final QueryFilterParams queryParams,
+            final ThingifierRequestContext context,
+            final ThingifierApiLifecycleContext lifecycle) {
         ThingRoute route = routeFor(url, lifecycle);
         WriteMethodPolicy policy = new WriteMethodPolicy(runtime);
         ApiResponse policyResponse =
-                policy.rejectIfNotAllowed(
-                        RoutingVerb.PATCH,
-                        route,
-                        uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields.empty(),
-                        context);
+                policy.rejectIfNotAllowed(RoutingVerb.PATCH, route, ApiBodyFields.empty(), context);
         if (policyResponse != null) {
             return policyResponse;
         }
@@ -114,12 +141,31 @@ public class RestApiPatchHandler {
             }
         }
 
-        ThingWriteRequestMapping mapping =
-                new EntityPatchDocumentMapper(runtime.schema())
-                        .map(
-                                style.orElse(EntityPatchUpdateStyle.PARTIAL_JSON_UPDATE),
+        EntityPatchDocumentMapper mapper = new EntityPatchDocumentMapper(runtime.schema());
+        EntityPatchUpdateStyle selectedStyle =
+                style.orElse(EntityPatchUpdateStyle.PARTIAL_JSON_UPDATE);
+        ThingWriteRequestMapping mapping = mapper.map(selectedStyle, route, rawBody);
+        if (mapping.isError()) {
+            return new ThingCommandResultApiMapper(runtime.apiConfig()).map(mapping.getError());
+        }
+
+        ApiBodyFields bodyFields = mapper.bodyFieldsForContext(selectedStyle, route, rawBody);
+        ApiResponse operationValidationResponse =
+                new ApiOperationValidationPolicy(runtime)
+                        .rejectIfInvalid(
+                                RoutingVerb.PATCH,
+                                url,
                                 route,
-                                rawBody);
+                                context,
+                                bodyFields,
+                                rawBody,
+                                queryParams,
+                                policy.operationTypeFor(
+                                        RoutingVerb.PATCH, route, bodyFields, context));
+        if (operationValidationResponse != null) {
+            return operationValidationResponse;
+        }
+
         return LifecycleWriteSupport.execute(
                 runtime,
                 lifecycleHooks,

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPostHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPostHandler.java
@@ -1,7 +1,9 @@
 package uk.co.compendiumdev.thingifier.api.restapihandlers;
 
 import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ApiOperationValidationPolicy;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.DefaultThingifierApiRuntime;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingCommandResultApiMapper;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingWriteRequestMapper;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingWriteRequestMapping;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierApiRuntime;
@@ -15,6 +17,7 @@ import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.BodyParser;
 import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
+import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
 
 /**
  * Handles generated Thingifier POST routes.
@@ -68,7 +71,13 @@ public class RestApiPostHandler {
      */
     public ApiResponse handle(
             final String url, final BodyParser args, final HttpHeadersBlock requestHeaders) {
-        return handle(url, args.bodyFields(), runtime.contextFrom(requestHeaders));
+        return handle(
+                url,
+                args.bodyFields(),
+                args.rawBody(),
+                new QueryFilterParams(),
+                runtime.contextFrom(requestHeaders),
+                null);
     }
 
     /**
@@ -81,7 +90,8 @@ public class RestApiPostHandler {
      */
     public ApiResponse handle(
             final String url, final BodyParser args, final ThingifierRequestContext context) {
-        return handle(url, args.bodyFields(), context);
+        return handle(
+                url, args.bodyFields(), args.rawBody(), new QueryFilterParams(), context, null);
     }
 
     /**
@@ -96,7 +106,7 @@ public class RestApiPostHandler {
             final String url,
             final ApiBodyFields bodyFields,
             final ThingifierRequestContext context) {
-        return handle(url, bodyFields, context, null);
+        return handle(url, bodyFields, "", new QueryFilterParams(), context, null);
     }
 
     /**
@@ -111,6 +121,33 @@ public class RestApiPostHandler {
     public ApiResponse handle(
             final String url,
             final ApiBodyFields bodyFields,
+            final ThingifierRequestContext context,
+            final ThingifierApiLifecycleContext lifecycle) {
+        return handle(
+                url,
+                bodyFields,
+                lifecycle == null ? "" : lifecycle.rawBody(),
+                lifecycle == null ? new QueryFilterParams() : lifecycle.queryParams(),
+                context,
+                lifecycle);
+    }
+
+    /**
+     * Handles a POST request with full request data for operation validation.
+     *
+     * @param url generated API path
+     * @param bodyFields parsed request body fields
+     * @param rawBody raw request body text
+     * @param queryParams parsed query parameters
+     * @param context request context containing the active store
+     * @param lifecycle lifecycle context, or null for direct processing
+     * @return API response for the POST
+     */
+    public ApiResponse handle(
+            final String url,
+            final ApiBodyFields bodyFields,
+            final String rawBody,
+            final QueryFilterParams queryParams,
             final ThingifierRequestContext context,
             final ThingifierApiLifecycleContext lifecycle) {
         ThingRoute route = routeFor(url, lifecycle);
@@ -128,6 +165,26 @@ public class RestApiPostHandler {
                         writePolicy.relationshipOperationsFor(RoutingVerb.POST, route),
                         context);
         ThingWriteRequestMapping mapping = mapper.mapPost(route, bodyFields);
+        if (mapping.isError()) {
+            return new ThingCommandResultApiMapper(runtime.apiConfig()).map(mapping.getError());
+        }
+
+        ApiResponse operationValidationResponse =
+                new ApiOperationValidationPolicy(runtime)
+                        .rejectIfInvalid(
+                                RoutingVerb.POST,
+                                url,
+                                route,
+                                context,
+                                bodyFields,
+                                rawBody,
+                                queryParams,
+                                writePolicy.operationTypeFor(
+                                        RoutingVerb.POST, route, bodyFields, context));
+        if (operationValidationResponse != null) {
+            return operationValidationResponse;
+        }
+
         return LifecycleWriteSupport.execute(
                 runtime,
                 lifecycleHooks,

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPutHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiPutHandler.java
@@ -1,7 +1,9 @@
 package uk.co.compendiumdev.thingifier.api.restapihandlers;
 
 import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ApiOperationValidationPolicy;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.DefaultThingifierApiRuntime;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingCommandResultApiMapper;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingWriteRequestMapper;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingWriteRequestMapping;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierApiRuntime;
@@ -15,6 +17,7 @@ import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields;
 import uk.co.compendiumdev.thingifier.api.http.bodyparser.BodyParser;
 import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
+import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
 
 /**
  * Handles generated Thingifier PUT routes.
@@ -68,7 +71,13 @@ public class RestApiPutHandler {
      */
     public ApiResponse handle(
             final String url, final BodyParser args, final HttpHeadersBlock requestHeaders) {
-        return handle(url, args.bodyFields(), runtime.contextFrom(requestHeaders));
+        return handle(
+                url,
+                args.bodyFields(),
+                args.rawBody(),
+                new QueryFilterParams(),
+                runtime.contextFrom(requestHeaders),
+                null);
     }
 
     /**
@@ -81,7 +90,8 @@ public class RestApiPutHandler {
      */
     public ApiResponse handle(
             final String url, final BodyParser args, final ThingifierRequestContext context) {
-        return handle(url, args.bodyFields(), context);
+        return handle(
+                url, args.bodyFields(), args.rawBody(), new QueryFilterParams(), context, null);
     }
 
     /**
@@ -96,7 +106,7 @@ public class RestApiPutHandler {
             final String url,
             final ApiBodyFields bodyFields,
             final ThingifierRequestContext context) {
-        return handle(url, bodyFields, context, null);
+        return handle(url, bodyFields, "", new QueryFilterParams(), context, null);
     }
 
     /**
@@ -113,10 +123,37 @@ public class RestApiPutHandler {
             final ApiBodyFields bodyFields,
             final ThingifierRequestContext context,
             final ThingifierApiLifecycleContext lifecycle) {
+        return handle(
+                url,
+                bodyFields,
+                lifecycle == null ? "" : lifecycle.rawBody(),
+                lifecycle == null ? new QueryFilterParams() : lifecycle.queryParams(),
+                context,
+                lifecycle);
+    }
+
+    /**
+     * Handles a PUT request with full request data for operation validation.
+     *
+     * @param url generated API path
+     * @param bodyFields parsed request body fields
+     * @param rawBody raw request body text
+     * @param queryParams parsed query parameters
+     * @param context request context containing the active store
+     * @param lifecycle lifecycle context, or null for direct processing
+     * @return API response for the PUT
+     */
+    public ApiResponse handle(
+            final String url,
+            final ApiBodyFields bodyFields,
+            final String rawBody,
+            final QueryFilterParams queryParams,
+            final ThingifierRequestContext context,
+            final ThingifierApiLifecycleContext lifecycle) {
         ThingRoute route = routeFor(url, lifecycle);
+        WriteMethodPolicy writePolicy = new WriteMethodPolicy(runtime);
         ApiResponse policyResponse =
-                new WriteMethodPolicy(runtime)
-                        .rejectIfNotAllowed(RoutingVerb.PUT, route, bodyFields, context);
+                writePolicy.rejectIfNotAllowed(RoutingVerb.PUT, route, bodyFields, context);
         if (policyResponse != null) {
             return policyResponse;
         }
@@ -125,6 +162,26 @@ public class RestApiPutHandler {
                 new ThingWriteRequestMapper(
                                 runtime.schema(), runtime.apiConfig().writeMethods().entities())
                         .mapPut(route, bodyFields);
+        if (mapping.isError()) {
+            return new ThingCommandResultApiMapper(runtime.apiConfig()).map(mapping.getError());
+        }
+
+        ApiResponse operationValidationResponse =
+                new ApiOperationValidationPolicy(runtime)
+                        .rejectIfInvalid(
+                                RoutingVerb.PUT,
+                                url,
+                                route,
+                                context,
+                                bodyFields,
+                                rawBody,
+                                queryParams,
+                                writePolicy.operationTypeFor(
+                                        RoutingVerb.PUT, route, bodyFields, context));
+        if (operationValidationResponse != null) {
+            return operationValidationResponse;
+        }
+
         return LifecycleWriteSupport.execute(
                 runtime,
                 lifecycleHooks,

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/restapihandlers/RestApiQueryHandler.java
@@ -1,6 +1,7 @@
 package uk.co.compendiumdev.thingifier.api.restapihandlers;
 
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ApiMappingError;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ApiOperationValidationPolicy;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingReadRequestMapper;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingReadRequestMapping;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingReadResultApiMapper;
@@ -17,6 +18,7 @@ import uk.co.compendiumdev.thingifier.api.ermodelconversion.JsonThing;
 import uk.co.compendiumdev.thingifier.api.http.ApiRequestEnvelope;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierHttpApi;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
+import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityViewDefinition;
@@ -138,6 +140,21 @@ public final class RestApiQueryHandler {
             return mapping.response;
         }
 
+        ApiResponse operationValidationResponse =
+                new ApiOperationValidationPolicy(runtime)
+                        .rejectIfInvalid(
+                                RoutingVerb.QUERY,
+                                url,
+                                route,
+                                context,
+                                ApiBodyFields.empty(),
+                                queryBody,
+                                mapping.queryParams,
+                                "QUERY");
+        if (operationValidationResponse != null) {
+            return operationValidationResponse;
+        }
+
         if (lifecycle == null) {
             return executeMappedQuery(url, mapping, queryBodyFormat, queryBody, context, apiMapper);
         }
@@ -248,7 +265,7 @@ public final class RestApiQueryHandler {
         if (mapping.isError()) {
             return QueryMapping.response(apiMapper.map(mapping.getError()));
         }
-        return QueryMapping.mapping(mapping);
+        return QueryMapping.mapping(mapping, effectiveQueryParams.queryParams());
     }
 
     /**
@@ -426,16 +443,22 @@ public final class RestApiQueryHandler {
     private static final class QueryMapping {
 
         private final ThingReadRequestMapping mapping;
+        private final QueryFilterParams queryParams;
         private final ApiResponse response;
 
         /**
          * Creates a query mapping value that holds either a mapped request or an early response.
          *
          * @param mapping mapped read request, or null when response is populated
+         * @param queryParams effective query params used to build the mapped request
          * @param response early API response, or null when mapping is populated
          */
-        private QueryMapping(final ThingReadRequestMapping mapping, final ApiResponse response) {
+        private QueryMapping(
+                final ThingReadRequestMapping mapping,
+                final QueryFilterParams queryParams,
+                final ApiResponse response) {
             this.mapping = mapping;
+            this.queryParams = queryParams == null ? new QueryFilterParams() : queryParams;
             this.response = response;
         }
 
@@ -445,8 +468,9 @@ public final class RestApiQueryHandler {
          * @param mapping mapped read request
          * @return query mapping wrapper
          */
-        private static QueryMapping mapping(final ThingReadRequestMapping mapping) {
-            return new QueryMapping(mapping, null);
+        private static QueryMapping mapping(
+                final ThingReadRequestMapping mapping, final QueryFilterParams queryParams) {
+            return new QueryMapping(mapping, queryParams, null);
         }
 
         /**
@@ -456,7 +480,7 @@ public final class RestApiQueryHandler {
          * @return query mapping wrapper containing the response
          */
         private static QueryMapping response(final ApiResponse response) {
-            return new QueryMapping(null, response);
+            return new QueryMapping(null, null, response);
         }
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiRouteRule.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiRouteRule.java
@@ -11,6 +11,8 @@ import uk.co.compendiumdev.thingifier.api.docgen.RoutingStatus;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.api.security.SecuritySchemeNames;
 import uk.co.compendiumdev.thingifier.api.security.ThingifierApiAuthorizer;
+import uk.co.compendiumdev.thingifier.api.validation.ApiOperationValidator;
+import uk.co.compendiumdev.thingifier.api.validation.ApiOperationValidatorDefinition;
 import uk.co.compendiumdev.thingifier.apiconfig.EntityPatchUpdateStyle;
 import uk.co.compendiumdev.thingifier.apiconfig.EntityWriteOperation;
 import uk.co.compendiumdev.thingifier.apiconfig.RelationshipWriteOperation;
@@ -36,6 +38,7 @@ public final class ThingifierApiRouteRule {
     private String bearerAuthSchemeName;
     private String enforcedBearerAuthSchemeName;
     private final List<ThingifierApiAuthorizer> authorizers;
+    private final List<ApiOperationValidatorDefinition> apiOperationValidators;
     private String documentation;
     private String requestPayload;
     private String requestEntityView;
@@ -61,6 +64,7 @@ public final class ThingifierApiRouteRule {
         this.bearerAuthSchemeName = SecuritySchemeNames.DEFAULT_BEARER_AUTH_SCHEME;
         this.enforcedBearerAuthSchemeName = null;
         this.authorizers = new java.util.ArrayList<>();
+        this.apiOperationValidators = new java.util.ArrayList<>();
         this.documentation = null;
         this.requestPayload = null;
         this.requestEntityView = null;
@@ -513,6 +517,46 @@ public final class ThingifierApiRouteRule {
      */
     public ThingifierApiRouteRule relationshipCan(final RelationshipWriteOperation... operations) {
         return relationshipWriteOperations(operations);
+    }
+
+    /**
+     * Adds a request-aware validator for this public API operation.
+     *
+     * <p>Use operation validators when the rule belongs to the route contract rather than the
+     * entity model. They run after authentication, data-scope selection, request parsing, fixed
+     * route preparation, declarative write policy, and command/query mapping have succeeded, but
+     * before entity field/instance/domain/global validation and before mutation.
+     *
+     * @param name stable validator name for diagnostics and future tooling
+     * @param validator callback used to accept or reject this operation
+     * @return this rule so route API configuration can be chained
+     * @throws IllegalArgumentException when the name is blank or the validator is null
+     */
+    public ThingifierApiRouteRule withApiOperationValidator(
+            final String name, final ApiOperationValidator validator) {
+        apiOperationValidators.add(new ApiOperationValidatorDefinition(name, validator));
+        return this;
+    }
+
+    /**
+     * Reports whether this route has request-aware operation validators.
+     *
+     * @return true when validators are registered
+     */
+    public boolean hasApiOperationValidators() {
+        return !apiOperationValidators.isEmpty();
+    }
+
+    /**
+     * Returns the operation validators in declaration order.
+     *
+     * <p>Validators are intentionally runtime-only for v1. They are not serialized to YAML or
+     * emitted into OpenAPI because Java callbacks cannot safely round-trip through those formats.
+     *
+     * @return immutable list of validator registrations
+     */
+    public List<ApiOperationValidatorDefinition> apiOperationValidators() {
+        return Collections.unmodifiableList(apiOperationValidators);
     }
 
     /**

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/validation/ApiOperationValidationContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/validation/ApiOperationValidationContext.java
@@ -1,0 +1,258 @@
+package uk.co.compendiumdev.thingifier.api.validation;
+
+import java.util.Map;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
+import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
+import uk.co.compendiumdev.thingifier.api.http.bodyparser.ApiBodyFields;
+import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
+import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
+import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
+
+/**
+ * Immutable request-aware context supplied to route-level API operation validators.
+ *
+ * <p>This context exists because some API rules are about the public operation rather than the
+ * entity model: they may depend on authentication, selected data scope, the public fixed route, or
+ * route-specific request body semantics. The authenticator and route matcher have already made
+ * trusted decisions before this context is built.
+ */
+public final class ApiOperationValidationContext {
+
+    private final RoutingVerb verb;
+    private final String publicPath;
+    private final ThingRoute route;
+    private final String targetEntityName;
+    private final String targetIdentifier;
+    private final String operationType;
+    private final ThingifierRequestContext requestContext;
+    private final HttpHeadersBlock headers;
+    private final QueryFilterParams queryParameters;
+    private final ApiBodyFields requestBody;
+    private final String rawBody;
+    private final String requestEntityView;
+    private final String responseEntityView;
+
+    /**
+     * Creates an operation validation context.
+     *
+     * @param verb route verb being processed
+     * @param publicPath public API path requested by the caller
+     * @param route resolved Thingifier route target
+     * @param targetEntityName target entity name, or null when the route is not entity-backed
+     * @param targetIdentifier target instance identifier, or null for collection routes
+     * @param operationType read/write operation label such as CREATE, UPDATE, DELETE, or QUERY
+     * @param requestContext active request context after authentication and data-scope selection
+     * @param headers request headers
+     * @param queryParameters parsed query parameters
+     * @param requestBody parsed request body fields
+     * @param rawBody raw request body text
+     * @param requestEntityView request entity view selected for this route, or null
+     * @param responseEntityView response entity view selected for the expected success status, or
+     *     null
+     */
+    public ApiOperationValidationContext(
+            final RoutingVerb verb,
+            final String publicPath,
+            final ThingRoute route,
+            final String targetEntityName,
+            final String targetIdentifier,
+            final String operationType,
+            final ThingifierRequestContext requestContext,
+            final HttpHeadersBlock headers,
+            final QueryFilterParams queryParameters,
+            final ApiBodyFields requestBody,
+            final String rawBody,
+            final String requestEntityView,
+            final String responseEntityView) {
+        this.verb = verb;
+        this.publicPath = publicPath == null ? "" : publicPath;
+        this.route = route;
+        this.targetEntityName = targetEntityName;
+        this.targetIdentifier = targetIdentifier;
+        this.operationType = operationType == null ? "" : operationType;
+        this.requestContext = requestContext;
+        this.headers = copyHeaders(headers);
+        this.queryParameters = copyQueryParameters(queryParameters);
+        this.requestBody = requestBody == null ? ApiBodyFields.empty() : requestBody;
+        this.rawBody = rawBody == null ? "" : rawBody;
+        this.requestEntityView = requestEntityView;
+        this.responseEntityView = responseEntityView;
+    }
+
+    /**
+     * Returns the route verb being processed.
+     *
+     * @return routing verb
+     */
+    public RoutingVerb verb() {
+        return verb;
+    }
+
+    /**
+     * Returns the public API path requested by the caller.
+     *
+     * @return public path
+     */
+    public String publicPath() {
+        return publicPath;
+    }
+
+    /**
+     * Returns the resolved Thingifier route target.
+     *
+     * @return route object used by generated handlers
+     */
+    public ThingRoute route() {
+        return route;
+    }
+
+    /**
+     * Returns the entity targeted by this operation.
+     *
+     * @return entity name, or null when not entity-backed
+     */
+    public String targetEntityName() {
+        return targetEntityName;
+    }
+
+    /**
+     * Returns the target instance identifier.
+     *
+     * @return identifier, or null for collection operations
+     */
+    public String targetIdentifier() {
+        return targetIdentifier;
+    }
+
+    /**
+     * Returns the resolved operation type.
+     *
+     * <p>Generated writes expose concrete operation names such as CREATE, UPDATE,
+     * CREATE_AND_CONNECT, UPDATE_CONNECTED, DISCONNECT, and DELETE so validators do not have to
+     * infer intent from route shape.
+     *
+     * @return operation type label
+     */
+    public String operationType() {
+        return operationType;
+    }
+
+    /**
+     * Returns the active data-scope name after authentication has had a chance to select it.
+     *
+     * @return data-scope name
+     */
+    public String dataScopeName() {
+        return requestContext == null ? null : requestContext.dataScopeName();
+    }
+
+    /**
+     * Returns the active Thingifier store after data-scope selection.
+     *
+     * @return active store, or null when no request context is available
+     */
+    public ThingStore store() {
+        return requestContext == null ? null : requestContext.store();
+    }
+
+    /**
+     * Returns the authenticated principal for the usual single-scheme route case.
+     *
+     * @return authenticated principal, or null when none has been stored
+     */
+    public Object authenticatedPrincipal() {
+        Map<String, Object> principals = authenticatedPrincipals();
+        if (principals.isEmpty()) {
+            return null;
+        }
+        return principals.values().iterator().next();
+    }
+
+    /**
+     * Returns the authenticated principal for a named security scheme.
+     *
+     * @param schemeName security scheme name
+     * @return authenticated principal, or null when that scheme did not authenticate
+     */
+    public Object authenticatedPrincipal(final String schemeName) {
+        return requestContext == null ? null : requestContext.authenticatedPrincipal(schemeName);
+    }
+
+    /**
+     * Returns all authenticated principals by security scheme.
+     *
+     * @return immutable copy of authenticated principal entries
+     */
+    public Map<String, Object> authenticatedPrincipals() {
+        return requestContext == null ? Map.of() : requestContext.authenticatedPrincipals();
+    }
+
+    /**
+     * Returns a copy of the request headers.
+     *
+     * @return request headers
+     */
+    public HttpHeadersBlock headers() {
+        return copyHeaders(headers);
+    }
+
+    /**
+     * Returns a copy of the parsed query parameters.
+     *
+     * @return query parameters
+     */
+    public QueryFilterParams queryParameters() {
+        return copyQueryParameters(queryParameters);
+    }
+
+    /**
+     * Returns parsed body fields.
+     *
+     * @return request body fields, never null
+     */
+    public ApiBodyFields requestBody() {
+        return requestBody;
+    }
+
+    /**
+     * Returns the raw request body text.
+     *
+     * @return raw body, never null
+     */
+    public String rawBody() {
+        return rawBody;
+    }
+
+    /**
+     * Returns the route/entity request view selected before operation validation.
+     *
+     * @return request entity view name, or null
+     */
+    public String requestEntityView() {
+        return requestEntityView;
+    }
+
+    /**
+     * Returns the route/entity response view selected for the expected success response.
+     *
+     * @return response entity view name, or null
+     */
+    public String responseEntityView() {
+        return responseEntityView;
+    }
+
+    private HttpHeadersBlock copyHeaders(final HttpHeadersBlock source) {
+        HttpHeadersBlock copy = new HttpHeadersBlock();
+        if (source != null) {
+            copy.putAll(source);
+        }
+        return copy;
+    }
+
+    private QueryFilterParams copyQueryParameters(final QueryFilterParams source) {
+        QueryFilterParams copy = new QueryFilterParams();
+        copy.addAll(source);
+        return copy;
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/validation/ApiOperationValidationResult.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/validation/ApiOperationValidationResult.java
@@ -1,0 +1,82 @@
+package uk.co.compendiumdev.thingifier.api.validation;
+
+/**
+ * Result returned by an {@link ApiOperationValidator}.
+ *
+ * <p>The result intentionally models only accept or reject for v1. A rejection is converted into
+ * Thingifier's normal API error response and stops later operation validators, entity validators,
+ * lifecycle validation phases, and mutation.
+ */
+public final class ApiOperationValidationResult {
+
+    private final boolean accepted;
+    private final int statusCode;
+    private final String message;
+
+    private ApiOperationValidationResult(
+            final boolean accepted, final int statusCode, final String message) {
+        this.accepted = accepted;
+        this.statusCode = statusCode;
+        this.message = message == null ? "" : message;
+    }
+
+    /**
+     * Creates an accepted result so the operation can continue.
+     *
+     * @return accepted validation result
+     */
+    public static ApiOperationValidationResult accept() {
+        return new ApiOperationValidationResult(true, 200, "");
+    }
+
+    /**
+     * Creates a rejected result with the response status and message to return to the caller.
+     *
+     * @param statusCode HTTP-style status code to return
+     * @param message error message to include in Thingifier's normal error response
+     * @return rejected validation result
+     * @throws IllegalArgumentException when the status code is outside the HTTP range
+     */
+    public static ApiOperationValidationResult reject(final int statusCode, final String message) {
+        if (statusCode < 100 || statusCode > 599) {
+            throw new IllegalArgumentException("statusCode must be between 100 and 599");
+        }
+        return new ApiOperationValidationResult(false, statusCode, message);
+    }
+
+    /**
+     * Reports whether validation accepted the operation.
+     *
+     * @return true when processing can continue
+     */
+    public boolean accepted() {
+        return accepted;
+    }
+
+    /**
+     * Reports whether validation rejected the operation.
+     *
+     * @return true when processing must stop
+     */
+    public boolean rejected() {
+        return !accepted;
+    }
+
+    /**
+     * Returns the status code for a rejected operation.
+     *
+     * @return rejection status code
+     */
+    public int statusCode() {
+        return statusCode;
+    }
+
+    /**
+     * Returns the error message for a rejected operation.
+     *
+     * @return rejection message, never null
+     */
+    public String message() {
+        return message;
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/validation/ApiOperationValidator.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/validation/ApiOperationValidator.java
@@ -1,0 +1,22 @@
+package uk.co.compendiumdev.thingifier.api.validation;
+
+/**
+ * Validates one matched API operation after request parsing and route policy checks.
+ *
+ * <p>Use this for request-aware API rules that do not belong in entity model validation, such as
+ * "this route requires a principal-selected challenger" or "this public operation requires a field
+ * that the entity itself does not always require". Validators are code-only and run after
+ * authentication, data-scope selection, fixed-route resolution, content parsing, request view
+ * checks, write-method policy, and command/query mapping have all succeeded.
+ */
+@FunctionalInterface
+public interface ApiOperationValidator {
+
+    /**
+     * Validates the current API operation.
+     *
+     * @param context immutable request, route, auth, data-scope, and payload details
+     * @return accepted or rejected validation result
+     */
+    ApiOperationValidationResult validate(ApiOperationValidationContext context);
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/validation/ApiOperationValidatorDefinition.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/validation/ApiOperationValidatorDefinition.java
@@ -1,0 +1,50 @@
+package uk.co.compendiumdev.thingifier.api.validation;
+
+/**
+ * Named route-level operation validator registration.
+ *
+ * <p>The name is for diagnostics and future tooling. Validators themselves are code-only in v1 so
+ * they are deliberately not exported to YAML, model import/export, or OpenAPI.
+ */
+public final class ApiOperationValidatorDefinition {
+
+    private final String name;
+    private final ApiOperationValidator validator;
+
+    /**
+     * Creates a named validator registration.
+     *
+     * @param name stable validator name for readers and diagnostics
+     * @param validator callback to run for the route
+     * @throws IllegalArgumentException when the name is blank or the validator is null
+     */
+    public ApiOperationValidatorDefinition(
+            final String name, final ApiOperationValidator validator) {
+        if (name == null || name.trim().isEmpty()) {
+            throw new IllegalArgumentException("validator name is required");
+        }
+        if (validator == null) {
+            throw new IllegalArgumentException("validator is required");
+        }
+        this.name = name.trim();
+        this.validator = validator;
+    }
+
+    /**
+     * Returns the registration name.
+     *
+     * @return validator name
+     */
+    public String name() {
+        return name;
+    }
+
+    /**
+     * Returns the validator callback.
+     *
+     * @return operation validator
+     */
+    public ApiOperationValidator validator() {
+        return validator;
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/validation/ApiOperationValidators.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/validation/ApiOperationValidators.java
@@ -1,0 +1,71 @@
+package uk.co.compendiumdev.thingifier.api.validation;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Factory methods for common API operation validators.
+ *
+ * <p>These helpers cover route-level API rules which are more about a public operation contract
+ * than entity state. They are intentionally code-only so applications can compose them with custom
+ * validators without adding serialization requirements to the model.
+ */
+public final class ApiOperationValidators {
+
+    private ApiOperationValidators() {}
+
+    /**
+     * Starts a validator that rejects when parsed request body fields are absent.
+     *
+     * <p>This checks field presence only. Use entity field validation for type, mandatory, and
+     * non-empty value rules.
+     *
+     * @param fieldNames body field names that must be present
+     * @return builder used to choose the rejection response
+     * @throws IllegalArgumentException when no field names are supplied or any field name is blank
+     */
+    public static RequiredBodyFieldsValidatorBuilder requireBodyFields(final String... fieldNames) {
+        return new RequiredBodyFieldsValidatorBuilder(fieldNames);
+    }
+
+    /** Builder for {@link #requireBodyFields(String...)} rejection details. */
+    public static final class RequiredBodyFieldsValidatorBuilder {
+
+        private final List<String> fieldNames;
+
+        private RequiredBodyFieldsValidatorBuilder(final String... fieldNames) {
+            if (fieldNames == null || fieldNames.length == 0) {
+                throw new IllegalArgumentException("at least one field name is required");
+            }
+            List<String> names = new ArrayList<>();
+            for (String fieldName : fieldNames) {
+                if (fieldName == null || fieldName.trim().isEmpty()) {
+                    throw new IllegalArgumentException("field name is required");
+                }
+                names.add(fieldName.trim());
+            }
+            this.fieldNames = Collections.unmodifiableList(names);
+        }
+
+        /**
+         * Creates the validator with the rejection response to use when any field is missing.
+         *
+         * @param statusCode HTTP-style status code to return
+         * @param message error message to include in Thingifier's normal error response
+         * @return operation validator
+         */
+        public ApiOperationValidator onMissing(final int statusCode, final String message) {
+            ApiOperationValidationResult rejection =
+                    ApiOperationValidationResult.reject(statusCode, message);
+            return context -> {
+                for (String fieldName : fieldNames) {
+                    if (!context.requestBody().asMap().containsKey(fieldName)) {
+                        return rejection;
+                    }
+                }
+                return ApiOperationValidationResult.accept();
+            };
+        }
+    }
+}

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/validation/ApiOperationValidationTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/validation/ApiOperationValidationTest.java
@@ -1,0 +1,354 @@
+package uk.co.compendiumdev.thingifier.api.validation;
+
+import static uk.co.compendiumdev.thingifier.api.security.DataScopeCreationPolicy.ENSURE_EXISTS;
+import static uk.co.compendiumdev.thingifier.apiconfig.EntityWriteOperation.UPDATE;
+import static uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldType.AUTO_INCREMENT;
+import static uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldType.STRING;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
+import uk.co.compendiumdev.thingifier.api.http.HttpApiRequest;
+import uk.co.compendiumdev.thingifier.api.http.HttpApiResponse;
+import uk.co.compendiumdev.thingifier.api.http.ThingifierHttpApi;
+import uk.co.compendiumdev.thingifier.api.http.bodyparser.BodyParser;
+import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
+import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
+import uk.co.compendiumdev.thingifier.api.security.ThingifierApiAuthenticationResult;
+import uk.co.compendiumdev.thingifier.api.spec.FixedResourcePolicy;
+import uk.co.compendiumdev.thingifier.core.EntityRelModel;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.Field;
+import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
+import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstanceDraft;
+import uk.co.compendiumdev.thingifier.core.reporting.ValidationReport;
+import uk.co.compendiumdev.thingifier.core.repository.ThingStore;
+
+class ApiOperationValidationTest {
+
+    @Test
+    void routeRuleStoresNamedOperationValidatorsInRegistrationOrder() {
+        final Thingifier thingifier = todoModel();
+        final ApiOperationValidator accept = context -> ApiOperationValidationResult.accept();
+
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.POST, "/todos")
+                .withApiOperationValidator("first", accept)
+                .withApiOperationValidator("second", accept);
+
+        final List<ApiOperationValidatorDefinition> validators =
+                thingifier
+                        .apiSpec()
+                        .ruleFor(RoutingVerb.POST, "/todos", "")
+                        .orElseThrow()
+                        .apiOperationValidators();
+
+        Assertions.assertEquals("first", validators.get(0).name());
+        Assertions.assertEquals("second", validators.get(1).name());
+    }
+
+    @Test
+    void requiredBodyFieldsValidatorRejectsMissingRequestField() {
+        final Thingifier thingifier = todoModel();
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.POST, "/todos")
+                .withApiOperationValidator(
+                        "requiresApiToken",
+                        ApiOperationValidators.requireBodyFields("apiToken")
+                                .onMissing(422, "apiToken is required for this operation"));
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .post(jsonRequest("/todos", "{\"title\":\"walk\"}"));
+
+        Assertions.assertEquals(422, response.getStatusCode());
+        Assertions.assertTrue(response.getBody().contains("apiToken is required"));
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    @Test
+    void operationValidatorRejectionStopsEntityValidationAndMutation() {
+        final Thingifier thingifier = todoModel();
+        final AtomicInteger instanceValidatorCalls = new AtomicInteger();
+        thingifier
+                .getDefinitionNamed("todo")
+                .withInstanceValidation(
+                        context -> {
+                            instanceValidatorCalls.incrementAndGet();
+                            return new ValidationReport();
+                        });
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.POST, "/todos")
+                .withApiOperationValidator(
+                        "routeGate",
+                        context ->
+                                ApiOperationValidationResult.reject(
+                                        409, "operation rejected before model validation"));
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .post(jsonRequest("/todos", "{\"title\":\"walk\"}"));
+
+        Assertions.assertEquals(409, response.getStatusCode());
+        Assertions.assertEquals(0, instanceValidatorCalls.get());
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    @Test
+    void operationValidatorsRunInOrderAndStopAfterFirstRejection() {
+        final Thingifier thingifier = todoModel();
+        final List<String> calls = new ArrayList<>();
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.GET, "/todos")
+                .withApiOperationValidator(
+                        "first",
+                        context -> {
+                            calls.add("first");
+                            return ApiOperationValidationResult.accept();
+                        })
+                .withApiOperationValidator(
+                        "second",
+                        context -> {
+                            calls.add("second");
+                            return ApiOperationValidationResult.reject(403, "not for this route");
+                        })
+                .withApiOperationValidator(
+                        "third",
+                        context -> {
+                            calls.add("third");
+                            return ApiOperationValidationResult.accept();
+                        });
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier).get(new HttpApiRequest("/todos"));
+
+        Assertions.assertEquals(403, response.getStatusCode());
+        Assertions.assertEquals(List.of("first", "second"), calls);
+    }
+
+    @Test
+    void authenticationFailureSkipsOperationValidators() {
+        final Thingifier thingifier = todoModel();
+        final AtomicInteger validatorCalls = new AtomicInteger();
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "todoToken",
+                        context ->
+                                ThingifierApiAuthenticationResult.authenticated("todo-principal"));
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.POST, "/todos")
+                .secureWithBearerAuth("todoToken")
+                .withApiOperationValidator(
+                        "counter",
+                        context -> {
+                            validatorCalls.incrementAndGet();
+                            return ApiOperationValidationResult.accept();
+                        });
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .post(jsonRequest("/todos", "{\"title\":\"walk\"}"));
+
+        Assertions.assertEquals(401, response.getStatusCode());
+        Assertions.assertEquals(0, validatorCalls.get());
+    }
+
+    @Test
+    void invalidJsonSkipsOperationValidators() {
+        final Thingifier thingifier = todoModel();
+        final AtomicInteger validatorCalls = new AtomicInteger();
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.POST, "/todos")
+                .withApiOperationValidator(
+                        "counter",
+                        context -> {
+                            validatorCalls.incrementAndGet();
+                            return ApiOperationValidationResult.accept();
+                        });
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier).post(jsonRequest("/todos", "{\"title\""));
+
+        Assertions.assertEquals(400, response.getStatusCode());
+        Assertions.assertEquals(0, validatorCalls.get());
+    }
+
+    @Test
+    void methodNotAllowedSkipsOperationValidators() {
+        final Thingifier thingifier = todoModel();
+        final AtomicInteger validatorCalls = new AtomicInteger();
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.POST, "/todos")
+                .methodNotAllowed()
+                .withApiOperationValidator(
+                        "counter",
+                        context -> {
+                            validatorCalls.incrementAndGet();
+                            return ApiOperationValidationResult.accept();
+                        });
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .post(jsonRequest("/todos", "{\"title\":\"walk\"}"));
+
+        Assertions.assertEquals(405, response.getStatusCode());
+        Assertions.assertEquals(0, validatorCalls.get());
+    }
+
+    @Test
+    void directApiPostEnforcesOperationValidator() {
+        final Thingifier thingifier = todoModel();
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.POST, "/todos")
+                .withApiOperationValidator(
+                        "directGate",
+                        context ->
+                                ApiOperationValidationResult.reject(
+                                        451, "direct operation rejected"));
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"walk\"}"),
+                                new HttpHeadersBlock());
+
+        Assertions.assertEquals(451, response.getStatusCode());
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    @Test
+    void httpFixedRouteContextIncludesAuthSelectedScopeAndResolvedTarget() {
+        final Thingifier thingifier = secretNoteModel();
+        ensureDataScopeExists(thingifier, "tenant-one");
+        createSecretNote(thingifier, "tenant-one", "original");
+        final AtomicReference<ApiOperationValidationContext> seenContext = new AtomicReference<>();
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "secretToken",
+                        context ->
+                                ThingifierApiAuthenticationResult.authenticated("secret-principal")
+                                        .useDataScope("tenant-one", ENSURE_EXISTS));
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.POST, "/secret/note")
+                .mapsToEntity("secretnote")
+                .withFixedIdentifier("note", FixedResourcePolicy.RETURN_404)
+                .entityCan(UPDATE)
+                .entityView("PublicNote")
+                .secureWithBearerAuth("secretToken")
+                .withApiOperationValidator(
+                        "captureContext",
+                        context -> {
+                            seenContext.set(context);
+                            return ApiOperationValidationResult.accept();
+                        });
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .post(
+                                jsonRequest("/secret/note", "{\"body\":\"updated\"}")
+                                        .addHeader("Authorization", "Bearer valid-token"));
+
+        final ApiOperationValidationContext context = seenContext.get();
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertNotNull(context);
+        Assertions.assertEquals(RoutingVerb.POST, context.verb());
+        Assertions.assertEquals("secret/note", context.publicPath());
+        Assertions.assertEquals("secretnote", context.targetEntityName());
+        Assertions.assertEquals("note", context.targetIdentifier());
+        Assertions.assertEquals("UPDATE", context.operationType());
+        Assertions.assertEquals("secret-principal", context.authenticatedPrincipal());
+        Assertions.assertEquals("tenant-one", context.dataScopeName());
+        Assertions.assertSame(thingifier.getStore("tenant-one"), context.store());
+        Assertions.assertTrue(context.headers().get("Authorization").startsWith("Bearer "));
+        Assertions.assertEquals("updated", context.requestBody().asStringMap().get("body"));
+        Assertions.assertTrue(context.rawBody().contains("updated"));
+        Assertions.assertEquals("PublicNote", context.requestEntityView());
+        Assertions.assertEquals("PublicNote", context.responseEntityView());
+        Assertions.assertEquals("updated", secretNoteBody(thingifier, "tenant-one"));
+    }
+
+    private Thingifier todoModel() {
+        final Thingifier thingifier = new Thingifier();
+        final EntityDefinition todo = thingifier.defineThing("todo", "todos", 5);
+        todo.addAsPrimaryKeyField(Field.is("id", AUTO_INCREMENT));
+        todo.addField(Field.is("title", STRING).makeMandatory());
+        return thingifier;
+    }
+
+    private Thingifier secretNoteModel() {
+        final Thingifier thingifier = new Thingifier();
+        final EntityDefinition note = thingifier.defineThing("secretnote", "secretnotes", 1);
+        note.addAsPrimaryKeyField(Field.is("id", STRING));
+        note.addField(Field.is("body", STRING));
+        note.addField(Field.is("internal", STRING));
+        note.defineView("PublicNote").hideResponseFields("internal");
+        return thingifier;
+    }
+
+    private void ensureDataScopeExists(final Thingifier thingifier, final String dataScopeName) {
+        thingifier.getERmodel().createInstanceDatabaseIfNotExisting(dataScopeName);
+    }
+
+    private void createSecretNote(
+            final Thingifier thingifier, final String dataScopeName, final String body) {
+        storeFor(thingifier, dataScopeName)
+                .entities()
+                .create(
+                        EntityInstanceDraft.forEntity(thingifier.getDefinitionNamed("secretnote"))
+                                .withField("id", "note")
+                                .withField("body", body)
+                                .withField("internal", "hidden"));
+    }
+
+    private String secretNoteBody(final Thingifier thingifier, final String dataScopeName) {
+        final EntityInstance note =
+                storeFor(thingifier, dataScopeName)
+                        .entityQueries()
+                        .findByQueryIdentifier(thingifier.getDefinitionNamed("secretnote"), "note");
+        return note.getFieldValue("body").asString();
+    }
+
+    private int todoCount(final Thingifier thingifier) {
+        return storeFor(thingifier, EntityRelModel.DEFAULT_DATABASE_NAME)
+                .entityQueries()
+                .count(thingifier.getDefinitionNamed("todo"));
+    }
+
+    private ThingStore storeFor(final Thingifier thingifier, final String dataScopeName) {
+        return thingifier.getStore(dataScopeName);
+    }
+
+    private HttpApiRequest jsonRequest(final String path, final String body) {
+        return new HttpApiRequest(path)
+                .setVerb("POST")
+                .addHeader("Content-Type", "application/json")
+                .addHeader("Accept", "application/json")
+                .setBody(body);
+    }
+
+    private BodyParser parser(final Thingifier thingifier, final String body) {
+        return new BodyParser(
+                new HttpApiRequest("/request")
+                        .addHeader("Content-Type", "application/json")
+                        .setBody(body),
+                thingifier.getThingNames());
+    }
+}


### PR DESCRIPTION
## Summary
- Add route-level request-aware API operation validators.
- Expose operation context including route, target entity/id, operation type, request data, auth principals, and active data scope/store.
- Run validators after routing/auth/request mapping and before lifecycle validation hooks, model validation, and mutation.
- Add focused tests for ordering, short-circuiting, skip conditions, direct API behavior, and auth-selected fixed-route context.

## Verification
- `mvn clean verify`
- `mvn clean install`
- commit hook full Maven verification

Closes #154