### PR TITLE
Add route-level API response policies

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/ApiOperationValidationPolicy.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/ApiOperationValidationPolicy.java
@@ -85,7 +85,7 @@ public final class ApiOperationValidationPolicy {
             ApiOperationValidationResult result =
                     definition.validator().validate(validationContext);
             if (result != null && result.rejected()) {
-                return ApiResponse.error(result.statusCode(), result.message());
+                return ApiResponse.validationError(result.statusCode(), result.message());
             }
         }
         return null;

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/RouteApiResponsePolicyApplier.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/RouteApiResponsePolicyApplier.java
@@ -1,0 +1,169 @@
+package uk.co.compendiumdev.thingifier.adapter.http.apihandlers;
+
+import java.util.Optional;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
+import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
+import uk.co.compendiumdev.thingifier.api.response.RouteApiResponsePolicy;
+import uk.co.compendiumdev.thingifier.api.spec.ThingifierApiRouteRule;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.instance.FieldValue;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.instance.NamedValue;
+import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
+import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstanceDraft;
+
+/**
+ * Applies route-level response policies to generated API responses.
+ *
+ * <p>The applier sits after Thingifier has created a structured {@link ApiResponse}. That keeps
+ * route policies focused on public response shape while generated command/query handling,
+ * validation, persistence, and hooks continue to produce the canonical result first.
+ */
+public final class RouteApiResponsePolicyApplier {
+
+    private final ThingifierApiRuntime runtime;
+
+    /**
+     * Creates an applier using the current API runtime.
+     *
+     * @param runtime runtime used to find route rules and entity definitions
+     */
+    public RouteApiResponsePolicyApplier(final ThingifierApiRuntime runtime) {
+        this.runtime = runtime;
+    }
+
+    /**
+     * Applies the matching route response policy, if one exists.
+     *
+     * <p>Status and headers are applied before the supplied response-view callback so route
+     * status-specific views can see any status override. Body actions are applied last so a policy
+     * can suppress or replace the rendered body after normal view selection.
+     *
+     * @param verb routing verb for route-rule lookup
+     * @param publicPath public request path
+     * @param response generated response
+     * @param responseViewApplicator normal route/entity response-view applicator
+     * @return the same response after policy actions have been applied
+     */
+    public ApiResponse apply(
+            final RoutingVerb verb,
+            final String publicPath,
+            final ApiResponse response,
+            final ResponseViewApplicator responseViewApplicator) {
+        if (response == null) {
+            return null;
+        }
+
+        final Optional<RouteApiResponsePolicy> selectedPolicy =
+                routeRuleFor(verb, publicPath).flatMap(rule -> policyFor(rule, response));
+
+        selectedPolicy.ifPresent(policy -> applyStatusAndHeaders(policy, response));
+        if (responseViewApplicator != null) {
+            responseViewApplicator.apply(response);
+        }
+        selectedPolicy.ifPresent(policy -> applyBodyPolicy(policy, response));
+
+        return response;
+    }
+
+    private Optional<ThingifierApiRouteRule> routeRuleFor(
+            final RoutingVerb verb, final String publicPath) {
+        return runtime.apiSpec()
+                .ruleFor(verb, publicPath, runtime.apiConfig().getApiEndPointPrefix());
+    }
+
+    private Optional<RouteApiResponsePolicy> policyFor(
+            final ThingifierApiRouteRule rule, final ApiResponse response) {
+        if (response.isValidationErrorResponse()) {
+            return rule.validationErrorResponsePolicy();
+        }
+        if (response.isErrorResponse()) {
+            return rule.errorResponsePolicyFor(response.getStatusCode());
+        }
+        return rule.successResponsePolicy();
+    }
+
+    private void applyStatusAndHeaders(
+            final RouteApiResponsePolicy policy, final ApiResponse response) {
+        if (policy.statusCode() != null) {
+            response.withStatusCode(policy.statusCode());
+        }
+
+        for (RouteApiResponsePolicy.HeaderValue header : policy.staticHeaders()) {
+            response.setHeader(header.name(), header.value());
+        }
+
+        for (RouteApiResponsePolicy.InstanceFieldHeader header : policy.instanceFieldHeaders()) {
+            returnedFieldValue(response, header.fieldName())
+                    .ifPresent(value -> response.setHeader(header.headerName(), value));
+        }
+    }
+
+    private Optional<String> returnedFieldValue(
+            final ApiResponse response, final String fieldName) {
+        if (response.hasReturnedInstance()) {
+            final EntityInstance instance = response.getReturnedInstance();
+            if (instance.hasInstantiatedFieldNamed(fieldName)) {
+                final FieldValue value = instance.getFieldValue(fieldName);
+                return value == null ? Optional.empty() : Optional.ofNullable(value.asString());
+            }
+        }
+
+        if (response.hasReturnedDraft()) {
+            final EntityInstanceDraft draft = response.getReturnedDraft();
+            return draftFieldValue(draft, fieldName);
+        }
+
+        return Optional.empty();
+    }
+
+    private Optional<String> draftFieldValue(
+            final EntityInstanceDraft draft, final String fieldName) {
+        for (NamedValue value : draft.getFieldValues()) {
+            if (value.getName().equals(fieldName)) {
+                return Optional.ofNullable(value.asString());
+            }
+        }
+        for (NamedValue value : draft.getProtectedFieldValues()) {
+            if (value.getName().equals(fieldName)) {
+                return Optional.ofNullable(value.asString());
+            }
+        }
+        return Optional.empty();
+    }
+
+    private void applyBodyPolicy(final RouteApiResponsePolicy policy, final ApiResponse response) {
+        switch (policy.bodyAction()) {
+            case SUPPRESS:
+                response.clearBody();
+                break;
+            case TEXT:
+                response.setBody(policy.bodyText());
+                break;
+            case ENTITY_VIEW:
+                applyEntityView(response, policy.entityViewName());
+                break;
+            case PRESERVE:
+            default:
+                break;
+        }
+    }
+
+    private void applyEntityView(final ApiResponse response, final String viewName) {
+        final EntityDefinition entity = response.getTypeOfThingReturned();
+        if (entity == null || viewName == null || !entity.hasViewNamed(viewName)) {
+            return;
+        }
+        response.usingEntityView(entity.getViewNamed(viewName));
+    }
+
+    /** Applies normal route/entity response view policy before final body actions. */
+    @FunctionalInterface
+    public interface ResponseViewApplicator {
+        /**
+         * Applies response view configuration to the generated response.
+         *
+         * @param response response to update
+         */
+        void apply(ApiResponse response);
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/ThingCommandResultApiMapper.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/ThingCommandResultApiMapper.java
@@ -102,6 +102,11 @@ public final class ThingCommandResultApiMapper {
             response = ApiResponse.error(statusCode, messages);
         }
 
+        if (result.getError() != null
+                && result.getError().category() == ApplicationError.Category.VALIDATION) {
+            response = ApiResponse.validationError(statusCode, response.getErrorMessages());
+        }
+
         if (result.rolledBackCreatedInstance()) {
             response.addToErrorMessages(CREATED_ITEM_ROLLED_BACK_MESSAGE);
         }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/ThingifierRestAPIHandler.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/ThingifierRestAPIHandler.java
@@ -4,6 +4,7 @@ import java.util.function.Supplier;
 import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.DefaultThingifierApiRuntime;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.FixedRouteResourcePreparer;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.RouteApiResponsePolicyApplier;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.RouteAuthPolicy;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierApiRuntime;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
@@ -605,8 +606,12 @@ public class ThingifierRestAPIHandler {
             final ApiResponse response,
             final ThingifierRequestContext context) {
         final ApiResponse responseWithRepository = withRepository(response, context);
-        applyResponseEntityView(verb, url, responseWithRepository);
-        return responseWithRepository;
+        return new RouteApiResponsePolicyApplier(runtime)
+                .apply(
+                        verb,
+                        url,
+                        responseWithRepository,
+                        apiResponse -> applyResponseEntityView(verb, url, apiResponse));
     }
 
     /**

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/ThingifierHttpApi.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.adapter.hooks.ScopedHook;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.DefaultThingifierApiRuntime;
+import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.RouteApiResponsePolicyApplier;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.RouteAuthPolicy;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.ThingifierApiRuntime;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.CollectionRoute;
@@ -229,7 +230,7 @@ public final class ThingifierHttpApi {
         }
 
         if (httpResponse == null && isDisabledByApiSpec(request, effectiveVerb)) {
-            httpResponse = disabledRouteResponse(request);
+            httpResponse = disabledRouteResponse(request, effectiveVerb);
         }
 
         if (httpResponse == null && lifecycle != null) {
@@ -335,22 +336,31 @@ public final class ThingifierHttpApi {
             final HttpApiRequest request,
             final HttpVerb effectiveVerb,
             final ApiResponse apiResponse) {
+        final ApiResponse policyResponse =
+                new RouteApiResponsePolicyApplier(new DefaultThingifierApiRuntime(thingifier))
+                        .apply(
+                                routingVerbFor(effectiveVerb),
+                                request.getPath(),
+                                apiResponse,
+                                response ->
+                                        applyResponseEntityView(request, effectiveVerb, response));
+
         HttpApiResponse httpResponse =
                 new HttpApiResponse(
                         request.getHeaders(),
-                        apiResponse,
+                        policyResponse,
                         jsonThing,
                         thingifier.apiConfig(),
                         xmlEntityNamesFor(request.getPath(), effectiveVerb));
 
         if (effectiveVerb == HttpVerb.HEAD) {
             final int bodyLength = httpResponse.getBody().getBytes(StandardCharsets.UTF_8).length;
-            apiResponse.clearBody();
-            apiResponse.setHeader("Content-Length", Integer.toString(bodyLength));
+            policyResponse.clearBody();
+            policyResponse.setHeader("Content-Length", Integer.toString(bodyLength));
             httpResponse =
                     new HttpApiResponse(
                             request.getHeaders(),
-                            apiResponse,
+                            policyResponse,
                             jsonThing,
                             thingifier.apiConfig(),
                             xmlEntityNamesFor(request.getPath(), effectiveVerb));
@@ -394,15 +404,15 @@ public final class ThingifierHttpApi {
      * Creates the legacy not-found style response used for disabled generated routes.
      *
      * @param request HTTP API request
+     * @param verb effective HTTP API verb
      * @return HTTP API response representing the disabled route
      */
-    private HttpApiResponse disabledRouteResponse(final HttpApiRequest request) {
-        return new HttpApiResponse(
-                request.getHeaders(),
-                ApiResponse.error404("Could not find any instances with " + request.getPath()),
-                jsonThing,
-                thingifier.apiConfig(),
-                xmlEntityNamesFor(request.getPath(), HttpVerb.GET));
+    private HttpApiResponse disabledRouteResponse(
+            final HttpApiRequest request, final HttpVerb verb) {
+        return httpResponseFor(
+                request,
+                verb,
+                ApiResponse.error404("Could not find any instances with " + request.getPath()));
     }
 
     /**
@@ -423,13 +433,7 @@ public final class ThingifierHttpApi {
 
         if (!requestValidator.validateSyntax(request, verb)) {
 
-            httpResponse =
-                    new HttpApiResponse(
-                            request.getHeaders(),
-                            requestValidator.getErrorApiResponse(),
-                            jsonThing,
-                            thingifier.apiConfig(),
-                            xmlEntityNamesFor(request.getPath(), verb));
+            httpResponse = httpResponseFor(request, verb, requestValidator.getErrorApiResponse());
         }
 
         return httpResponse;
@@ -565,16 +569,14 @@ public final class ThingifierHttpApi {
 
         final String viewName = configuredViewName.get();
         if (!entity.hasViewNamed(viewName)) {
-            return new HttpApiResponse(
-                    request.getHeaders(),
+            return httpResponseFor(
+                    request,
+                    verb,
                     ApiResponse.error(
                             500,
                             String.format(
                                     "Entity view %s is not defined for %s",
-                                    viewName, entity.getName())),
-                    jsonThing,
-                    thingifier.apiConfig(),
-                    xmlEntityNamesFor(request.getPath(), verb));
+                                    viewName, entity.getName())));
         }
 
         final EntityViewDefinition view = entity.getViewNamed(viewName);
@@ -589,16 +591,14 @@ public final class ThingifierHttpApi {
             return null;
         }
 
-        return new HttpApiResponse(
-                request.getHeaders(),
-                ApiResponse.error(
+        return httpResponseFor(
+                request,
+                verb,
+                ApiResponse.validationError(
                         422,
                         String.format(
                                 "Fields are not allowed by %s: %s",
-                                viewName, String.join(", ", disallowedFields))),
-                jsonThing,
-                thingifier.apiConfig(),
-                xmlEntityNamesFor(request.getPath(), verb));
+                                viewName, String.join(", ", disallowedFields))));
     }
 
     /**
@@ -1095,13 +1095,7 @@ public final class ThingifierHttpApi {
                     thingifier
                             .api()
                             .get(query, request.getFilterableQueryParams(), request.getHeaders());
-            httpResponse =
-                    new HttpApiResponse(
-                            request.getHeaders(),
-                            apiResponse,
-                            jsonThing,
-                            thingifier.apiConfig(),
-                            xmlEntityNamesFor(request.getPath(), HttpVerb.GET));
+            httpResponse = httpResponseFor(request, HttpVerb.GET, apiResponse);
         }
 
         return runTheHttpApiResponseHooksOn(request, httpResponse, HttpVerb.GET);

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponse.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/ApiResponse.java
@@ -22,7 +22,7 @@ public final class ApiResponse {
     // TODO: instance GUID or instance-id should actually be the primary key
     public static final String PRIMARY_KEY_HEADER = "X-Thing-Instance-Primary-Key";
 
-    private final int statusCode;
+    private int statusCode;
     private boolean hasBody;
     // instead of storing a json as the body, store the things to return
     // let getBody do the conversion to json or xml
@@ -32,6 +32,7 @@ public final class ApiResponse {
     private boolean isCollection;
     // isErrorResponse true, return the stored collection of error messages
     private boolean isErrorResponse;
+    private boolean isValidationErrorResponse;
     private Collection<String> errorMessages;
 
     private HttpHeadersBlock headers;
@@ -53,6 +54,7 @@ public final class ApiResponse {
         draftToReturn = null;
         isCollection = false;
         isErrorResponse = false;
+        isValidationErrorResponse = false;
         errorMessages = new ArrayList<>();
         hasBody = false;
         body = null;
@@ -87,6 +89,20 @@ public final class ApiResponse {
      */
     public int getStatusCode() {
         return this.statusCode;
+    }
+
+    /**
+     * Replaces the HTTP-style status code while preserving the structured response body.
+     *
+     * <p>Route-level response policies use this when the same generated Thingifier operation should
+     * keep its returned entity/error payload but expose a route-specific status code.
+     *
+     * @param newStatusCode status code to expose through adapters
+     * @return this response so additional response policy actions can be chained
+     */
+    public ApiResponse withStatusCode(final int newStatusCode) {
+        this.statusCode = newStatusCode;
+        return this;
     }
 
     /**
@@ -277,12 +293,54 @@ public final class ApiResponse {
     }
 
     /**
+     * Creates a validation-style error response with one message.
+     *
+     * <p>The validation marker lets route response policies distinguish model/API validation
+     * failures from other errors that happen to share a status code.
+     *
+     * @param statusCode HTTP-style error status code
+     * @param errorMessage validation message to render in the error body
+     * @return validation error response
+     */
+    public static ApiResponse validationError(final int statusCode, final String errorMessage) {
+        Collection<String> localErrorMessages = new ArrayList<>();
+        localErrorMessages.add(errorMessage);
+        return validationError(statusCode, localErrorMessages);
+    }
+
+    /**
+     * Creates a validation-style error response with multiple messages.
+     *
+     * @param statusCode HTTP-style error status code
+     * @param errorMessages validation messages to render in the error body
+     * @return validation error response
+     */
+    public static ApiResponse validationError(
+            final int statusCode, final Collection<String> errorMessages) {
+        ApiResponse response = error(statusCode, errorMessages);
+        response.isValidationErrorResponse = true;
+        return response;
+    }
+
+    /**
      * Reports whether this response body should be rendered as errors.
      *
      * @return true when this is an error response
      */
     public boolean isErrorResponse() {
         return isErrorResponse;
+    }
+
+    /**
+     * Reports whether this error represents validation of the request or candidate operation.
+     *
+     * <p>This deliberately narrows route-level {@code onValidationError()} policies to responses
+     * produced by Thingifier validation rather than every response using status 422.
+     *
+     * @return true when this response was marked as a validation error
+     */
+    public boolean isValidationErrorResponse() {
+        return isValidationErrorResponse;
     }
 
     /**
@@ -310,6 +368,15 @@ public final class ApiResponse {
         }
 
         return thingsToReturn.get(0);
+    }
+
+    /**
+     * Reports whether the response contains exactly one persisted instance.
+     *
+     * @return true when {@link #getReturnedInstance()} can be called safely
+     */
+    public boolean hasReturnedInstance() {
+        return !isCollection && draftToReturn == null && thingsToReturn.size() == 1;
     }
 
     /**

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/RouteApiResponsePolicy.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/response/RouteApiResponsePolicy.java
@@ -1,0 +1,249 @@
+package uk.co.compendiumdev.thingifier.api.response;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Declarative response shaping for one route outcome.
+ *
+ * <p>A route response policy belongs to the API contract rather than the entity model. It lets a
+ * route keep Thingifier's generated operation handling while changing the outward HTTP-style
+ * response shape for compatibility or documented route semantics. Policies run after the generated
+ * operation has produced an {@link ApiResponse} and before that response is rendered.
+ */
+public final class RouteApiResponsePolicy {
+
+    /** Describes how the policy should handle the response body. */
+    public enum BodyAction {
+        /** Leave the generated Thingifier response body unchanged. */
+        PRESERVE,
+        /** Remove the response body while preserving status and headers. */
+        SUPPRESS,
+        /** Replace the response body with explicit text. */
+        TEXT,
+        /** Render the existing returned entity data through a named entity view. */
+        ENTITY_VIEW
+    }
+
+    private Integer statusCode;
+    private final List<HeaderValue> staticHeaders;
+    private final List<InstanceFieldHeader> instanceFieldHeaders;
+    private BodyAction bodyAction;
+    private String bodyText;
+    private String entityViewName;
+
+    /** Creates an empty policy that preserves Thingifier's generated response. */
+    public RouteApiResponsePolicy() {
+        statusCode = null;
+        staticHeaders = new ArrayList<>();
+        instanceFieldHeaders = new ArrayList<>();
+        bodyAction = BodyAction.PRESERVE;
+        bodyText = null;
+        entityViewName = null;
+    }
+
+    /**
+     * Overrides the response status code for this route outcome.
+     *
+     * @param statusCode HTTP-style status code to expose
+     * @return this policy so response actions can be chained
+     */
+    public RouteApiResponsePolicy status(final int statusCode) {
+        this.statusCode = statusCode;
+        return this;
+    }
+
+    /**
+     * Adds or replaces a static response header.
+     *
+     * @param name header name
+     * @param value header value, with null treated as an empty value
+     * @return this policy so response actions can be chained
+     * @throws IllegalArgumentException when the header name is blank
+     */
+    public RouteApiResponsePolicy header(final String name, final String value) {
+        staticHeaders.add(new HeaderValue(requireText(name, "header name"), value));
+        return this;
+    }
+
+    /**
+     * Adds a header whose value is read from the single returned instance or draft.
+     *
+     * <p>The action is deliberately narrow: it does not attempt collection behavior and it does
+     * nothing when the named field is not present on the returned instance/draft.
+     *
+     * @param headerName response header name
+     * @param fieldName returned instance/draft field name
+     * @return this policy so response actions can be chained
+     * @throws IllegalArgumentException when either name is blank
+     */
+    public RouteApiResponsePolicy addInstanceFieldAsHeader(
+            final String headerName, final String fieldName) {
+        instanceFieldHeaders.add(
+                new InstanceFieldHeader(
+                        requireText(headerName, "header name"),
+                        requireText(fieldName, "field name")));
+        return this;
+    }
+
+    /**
+     * Suppresses the rendered response body while preserving status and headers.
+     *
+     * @return this policy so response actions can be chained
+     */
+    public RouteApiResponsePolicy suppressBody() {
+        bodyAction = BodyAction.SUPPRESS;
+        bodyText = null;
+        entityViewName = null;
+        return this;
+    }
+
+    /**
+     * Replaces the rendered response body with plain text.
+     *
+     * @param body body text, with null treated as an empty body
+     * @return this policy so response actions can be chained
+     */
+    public RouteApiResponsePolicy bodyText(final String body) {
+        bodyAction = BodyAction.TEXT;
+        bodyText = body == null ? "" : body;
+        entityViewName = null;
+        return this;
+    }
+
+    /**
+     * Renders the existing returned entity data through the named response view.
+     *
+     * <p>This changes only response rendering. It does not mutate any stored entity fields.
+     *
+     * @param viewName entity view name used for rendering
+     * @return this policy so response actions can be chained
+     * @throws IllegalArgumentException when the view name is blank
+     */
+    public RouteApiResponsePolicy bodyUsingEntityView(final String viewName) {
+        bodyAction = BodyAction.ENTITY_VIEW;
+        bodyText = null;
+        entityViewName = requireText(viewName, "entity view name");
+        return this;
+    }
+
+    /**
+     * Returns the configured status override.
+     *
+     * @return status override, or null when the generated status should be preserved
+     */
+    public Integer statusCode() {
+        return statusCode;
+    }
+
+    /**
+     * Returns static response headers in declaration order.
+     *
+     * @return immutable static header actions
+     */
+    public List<HeaderValue> staticHeaders() {
+        return Collections.unmodifiableList(staticHeaders);
+    }
+
+    /**
+     * Returns instance-field header actions in declaration order.
+     *
+     * @return immutable instance-field header actions
+     */
+    public List<InstanceFieldHeader> instanceFieldHeaders() {
+        return Collections.unmodifiableList(instanceFieldHeaders);
+    }
+
+    /**
+     * Returns the configured body action.
+     *
+     * @return body action, defaulting to preserve
+     */
+    public BodyAction bodyAction() {
+        return bodyAction;
+    }
+
+    /**
+     * Returns the configured plain text body.
+     *
+     * @return body text, or null when not configured
+     */
+    public String bodyText() {
+        return bodyText;
+    }
+
+    /**
+     * Returns the configured entity view name.
+     *
+     * @return entity view name, or null when not configured
+     */
+    public String entityViewName() {
+        return entityViewName;
+    }
+
+    private String requireText(final String value, final String label) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(label + " is required");
+        }
+        return value.trim();
+    }
+
+    /** Static response header action. */
+    public static final class HeaderValue {
+        private final String name;
+        private final String value;
+
+        private HeaderValue(final String name, final String value) {
+            this.name = name;
+            this.value = value == null ? "" : value;
+        }
+
+        /**
+         * Returns the response header name.
+         *
+         * @return header name
+         */
+        public String name() {
+            return name;
+        }
+
+        /**
+         * Returns the response header value.
+         *
+         * @return header value
+         */
+        public String value() {
+            return value;
+        }
+    }
+
+    /** Header action that reads its value from a returned instance or draft field. */
+    public static final class InstanceFieldHeader {
+        private final String headerName;
+        private final String fieldName;
+
+        private InstanceFieldHeader(final String headerName, final String fieldName) {
+            this.headerName = headerName;
+            this.fieldName = fieldName;
+        }
+
+        /**
+         * Returns the response header name.
+         *
+         * @return header name
+         */
+        public String headerName() {
+            return headerName;
+        }
+
+        /**
+         * Returns the returned instance/draft field name.
+         *
+         * @return field name
+         */
+        public String fieldName() {
+            return fieldName;
+        }
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiRouteRule.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiRouteRule.java
@@ -5,10 +5,12 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingDefinition;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingStatus;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
+import uk.co.compendiumdev.thingifier.api.response.RouteApiResponsePolicy;
 import uk.co.compendiumdev.thingifier.api.security.SecuritySchemeNames;
 import uk.co.compendiumdev.thingifier.api.security.ThingifierApiAuthorizer;
 import uk.co.compendiumdev.thingifier.api.validation.ApiOperationValidator;
@@ -39,6 +41,9 @@ public final class ThingifierApiRouteRule {
     private String enforcedBearerAuthSchemeName;
     private final List<ThingifierApiAuthorizer> authorizers;
     private final List<ApiOperationValidatorDefinition> apiOperationValidators;
+    private RouteApiResponsePolicy successResponsePolicy;
+    private final Map<Integer, RouteApiResponsePolicy> errorResponsePolicies;
+    private RouteApiResponsePolicy validationErrorResponsePolicy;
     private String documentation;
     private String requestPayload;
     private String requestEntityView;
@@ -65,6 +70,9 @@ public final class ThingifierApiRouteRule {
         this.enforcedBearerAuthSchemeName = null;
         this.authorizers = new java.util.ArrayList<>();
         this.apiOperationValidators = new java.util.ArrayList<>();
+        this.successResponsePolicy = null;
+        this.errorResponsePolicies = new HashMap<>();
+        this.validationErrorResponsePolicy = null;
         this.documentation = null;
         this.requestPayload = null;
         this.requestEntityView = null;
@@ -560,6 +568,85 @@ public final class ThingifierApiRouteRule {
     }
 
     /**
+     * Configures response shaping for non-error responses returned by this route.
+     *
+     * <p>Route response policies let endpoint contracts adjust status codes, headers, bodies, and
+     * response views without replacing the generated Thingifier operation. The policy is route
+     * scoped, so other routes mapping to the same entity are not affected.
+     *
+     * @return mutable route response policy for successful outcomes
+     */
+    public RouteApiResponsePolicy onSuccess() {
+        if (successResponsePolicy == null) {
+            successResponsePolicy = new RouteApiResponsePolicy();
+        }
+        return successResponsePolicy;
+    }
+
+    /**
+     * Configures response shaping for generated error responses with one status code.
+     *
+     * @param statusCode error status code to match
+     * @return mutable route response policy for the status-specific error outcome
+     */
+    public RouteApiResponsePolicy onError(final int statusCode) {
+        return errorResponsePolicies.computeIfAbsent(
+                statusCode, ignored -> new RouteApiResponsePolicy());
+    }
+
+    /**
+     * Configures response shaping for Thingifier validation-style failures on this route.
+     *
+     * <p>This policy is checked before status-specific error policies so validation errors can have
+     * one route-specific shape regardless of the final status code exposed by the policy.
+     *
+     * @return mutable route response policy for validation errors
+     */
+    public RouteApiResponsePolicy onValidationError() {
+        if (validationErrorResponsePolicy == null) {
+            validationErrorResponsePolicy = new RouteApiResponsePolicy();
+        }
+        return validationErrorResponsePolicy;
+    }
+
+    /**
+     * Returns the success response policy when configured.
+     *
+     * @return success policy
+     */
+    public Optional<RouteApiResponsePolicy> successResponsePolicy() {
+        return Optional.ofNullable(successResponsePolicy);
+    }
+
+    /**
+     * Returns the validation error response policy when configured.
+     *
+     * @return validation error policy
+     */
+    public Optional<RouteApiResponsePolicy> validationErrorResponsePolicy() {
+        return Optional.ofNullable(validationErrorResponsePolicy);
+    }
+
+    /**
+     * Returns the error response policy for a status code.
+     *
+     * @param statusCode generated error status code
+     * @return status-specific error policy
+     */
+    public Optional<RouteApiResponsePolicy> errorResponsePolicyFor(final int statusCode) {
+        return Optional.ofNullable(errorResponsePolicies.get(statusCode));
+    }
+
+    /**
+     * Returns all status-specific error response policies.
+     *
+     * @return immutable map of error status to policy
+     */
+    public Map<Integer, RouteApiResponsePolicy> errorResponsePolicies() {
+        return Collections.unmodifiableMap(errorResponsePolicies);
+    }
+
+    /**
      * Uses the same entity view for request validation and successful responses on this route.
      *
      * <p>This route-level view overrides entity defaults and is kept for concise route contracts.
@@ -763,6 +850,36 @@ public final class ThingifierApiRouteRule {
         }
         if (hasFixedIdentifierMapping()) {
             route.mapToFixedEntity(mappedEntityName, fixedIdentifier, fixedResourcePolicy);
+        }
+        applyResponsePolicyMetadataTo(route);
+    }
+
+    private void applyResponsePolicyMetadataTo(final RoutingDefinition route) {
+        successResponsePolicy().ifPresent(policy -> applyPolicyMetadata(route, policy));
+        validationErrorResponsePolicy()
+                .ifPresent(
+                        policy -> {
+                            route.addPossibleStatus(RoutingStatus.returnValue(422));
+                            applyPolicyMetadata(route, policy);
+                        });
+        for (Map.Entry<Integer, RouteApiResponsePolicy> entry : errorResponsePolicies.entrySet()) {
+            route.addPossibleStatus(RoutingStatus.returnValue(entry.getKey()));
+            applyPolicyMetadata(route, entry.getValue());
+        }
+    }
+
+    private void applyPolicyMetadata(
+            final RoutingDefinition route, final RouteApiResponsePolicy policy) {
+        if (policy.statusCode() != null) {
+            route.addPossibleStatus(RoutingStatus.returnValue(policy.statusCode()));
+        }
+        for (RouteApiResponsePolicy.HeaderValue header : policy.staticHeaders()) {
+            route.addResponseHeader(header.name(), header.value());
+        }
+        for (RouteApiResponsePolicy.InstanceFieldHeader header : policy.instanceFieldHeaders()) {
+            route.addResponseHeader(
+                    header.headerName(),
+                    "Value from returned instance field " + header.fieldName());
         }
     }
 

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/response/RouteApiResponsePolicyTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/response/RouteApiResponsePolicyTest.java
@@ -1,0 +1,290 @@
+package uk.co.compendiumdev.thingifier.api.response;
+
+import static uk.co.compendiumdev.thingifier.apiconfig.EntityWriteOperation.UPDATE;
+import static uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldType.AUTO_INCREMENT;
+import static uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.FieldType.STRING;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import uk.co.compendiumdev.thingifier.Thingifier;
+import uk.co.compendiumdev.thingifier.api.docgen.ApiRoutingDefinition;
+import uk.co.compendiumdev.thingifier.api.docgen.ApiRoutingDefinitionDocGenerator;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingDefinition;
+import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
+import uk.co.compendiumdev.thingifier.api.http.HttpApiRequest;
+import uk.co.compendiumdev.thingifier.api.http.HttpApiResponse;
+import uk.co.compendiumdev.thingifier.api.http.ThingifierHttpApi;
+import uk.co.compendiumdev.thingifier.api.http.headers.HttpHeadersBlock;
+import uk.co.compendiumdev.thingifier.api.spec.ThingifierApiRouteRule;
+import uk.co.compendiumdev.thingifier.core.EntityRelModel;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
+import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.Field;
+import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstance;
+import uk.co.compendiumdev.thingifier.core.domain.instances.EntityInstanceDraft;
+import uk.co.compendiumdev.thingifier.core.query.QueryFilterParams;
+
+class RouteApiResponsePolicyTest {
+
+    @Test
+    void successPolicyCanOverrideStatusAndSuppressBodyForFixedUpdateRoute() {
+        final Thingifier thingifier = secretModel();
+        postSecretTokenRoute(thingifier).onSuccess().status(201).suppressBody();
+        createSecretToken(thingifier, "token", "issued-value");
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .post(jsonPost("/secret/token", "{\"value\":\"new-value\"}"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals("", response.getBody());
+        Assertions.assertEquals(
+                "new-value", secretToken(thingifier, "token").getFieldValue("value").asString());
+    }
+
+    @Test
+    void successPolicyCanAddHeaderFromReturnedInstanceField() {
+        final Thingifier thingifier = secretModel();
+        getSecretTokenRoute(thingifier)
+                .onSuccess()
+                .addInstanceFieldAsHeader("X-Secret-Token", "value");
+        createSecretToken(thingifier, "token", "issued-value");
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier).get(jsonRequest("/secret/token"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals("issued-value", response.getHeaders().get("X-Secret-Token"));
+    }
+
+    @Test
+    void instanceFieldHeaderIsSkippedWhenReturnedInstanceDoesNotHaveTheField() {
+        final Thingifier thingifier = secretModel();
+        getSecretTokenRoute(thingifier)
+                .onSuccess()
+                .addInstanceFieldAsHeader("X-Missing", "missing");
+        createSecretToken(thingifier, "token", "issued-value");
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier).get(jsonRequest("/secret/token"));
+
+        Assertions.assertFalse(response.getHeaders().headerExists("X-Missing"));
+    }
+
+    @Test
+    void routePolicyDoesNotAffectAnotherRouteReturningTheSameInstance() {
+        final Thingifier thingifier = secretModel();
+        getSecretTokenRoute(thingifier)
+                .onSuccess()
+                .addInstanceFieldAsHeader("X-Secret-Token", "value");
+        createSecretToken(thingifier, "token", "issued-value");
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier).get(jsonRequest("/secrettokens/token"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertFalse(response.getHeaders().headerExists("X-Secret-Token"));
+    }
+
+    @Test
+    void successPolicyCanSelectResponseEntityView() {
+        final Thingifier thingifier = secretModel();
+        getSecretNoteRoute(thingifier).onSuccess().bodyUsingEntityView("PublicNote");
+        createSecretNote(thingifier, "note", "visible", "hidden-internal-value");
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier).get(jsonRequest("/secret/note"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertTrue(response.getBody().contains("visible"));
+        Assertions.assertFalse(response.getBody().contains("internal"));
+        Assertions.assertFalse(response.getBody().contains("hidden-internal-value"));
+    }
+
+    @Test
+    void errorPolicyCanReplaceGeneratedErrorBody() {
+        final Thingifier thingifier = secretModel();
+        getSecretNoteRoute(thingifier).onError(404).bodyText("not here");
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier).get(jsonRequest("/secret/note"));
+
+        Assertions.assertEquals(404, response.getStatusCode());
+        Assertions.assertEquals("not here", response.getBody());
+    }
+
+    @Test
+    void validationPolicyWinsOverStatusSpecificErrorPolicy() {
+        final Thingifier thingifier = todoModel();
+        final ThingifierApiRouteRule route = thingifier.apiSpec().route(RoutingVerb.POST, "/todos");
+        route.onError(422).bodyText("generic");
+        route.onValidationError().status(499).bodyText("validation");
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier).post(jsonPost("/todos", "{}"));
+
+        Assertions.assertEquals(499, response.getStatusCode());
+        Assertions.assertEquals("validation", response.getBody());
+    }
+
+    @Test
+    void errorPolicyCanSuppressEarlyAcceptHeaderResponseBody() {
+        final Thingifier thingifier = secretModel();
+        thingifier.apiConfig().setApiToAllowJsonForResponses(false);
+        getSecretNoteRoute(thingifier).onError(406).suppressBody();
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .get(
+                                new HttpApiRequest("/secret/note")
+                                        .addHeader("Accept", "application/json"));
+
+        Assertions.assertEquals(406, response.getStatusCode());
+        Assertions.assertEquals("", response.getBody());
+    }
+
+    @Test
+    void directApiAppliesSuccessPolicy() {
+        final Thingifier thingifier = secretModel();
+        getSecretTokenRoute(thingifier)
+                .onSuccess()
+                .addInstanceFieldAsHeader("X-Secret-Token", "value");
+        createSecretToken(thingifier, "token", "issued-value");
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .get("secret/token", new QueryFilterParams(), new HttpHeadersBlock());
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals("issued-value", response.getHeaders().get("X-Secret-Token"));
+    }
+
+    @Test
+    void responsePolicyHeadersAreAddedToGeneratedRouteDocumentation() {
+        final Thingifier thingifier = secretModel();
+        getSecretTokenRoute(thingifier)
+                .onSuccess()
+                .status(201)
+                .header("X-Static", "configured")
+                .addInstanceFieldAsHeader("X-Secret-Token", "value");
+
+        final RoutingDefinition route =
+                route(
+                        new ApiRoutingDefinitionDocGenerator(thingifier).generate(""),
+                        RoutingVerb.GET,
+                        "secret/token");
+
+        Assertions.assertTrue(
+                route.getPossibleStatusReponses().stream()
+                        .anyMatch(status -> status.value() == 201));
+        Assertions.assertEquals("configured", route.getResponseHeaderValue("X-Static"));
+        Assertions.assertEquals(
+                "Value from returned instance field value",
+                route.getResponseHeaderValue("X-Secret-Token"));
+    }
+
+    private ThingifierApiRouteRule getSecretNoteRoute(final Thingifier thingifier) {
+        return thingifier
+                .apiSpec()
+                .route(RoutingVerb.GET, "/secret/note")
+                .mapsToEntity("secretnote")
+                .withFixedIdentifier("note");
+    }
+
+    private ThingifierApiRouteRule getSecretTokenRoute(final Thingifier thingifier) {
+        return thingifier
+                .apiSpec()
+                .route(RoutingVerb.GET, "/secret/token")
+                .mapsToEntity("secrettoken")
+                .withFixedIdentifier("token");
+    }
+
+    private ThingifierApiRouteRule postSecretTokenRoute(final Thingifier thingifier) {
+        return thingifier
+                .apiSpec()
+                .route(RoutingVerb.POST, "/secret/token")
+                .mapsToEntity("secrettoken")
+                .withFixedIdentifier("token")
+                .entityCan(UPDATE);
+    }
+
+    private Thingifier secretModel() {
+        final Thingifier thingifier = new Thingifier();
+
+        final EntityDefinition note = thingifier.defineThing("secretnote", "secretnotes", 10);
+        note.addAsPrimaryKeyField(Field.is("id", STRING));
+        note.addField(Field.is("text", STRING));
+        note.addField(Field.is("internal", STRING));
+        note.defineView("PublicNote").hideResponseFields("internal");
+
+        final EntityDefinition token = thingifier.defineThing("secrettoken", "secrettokens", 10);
+        token.addAsPrimaryKeyField(Field.is("id", STRING));
+        token.addField(Field.is("value", STRING));
+
+        return thingifier;
+    }
+
+    private Thingifier todoModel() {
+        final Thingifier thingifier = new Thingifier();
+        final EntityDefinition todo = thingifier.defineThing("todo", "todos", 10);
+        todo.addAsPrimaryKeyField(Field.is("id", AUTO_INCREMENT));
+        todo.addField(Field.is("title", STRING).makeMandatory());
+        return thingifier;
+    }
+
+    private EntityInstance createSecretNote(
+            final Thingifier thingifier,
+            final String id,
+            final String text,
+            final String internal) {
+        final EntityDefinition note = thingifier.getDefinitionNamed("secretnote");
+        return thingifier
+                .getStore(EntityRelModel.DEFAULT_DATABASE_NAME)
+                .entities()
+                .create(
+                        EntityInstanceDraft.forEntity(note)
+                                .withField("id", id)
+                                .withField("text", text)
+                                .withField("internal", internal));
+    }
+
+    private EntityInstance createSecretToken(
+            final Thingifier thingifier, final String id, final String value) {
+        final EntityDefinition token = thingifier.getDefinitionNamed("secrettoken");
+        return thingifier
+                .getStore(EntityRelModel.DEFAULT_DATABASE_NAME)
+                .entities()
+                .create(
+                        EntityInstanceDraft.forEntity(token)
+                                .withField("id", id)
+                                .withField("value", value));
+    }
+
+    private EntityInstance secretToken(final Thingifier thingifier, final String id) {
+        return thingifier
+                .getStore(EntityRelModel.DEFAULT_DATABASE_NAME)
+                .entityQueries()
+                .findByPrimaryKey(thingifier.getDefinitionNamed("secrettoken"), id);
+    }
+
+    private HttpApiRequest jsonRequest(final String path) {
+        return new HttpApiRequest(path).addHeader("Accept", "application/json");
+    }
+
+    private HttpApiRequest jsonPost(final String path, final String body) {
+        return new HttpApiRequest(path)
+                .setVerb("POST")
+                .addHeader("Content-Type", "application/json")
+                .addHeader("Accept", "application/json")
+                .setBody(body);
+    }
+
+    private RoutingDefinition route(
+            final ApiRoutingDefinition definition, final RoutingVerb verb, final String url) {
+        return definition.definitions().stream()
+                .filter(route -> route.verb() == verb)
+                .filter(route -> route.url().equals(url))
+                .findFirst()
+                .orElseThrow();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds route-level API response policies for success, status-specific errors, and validation errors.
- Supports status changes, headers, instance-field headers, body suppression, text bodies, and entity-view response bodies.
- Applies policies through direct and HTTP response rendering, including early HTTP errors.

## Verification
- mvn clean verify
- mvn -pl thingifier verify
- mvn install -DskipTests

Closes #156