### PR TITLE
Add API key auth alternatives

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/RouteAuthPolicy.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/RouteAuthPolicy.java
@@ -1,5 +1,6 @@
 package uk.co.compendiumdev.thingifier.adapter.http.apihandlers;
 
+import java.util.List;
 import java.util.Optional;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.CollectionRoute;
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.InstanceRoute;
@@ -8,6 +9,7 @@ import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.Relationshi
 import uk.co.compendiumdev.thingifier.adapter.http.apihandlers.route.ThingRoute;
 import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierRequestContext;
+import uk.co.compendiumdev.thingifier.api.http.headers.headerparser.ApiKeyHeaderParser;
 import uk.co.compendiumdev.thingifier.api.http.headers.headerparser.BasicAuthHeaderParser;
 import uk.co.compendiumdev.thingifier.api.http.headers.headerparser.BearerAuthHeaderParser;
 import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
@@ -20,6 +22,7 @@ import uk.co.compendiumdev.thingifier.api.security.ThingifierApiAuthorizationRes
 import uk.co.compendiumdev.thingifier.api.security.ThingifierApiAuthorizer;
 import uk.co.compendiumdev.thingifier.api.security.ThingifierApiDataScopeSelection;
 import uk.co.compendiumdev.thingifier.api.security.ThingifierApiRouteAuthDetails;
+import uk.co.compendiumdev.thingifier.api.security.ThingifierApiSecuritySchemeType;
 import uk.co.compendiumdev.thingifier.api.spec.ApiRoutePathMatcher;
 import uk.co.compendiumdev.thingifier.api.spec.ThingifierApiRouteRule;
 import uk.co.compendiumdev.thingifier.application.schema.EntityTypeRef;
@@ -93,12 +96,159 @@ public final class RouteAuthPolicy {
             return null;
         }
 
-        final ThingifierApiRouteRule rule = matchingRule.get();
-        if (rule.hasBasicAuthEnforcement()) {
-            return rejectForBasicAuth(verb, path, context, route, rule);
+        return rejectForAuthAlternatives(verb, path, context, route, matchingRule.get());
+    }
+
+    /**
+     * Enforces the route's ordered authentication alternatives.
+     *
+     * <p>Only the first declared scheme whose credential source is present is authenticated. A
+     * malformed or rejected selected credential stops the request immediately so a higher-priority
+     * credential cannot silently fall through to a later alternative.
+     *
+     * @param verb generated API verb
+     * @param path generated API path
+     * @param context active request context
+     * @param route mapped generated route
+     * @param rule matching route rule
+     * @return rejection response, or null when authentication and authorization succeed
+     */
+    private ApiResponse rejectForAuthAlternatives(
+            final RoutingVerb verb,
+            final String path,
+            final ThingifierRequestContext context,
+            final ThingRoute route,
+            final ThingifierApiRouteRule rule) {
+        final List<String> schemeNames = rule.authEnforcementSchemeNames();
+        for (String schemeName : schemeNames) {
+            final Optional<ThingifierApiSecuritySchemeType> schemeType =
+                    authSchemeTypeFor(rule, schemeName);
+            if (schemeType.isEmpty()) {
+                return unknownAuthScheme(schemeName);
+            }
+            if (!credentialSourceIsPresent(context, schemeName, schemeType.get())) {
+                continue;
+            }
+            return rejectForAuthScheme(
+                    verb, path, context, route, rule, schemeName, schemeType.get());
         }
 
-        return rejectForBearerAuth(verb, path, context, route, rule);
+        final Optional<ThingifierApiSecuritySchemeType> firstSchemeType =
+                authSchemeTypeFor(rule, schemeNames.get(0));
+        if (firstSchemeType.isEmpty()) {
+            return unknownAuthScheme(schemeNames.get(0));
+        }
+        return unauthorized(defaultChallengeFor(schemeNames.get(0), firstSchemeType.get()));
+    }
+
+    private ApiResponse rejectForAuthScheme(
+            final RoutingVerb verb,
+            final String path,
+            final ThingifierRequestContext context,
+            final ThingRoute route,
+            final ThingifierApiRouteRule rule,
+            final String schemeName,
+            final ThingifierApiSecuritySchemeType schemeType) {
+        switch (schemeType) {
+            case API_KEY:
+                return rejectForApiKeyAuth(verb, path, context, route, rule, schemeName);
+            case BASIC:
+                return rejectForBasicAuth(verb, path, context, route, rule, schemeName);
+            case BEARER:
+                return rejectForBearerAuth(verb, path, context, route, rule, schemeName);
+            default:
+                return unknownAuthScheme(schemeName);
+        }
+    }
+
+    private Optional<ThingifierApiSecuritySchemeType> authSchemeTypeFor(
+            final ThingifierApiRouteRule rule, final String schemeName) {
+        if (schemeName.equals(rule.apiKeyAuthEnforcementSchemeName())) {
+            return Optional.of(ThingifierApiSecuritySchemeType.API_KEY);
+        }
+        if (schemeName.equals(rule.basicAuthEnforcementSchemeName())) {
+            return Optional.of(ThingifierApiSecuritySchemeType.BASIC);
+        }
+        if (schemeName.equals(rule.bearerAuthEnforcementSchemeName())) {
+            return Optional.of(ThingifierApiSecuritySchemeType.BEARER);
+        }
+        return runtime.apiSpec().security().schemeType(schemeName);
+    }
+
+    private boolean credentialSourceIsPresent(
+            final ThingifierRequestContext context,
+            final String schemeName,
+            final ThingifierApiSecuritySchemeType schemeType) {
+        switch (schemeType) {
+            case API_KEY:
+                return context.headers()
+                        .headerExists(runtime.apiSpec().security().apiKeyHeaderName(schemeName));
+            case BASIC:
+                return new BasicAuthHeaderParser(context.headers().get(AUTHORIZATION_HEADER))
+                        .isBasicAuth();
+            case BEARER:
+                return new BearerAuthHeaderParser(context.headers().get(AUTHORIZATION_HEADER))
+                        .isBearerToken();
+            default:
+                return false;
+        }
+    }
+
+    private String defaultChallengeFor(
+            final String schemeName, final ThingifierApiSecuritySchemeType schemeType) {
+        switch (schemeType) {
+            case BASIC:
+                return basicChallengeFor(schemeName);
+            case BEARER:
+                return BEARER_CHALLENGE;
+            case API_KEY:
+            default:
+                return "";
+        }
+    }
+
+    private ApiResponse unknownAuthScheme(final String schemeName) {
+        return ApiResponse.error(
+                500, "No security scheme declaration configured for auth scheme " + schemeName);
+    }
+
+    /**
+     * Enforces a named API key auth route rule.
+     *
+     * @param verb generated API verb
+     * @param path generated API path
+     * @param context active request context
+     * @param route mapped generated route
+     * @param rule matching route rule
+     * @return rejection response, or null when authentication and authorization succeed
+     */
+    private ApiResponse rejectForApiKeyAuth(
+            final RoutingVerb verb,
+            final String path,
+            final ThingifierRequestContext context,
+            final ThingRoute route,
+            final ThingifierApiRouteRule rule,
+            final String schemeName) {
+        final String headerName = runtime.apiSpec().security().apiKeyHeaderName(schemeName);
+        final ApiKeyHeaderParser apiKey = new ApiKeyHeaderParser(context.headers().get(headerName));
+        if (!apiKey.isValid()) {
+            return unauthorized("");
+        }
+
+        final Optional<ThingifierApiAuthenticator> authenticator =
+                runtime.apiSpec().authenticatorFor(schemeName);
+        if (authenticator.isEmpty()) {
+            return ApiResponse.error(
+                    500, "No authenticator configured for API key auth scheme " + schemeName);
+        }
+
+        final ThingifierApiAuthenticationContext authenticationContext =
+                ThingifierApiAuthenticationContext.apiKey(
+                        authDetails(schemeName, verb, path, context, route, rule),
+                        apiKey.credential(),
+                        headerName);
+        return rejectAfterAuthentication(
+                rule, context, schemeName, authenticator.get(), authenticationContext, "");
     }
 
     /**
@@ -116,8 +266,8 @@ public final class RouteAuthPolicy {
             final String path,
             final ThingifierRequestContext context,
             final ThingRoute route,
-            final ThingifierApiRouteRule rule) {
-        final String schemeName = rule.bearerAuthEnforcementSchemeName();
+            final ThingifierApiRouteRule rule,
+            final String schemeName) {
         final BearerAuthHeaderParser bearer =
                 new BearerAuthHeaderParser(context.headers().get(AUTHORIZATION_HEADER));
         if (!bearer.isValid()) {
@@ -159,8 +309,8 @@ public final class RouteAuthPolicy {
             final String path,
             final ThingifierRequestContext context,
             final ThingRoute route,
-            final ThingifierApiRouteRule rule) {
-        final String schemeName = rule.basicAuthEnforcementSchemeName();
+            final ThingifierApiRouteRule rule,
+            final String schemeName) {
         final String challenge = basicChallengeFor(schemeName);
         final BasicAuthHeaderParser basic =
                 new BasicAuthHeaderParser(context.headers().get(AUTHORIZATION_HEADER));
@@ -276,9 +426,7 @@ public final class RouteAuthPolicy {
      * @return true when named auth should be enforced for this request
      */
     private boolean requiresAuth(final ThingifierApiRouteRule rule) {
-        return !rule.isDisabled()
-                && !rule.isMethodNotAllowed()
-                && (rule.hasBasicAuthEnforcement() || rule.hasBearerAuthEnforcement());
+        return !rule.isDisabled() && !rule.isMethodNotAllowed() && rule.hasAuthEnforcement();
     }
 
     /**
@@ -383,7 +531,11 @@ public final class RouteAuthPolicy {
      * @return 401 response with a WWW-Authenticate challenge
      */
     private ApiResponse unauthorized(final String challenge) {
-        return ApiResponse.error(401, "Unauthorized").setHeader(WWW_AUTHENTICATE_HEADER, challenge);
+        final ApiResponse response = ApiResponse.error(401, "Unauthorized");
+        if (challenge != null && !challenge.trim().isEmpty()) {
+            response.setHeader(WWW_AUTHENTICATE_HEADER, challenge);
+        }
+        return response;
     }
 
     /**
@@ -396,6 +548,8 @@ public final class RouteAuthPolicy {
     private ApiResponse challengeIfUnauthorized(
             final ApiResponse response, final String challenge) {
         if (response.getStatusCode() == 401
+                && challenge != null
+                && !challenge.trim().isEmpty()
                 && response.getHeaderValue(WWW_AUTHENTICATE_HEADER).isEmpty()) {
             response.setHeader(WWW_AUTHENTICATE_HEADER, challenge);
         }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/RoutingDefinition.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/docgen/RoutingDefinition.java
@@ -7,6 +7,7 @@ import java.util.List;
 import uk.co.compendiumdev.thingifier.api.http.headers.headerparser.ContentTypeHeaderParser;
 import uk.co.compendiumdev.thingifier.api.response.ResponseHeader;
 import uk.co.compendiumdev.thingifier.api.security.SecuritySchemeNames;
+import uk.co.compendiumdev.thingifier.api.security.ThingifierApiSecuritySpec;
 import uk.co.compendiumdev.thingifier.api.spec.FixedResourcePolicy;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.Field;
@@ -37,6 +38,11 @@ public class RoutingDefinition {
     private String basicAuthSchemeName = SecuritySchemeNames.DEFAULT_BASIC_AUTH_SCHEME;
     private boolean usesBearerAuth = false;
     private String bearerAuthSchemeName = SecuritySchemeNames.DEFAULT_BEARER_AUTH_SCHEME;
+    private boolean usesApiKeyAuth = false;
+    private String apiKeyAuthSchemeName = SecuritySchemeNames.DEFAULT_API_KEY_AUTH_SCHEME;
+    private String apiKeyHeaderName = ThingifierApiSecuritySpec.DEFAULT_API_KEY_HEADER;
+    private boolean apiKeyHeaderNameConfigured = false;
+    private List<String> authSchemeNames;
     private boolean hiddenFromDocumentation = false;
     private boolean disabled = false;
     private String requestEntityViewName;
@@ -76,6 +82,7 @@ public class RoutingDefinition {
         responseHeaders = new HashMap<>();
         requestEntityViewName = null;
         responseEntityViewNames = new HashMap<>();
+        authSchemeNames = new ArrayList<>();
         fixedEntityName = null;
         fixedIdentifier = null;
         fixedResourcePolicy = FixedResourcePolicy.RETURN_404;
@@ -675,6 +682,7 @@ public class RoutingDefinition {
     public RoutingDefinition secureWithBasicAuth(final String schemeName) {
         usesBasicAuth = true;
         basicAuthSchemeName = SecuritySchemeNames.requireValid(schemeName);
+        replaceAuthSchemeNamesWith(basicAuthSchemeName);
         return this;
     }
 
@@ -714,6 +722,7 @@ public class RoutingDefinition {
     public RoutingDefinition secureWithBearerAuth(final String schemeName) {
         usesBearerAuth = true;
         bearerAuthSchemeName = SecuritySchemeNames.requireValid(schemeName);
+        replaceAuthSchemeNamesWith(bearerAuthSchemeName);
         return this;
     }
 
@@ -733,6 +742,119 @@ public class RoutingDefinition {
      */
     public String bearerAuthSchemeName() {
         return bearerAuthSchemeName;
+    }
+
+    /**
+     * Marks the route as requiring the default API key auth scheme in generated documentation.
+     *
+     * @return this definition so route metadata can be chained
+     */
+    public RoutingDefinition secureWithApiKey() {
+        return secureWithApiKey(SecuritySchemeNames.DEFAULT_API_KEY_AUTH_SCHEME);
+    }
+
+    /**
+     * Marks the route as requiring a named API key auth scheme in generated documentation.
+     *
+     * <p>The concrete header name is normally supplied by {@link ThingifierApiSecuritySpec}. This
+     * overload keeps generated route metadata focused on the scheme selected by the route.
+     *
+     * @param schemeName API key security scheme name
+     * @return this definition so route metadata can be chained
+     */
+    public RoutingDefinition secureWithApiKey(final String schemeName) {
+        usesApiKeyAuth = true;
+        apiKeyAuthSchemeName = SecuritySchemeNames.requireValid(schemeName);
+        replaceAuthSchemeNamesWith(apiKeyAuthSchemeName);
+        return this;
+    }
+
+    /**
+     * Marks the route as requiring a named API key auth scheme with an explicit header.
+     *
+     * <p>This is useful for manually added documentation routes that do not have a Thingifier API
+     * security declaration to resolve the header name from.
+     *
+     * @param schemeName API key security scheme name
+     * @param headerName request header carrying the API key credential
+     * @return this definition so route metadata can be chained
+     */
+    public RoutingDefinition secureWithApiKey(final String schemeName, final String headerName) {
+        secureWithApiKey(schemeName);
+        apiKeyHeaderName = SecuritySchemeNames.requireValidHeaderName(headerName);
+        apiKeyHeaderNameConfigured = true;
+        return this;
+    }
+
+    /**
+     * Marks the route as accepting any of several named auth schemes in declaration order.
+     *
+     * <p>This metadata is used by OpenAPI generation to render OR-style security requirements.
+     * Generated routes normally resolve each scheme type from the owning Thingifier API security
+     * spec. Manually documented routes can still call the scheme-specific helpers to provide
+     * fallback type/header metadata.
+     *
+     * @param schemeNames ordered security scheme names accepted by the route
+     * @return this definition so route metadata can be chained
+     * @throws IllegalArgumentException when no scheme names are supplied or a name is blank
+     */
+    public RoutingDefinition secureWithAnyOf(final String... schemeNames) {
+        authSchemeNames = normalizedSchemeNames(schemeNames);
+        return this;
+    }
+
+    /**
+     * Reports whether the route has explicit ordered auth scheme metadata.
+     *
+     * @return true when one or more auth scheme names are configured
+     */
+    public boolean hasAuthSchemeNames() {
+        return !authSchemeNames.isEmpty();
+    }
+
+    /**
+     * Returns ordered auth scheme names for this route.
+     *
+     * @return immutable ordered scheme names
+     */
+    public List<String> authSchemeNames() {
+        return List.copyOf(authSchemeNames);
+    }
+
+    /**
+     * Reports whether the route is documented as API-key secured.
+     *
+     * @return true when API key auth should be documented
+     */
+    public boolean isSecuredByApiKeyAuth() {
+        return usesApiKeyAuth;
+    }
+
+    /**
+     * Returns the API key security scheme name used in generated documentation.
+     *
+     * @return API key security scheme name
+     */
+    public String apiKeyAuthSchemeName() {
+        return apiKeyAuthSchemeName;
+    }
+
+    /**
+     * Reports whether this route carries an explicit API key header name.
+     *
+     * @return true when the header was configured directly on this route definition
+     */
+    public boolean hasApiKeyHeaderName() {
+        return apiKeyHeaderNameConfigured;
+    }
+
+    /**
+     * Returns the route's API key header name.
+     *
+     * @return configured API key header, or the default API key header
+     */
+    public String apiKeyHeaderName() {
+        return apiKeyHeaderName;
     }
 
     /**
@@ -772,6 +894,28 @@ public class RoutingDefinition {
      */
     public boolean isDisabled() {
         return disabled;
+    }
+
+    private void replaceAuthSchemeNamesWith(final String schemeName) {
+        authSchemeNames.clear();
+        authSchemeNames.add(schemeName);
+    }
+
+    private List<String> normalizedSchemeNames(final String... schemeNames) {
+        if (schemeNames == null || schemeNames.length == 0) {
+            throw new IllegalArgumentException("secureWithAnyOf requires at least one scheme");
+        }
+        final List<String> normalizedSchemeNames = new ArrayList<>();
+        for (String schemeName : schemeNames) {
+            final String normalizedSchemeName = SecuritySchemeNames.requireValid(schemeName);
+            if (!normalizedSchemeNames.contains(normalizedSchemeName)) {
+                normalizedSchemeNames.add(normalizedSchemeName);
+            }
+        }
+        if (normalizedSchemeNames.isEmpty()) {
+            throw new IllegalArgumentException("secureWithAnyOf requires at least one scheme");
+        }
+        return normalizedSchemeNames;
     }
 
     public static final class RequestUrlParameter {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/HttpApiRequest.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/HttpApiRequest.java
@@ -166,12 +166,7 @@ public final class HttpApiRequest {
 
     public HttpApiRequest addHeader(final String headerName, final String headerValue) {
         final String trimmedHeaderValue = headerValue.trim();
-        // Authorization parameters are case-sensitive, e.g. Basic credentials are Base64.
-        final String value =
-                "authorization".equalsIgnoreCase(headerName)
-                        ? trimmedHeaderValue
-                        : trimmedHeaderValue.toLowerCase();
-        this.headers.put(headerName, value);
+        this.headers.put(headerName, trimmedHeaderValue);
         return this;
     }
 

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/ApiKeyHeaderParser.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/ApiKeyHeaderParser.java
@@ -1,0 +1,40 @@
+package uk.co.compendiumdev.thingifier.api.http.headers.headerparser;
+
+/**
+ * Parses an API key credential from a configured request header.
+ *
+ * <p>API key auth treats the header name as part of the public API contract and the value as an
+ * opaque credential. Thingifier only checks that a non-blank credential is present before handing
+ * it to application authenticator code.
+ */
+public final class ApiKeyHeaderParser {
+
+    private final String credential;
+
+    /**
+     * Creates a parser for one configured API key header value.
+     *
+     * @param headerValue raw header value from the request
+     */
+    public ApiKeyHeaderParser(final String headerValue) {
+        credential = headerValue == null ? "" : headerValue.trim();
+    }
+
+    /**
+     * Reports whether the configured header supplied a usable credential.
+     *
+     * @return true when the header value is present and not blank
+     */
+    public boolean isValid() {
+        return !credential.isEmpty();
+    }
+
+    /**
+     * Returns the parsed API key credential.
+     *
+     * @return trimmed API key value, or an empty string when invalid
+     */
+    public String credential() {
+        return credential;
+    }
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/SecuritySchemeNames.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/SecuritySchemeNames.java
@@ -14,6 +14,9 @@ public final class SecuritySchemeNames {
     /** Default OpenAPI scheme name used by the historical no-argument Basic marker. */
     public static final String DEFAULT_BASIC_AUTH_SCHEME = "basicAuth";
 
+    /** Default OpenAPI scheme name used by API key routes when no explicit name is supplied. */
+    public static final String DEFAULT_API_KEY_AUTH_SCHEME = "apiKeyAuth";
+
     private SecuritySchemeNames() {}
 
     /**
@@ -28,5 +31,27 @@ public final class SecuritySchemeNames {
             throw new IllegalArgumentException("security scheme name is required");
         }
         return schemeName.trim();
+    }
+
+    /**
+     * Validates and trims an HTTP header name used as an auth credential source.
+     *
+     * <p>API key schemes expose their header names in OpenAPI and use them for runtime credential
+     * lookup, so rejecting blank or malformed names prevents confusing docs and unsafe response
+     * metadata.
+     *
+     * @param headerName caller supplied HTTP header name
+     * @return trimmed header name
+     * @throws IllegalArgumentException when the header name is null, blank, or not an HTTP token
+     */
+    public static String requireValidHeaderName(final String headerName) {
+        if (headerName == null || headerName.trim().isEmpty()) {
+            throw new IllegalArgumentException("API key header name is required");
+        }
+        final String normalized = headerName.trim();
+        if (!normalized.matches("[!#$%&'*+.^_`|~0-9A-Za-z-]+")) {
+            throw new IllegalArgumentException("API key header name must be an HTTP field name");
+        }
+        return normalized;
     }
 }

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthenticationContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthenticationContext.java
@@ -23,9 +23,12 @@ public final class ThingifierApiAuthenticationContext {
     private final ThingRoute route;
     private final HttpHeadersBlock headers;
     private final ThingifierRequestContext requestContext;
+    private final String authCredential;
+    private final String authCredentialSource;
     private final String bearerToken;
     private final String basicUsername;
     private final String basicPassword;
+    private final String apiKey;
     private final EntityDefinition targetEntity;
     private final String targetIdentifier;
     private final EntityDefinition parentEntity;
@@ -41,15 +44,16 @@ public final class ThingifierApiAuthenticationContext {
      */
     public ThingifierApiAuthenticationContext(
             final ThingifierApiRouteAuthDetails details, final String bearerToken) {
-        this(details, bearerToken, "", "");
+        this(details, bearerToken, "", "", "", bearerToken, "Authorization");
     }
 
     /**
      * Creates an immutable authentication context with parsed auth credentials.
      *
      * <p>Only the fields relevant to the enforced scheme are populated. Bearer routes receive a
-     * bearer token, and Basic routes receive username/password values. Keeping one context type
-     * lets applications use the same authenticator interface for every scheme.
+     * bearer token, Basic routes receive username/password values, and API key routes use {@link
+     * #apiKey(ThingifierApiRouteAuthDetails, String, String)}. Keeping one context type lets
+     * applications use the same authenticator interface for every scheme.
      *
      * @param details reusable route and request details
      * @param bearerToken parsed bearer token from the Authorization header
@@ -61,6 +65,37 @@ public final class ThingifierApiAuthenticationContext {
             final String bearerToken,
             final String basicUsername,
             final String basicPassword) {
+        this(details, bearerToken, basicUsername, basicPassword, "", "", "Authorization");
+    }
+
+    /**
+     * Creates an immutable authentication context for an API key header.
+     *
+     * <p>API key values are public API credentials read from a configured request header. The
+     * source name is preserved so authenticators can distinguish schemes that intentionally share a
+     * callback but use different headers.
+     *
+     * @param details reusable route and request details
+     * @param apiKey parsed API key credential
+     * @param headerName request header that supplied the credential
+     * @return authentication context populated for API key auth
+     */
+    public static ThingifierApiAuthenticationContext apiKey(
+            final ThingifierApiRouteAuthDetails details,
+            final String apiKey,
+            final String headerName) {
+        return new ThingifierApiAuthenticationContext(
+                details, "", "", "", apiKey, apiKey, headerName);
+    }
+
+    private ThingifierApiAuthenticationContext(
+            final ThingifierApiRouteAuthDetails details,
+            final String bearerToken,
+            final String basicUsername,
+            final String basicPassword,
+            final String apiKey,
+            final String authCredential,
+            final String authCredentialSource) {
         this.schemeName = details.schemeName();
         this.verb = details.verb();
         this.path = details.path();
@@ -68,9 +103,12 @@ public final class ThingifierApiAuthenticationContext {
         this.route = details.route();
         this.headers = details.headers();
         this.requestContext = details.requestContext();
+        this.authCredential = authCredential == null ? "" : authCredential;
+        this.authCredentialSource = authCredentialSource == null ? "" : authCredentialSource;
         this.bearerToken = bearerToken == null ? "" : bearerToken;
         this.basicUsername = basicUsername == null ? "" : basicUsername;
         this.basicPassword = basicPassword == null ? "" : basicPassword;
+        this.apiKey = apiKey == null ? "" : apiKey;
         this.targetEntity = details.targetEntity();
         this.targetIdentifier = details.targetIdentifier();
         this.parentEntity = details.parentEntity();
@@ -86,6 +124,18 @@ public final class ThingifierApiAuthenticationContext {
      */
     public String schemeName() {
         return schemeName;
+    }
+
+    /**
+     * Returns the security scheme name that selected the authenticator.
+     *
+     * <p>This alias mirrors the public API wording used by generic authenticators. It returns the
+     * same value as {@link #schemeName()}.
+     *
+     * @return security scheme name
+     */
+    public String authSchemeName() {
+        return schemeName();
     }
 
     /**
@@ -175,6 +225,31 @@ public final class ThingifierApiAuthenticationContext {
     }
 
     /**
+     * Returns the parsed credential for token-style authentication schemes.
+     *
+     * <p>Bearer and API key routes populate this with the bearer token or API key. Basic auth
+     * exposes its credential pair through {@link #basicUsername()} and {@link #basicPassword()}
+     * instead of combining them into one string.
+     *
+     * @return parsed token-style credential, or an empty string for Basic auth
+     */
+    public String authCredential() {
+        return authCredential;
+    }
+
+    /**
+     * Returns where the parsed credential came from.
+     *
+     * <p>Bearer and Basic use {@code Authorization}. API key auth returns the configured public
+     * header name, for example {@code X-AUTH-TOKEN}.
+     *
+     * @return credential source header name, or an empty string when unavailable
+     */
+    public String authCredentialSource() {
+        return authCredentialSource;
+    }
+
+    /**
      * Returns the parsed bearer token.
      *
      * @return bearer token without the Authorization scheme prefix
@@ -199,6 +274,15 @@ public final class ThingifierApiAuthenticationContext {
      */
     public String basicPassword() {
         return basicPassword;
+    }
+
+    /**
+     * Returns the parsed API key credential.
+     *
+     * @return API key value, or an empty string when the enforced scheme is not API key auth
+     */
+    public String apiKey() {
+        return apiKey;
     }
 
     /**

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthenticationResult.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthenticationResult.java
@@ -8,7 +8,8 @@ import uk.co.compendiumdev.thingifier.api.response.ApiResponse;
  *
  * <p>The result either supplies a principal for later authorization or an API response explaining
  * why the credentials cannot be accepted. Thingifier supplies the standard missing and malformed
- * bearer-token responses before invoking authenticators.
+ * credential responses before invoking authenticators when the route's auth scheme cannot be
+ * parsed.
  *
  * <p>Successful authenticators may also choose a data scope for the rest of the request. That
  * selection is trusted because it is returned only after application code has validated the

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthorizationContext.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthorizationContext.java
@@ -61,6 +61,18 @@ public final class ThingifierApiAuthorizationContext {
     }
 
     /**
+     * Returns the security scheme name that selected the authenticator.
+     *
+     * <p>This alias mirrors the public API wording used by generic authorizers. It returns the same
+     * value as {@link #schemeName()}.
+     *
+     * @return security scheme name
+     */
+    public String authSchemeName() {
+        return authenticationContext.authSchemeName();
+    }
+
+    /**
      * Returns the generated API verb being processed.
      *
      * @return routing verb
@@ -146,6 +158,24 @@ public final class ThingifierApiAuthorizationContext {
     }
 
     /**
+     * Returns the parsed credential for token-style authentication schemes.
+     *
+     * @return bearer token or API key, or an empty string for Basic auth
+     */
+    public String authCredential() {
+        return authenticationContext.authCredential();
+    }
+
+    /**
+     * Returns where the parsed credential came from.
+     *
+     * @return credential source header name, or an empty string when unavailable
+     */
+    public String authCredentialSource() {
+        return authenticationContext.authCredentialSource();
+    }
+
+    /**
      * Returns the parsed bearer token.
      *
      * @return bearer token without the Authorization scheme prefix
@@ -170,6 +200,15 @@ public final class ThingifierApiAuthorizationContext {
      */
     public String basicPassword() {
         return authenticationContext.basicPassword();
+    }
+
+    /**
+     * Returns the parsed API key credential from the authentication step.
+     *
+     * @return API key value, or an empty string when the enforced scheme is not API key auth
+     */
+    public String apiKey() {
+        return authenticationContext.apiKey();
     }
 
     /**

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiSecuritySchemeType.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiSecuritySchemeType.java
@@ -1,0 +1,19 @@
+package uk.co.compendiumdev.thingifier.api.security;
+
+/**
+ * Identifies how a named security scheme supplies credentials on an HTTP request.
+ *
+ * <p>Route rules can accept security scheme names without repeating transport details. The API
+ * security declaration resolves each name to one of these types so runtime authentication and
+ * OpenAPI generation both read the same credential source.
+ */
+public enum ThingifierApiSecuritySchemeType {
+    /** HTTP Basic credentials from the {@code Authorization} header. */
+    BASIC,
+
+    /** HTTP Bearer token from the {@code Authorization} header. */
+    BEARER,
+
+    /** Opaque API key from a configured request header. */
+    API_KEY
+}

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiSecuritySpec.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiSecuritySpec.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -18,13 +19,18 @@ public final class ThingifierApiSecuritySpec {
     /** Default Basic realm used when a scheme has not configured one. */
     public static final String DEFAULT_BASIC_REALM = "Thingifier";
 
+    /** Default request header used by API key schemes when no header is explicitly configured. */
+    public static final String DEFAULT_API_KEY_HEADER = "X-API-KEY";
+
     private final Set<String> bearerSchemes;
     private final Map<String, String> basicRealms;
+    private final Map<String, String> apiKeyHeaders;
 
     /** Creates an empty security declaration set. */
     public ThingifierApiSecuritySpec() {
         bearerSchemes = new LinkedHashSet<>();
         basicRealms = new LinkedHashMap<>();
+        apiKeyHeaders = new LinkedHashMap<>();
     }
 
     /**
@@ -65,6 +71,37 @@ public final class ThingifierApiSecuritySpec {
     }
 
     /**
+     * Declares a named API key scheme using the default {@code X-API-KEY} header.
+     *
+     * <p>API key schemes are for user-facing token headers that should be enforced at runtime and
+     * rendered in OpenAPI as {@code type: apiKey}, {@code in: header}.
+     *
+     * @param schemeName name to use in API spec route rules and OpenAPI security schemes
+     * @return this security spec so declarations can be chained
+     */
+    public ThingifierApiSecuritySpec apiKey(final String schemeName) {
+        return apiKey(schemeName, DEFAULT_API_KEY_HEADER);
+    }
+
+    /**
+     * Declares a named API key scheme with a configured request header.
+     *
+     * <p>The header name is part of the public API contract. Thingifier reads the credential from
+     * this header before invoking the named authenticator, and OpenAPI advertises the same header
+     * so clients know how to supply the token.
+     *
+     * @param schemeName name to use in API spec route rules and OpenAPI security schemes
+     * @param headerName request header that carries the API key credential
+     * @return this security spec so declarations can be chained
+     */
+    public ThingifierApiSecuritySpec apiKey(final String schemeName, final String headerName) {
+        apiKeyHeaders.put(
+                SecuritySchemeNames.requireValid(schemeName),
+                SecuritySchemeNames.requireValidHeaderName(headerName));
+        return this;
+    }
+
+    /**
      * Reports whether the named bearer scheme has been declared.
      *
      * @param schemeName security scheme name
@@ -82,6 +119,40 @@ public final class ThingifierApiSecuritySpec {
      */
     public boolean hasBasic(final String schemeName) {
         return basicRealms.containsKey(SecuritySchemeNames.requireValid(schemeName));
+    }
+
+    /**
+     * Reports whether the named API key scheme has been declared.
+     *
+     * @param schemeName security scheme name
+     * @return true when a matching API key scheme is known
+     */
+    public boolean hasApiKey(final String schemeName) {
+        return apiKeyHeaders.containsKey(SecuritySchemeNames.requireValid(schemeName));
+    }
+
+    /**
+     * Resolves the transport type for a declared security scheme.
+     *
+     * <p>Alternative route auth works from ordered scheme names. This lookup keeps those route
+     * declarations concise while still letting Thingifier parse the correct credential source for
+     * each named scheme.
+     *
+     * @param schemeName security scheme name
+     * @return scheme type when the name has been declared
+     */
+    public Optional<ThingifierApiSecuritySchemeType> schemeType(final String schemeName) {
+        final String normalizedSchemeName = SecuritySchemeNames.requireValid(schemeName);
+        if (bearerSchemes.contains(normalizedSchemeName)) {
+            return Optional.of(ThingifierApiSecuritySchemeType.BEARER);
+        }
+        if (basicRealms.containsKey(normalizedSchemeName)) {
+            return Optional.of(ThingifierApiSecuritySchemeType.BASIC);
+        }
+        if (apiKeyHeaders.containsKey(normalizedSchemeName)) {
+            return Optional.of(ThingifierApiSecuritySchemeType.API_KEY);
+        }
+        return Optional.empty();
     }
 
     /**
@@ -103,6 +174,15 @@ public final class ThingifierApiSecuritySpec {
     }
 
     /**
+     * Returns all declared API key scheme names in declaration order.
+     *
+     * @return immutable set of API key scheme names
+     */
+    public Set<String> apiKeySchemes() {
+        return Collections.unmodifiableSet(apiKeyHeaders.keySet());
+    }
+
+    /**
      * Returns the Basic realm for a named scheme.
      *
      * <p>Routes may enforce a named Basic scheme without an explicit security declaration. In that
@@ -114,6 +194,22 @@ public final class ThingifierApiSecuritySpec {
     public String basicRealm(final String schemeName) {
         return basicRealms.getOrDefault(
                 SecuritySchemeNames.requireValid(schemeName), DEFAULT_BASIC_REALM);
+    }
+
+    /**
+     * Returns the header name for a named API key scheme.
+     *
+     * <p>Routes may enforce a named API key scheme without an explicit security declaration. In
+     * that case the default header keeps runtime behaviour and documentation predictable, while
+     * applications that expose a public header such as {@code X-AUTH-TOKEN} should declare it with
+     * {@link #apiKey(String, String)}.
+     *
+     * @param schemeName security scheme name
+     * @return configured API key header, or {@code X-API-KEY} when no declaration exists
+     */
+    public String apiKeyHeaderName(final String schemeName) {
+        return apiKeyHeaders.getOrDefault(
+                SecuritySchemeNames.requireValid(schemeName), DEFAULT_API_KEY_HEADER);
     }
 
     private String normalizedRealm(final String realm) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiRouteRule.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiRouteRule.java
@@ -39,6 +39,10 @@ public final class ThingifierApiRouteRule {
     private boolean usesBearerAuth;
     private String bearerAuthSchemeName;
     private String enforcedBearerAuthSchemeName;
+    private boolean usesApiKeyAuth;
+    private String apiKeyAuthSchemeName;
+    private String enforcedApiKeyAuthSchemeName;
+    private final List<String> authEnforcementSchemeNames;
     private final List<ThingifierApiAuthorizer> authorizers;
     private final List<ApiOperationValidatorDefinition> apiOperationValidators;
     private RouteApiResponsePolicy successResponsePolicy;
@@ -68,6 +72,10 @@ public final class ThingifierApiRouteRule {
         this.usesBearerAuth = false;
         this.bearerAuthSchemeName = SecuritySchemeNames.DEFAULT_BEARER_AUTH_SCHEME;
         this.enforcedBearerAuthSchemeName = null;
+        this.usesApiKeyAuth = false;
+        this.apiKeyAuthSchemeName = SecuritySchemeNames.DEFAULT_API_KEY_AUTH_SCHEME;
+        this.enforcedApiKeyAuthSchemeName = null;
+        this.authEnforcementSchemeNames = new java.util.ArrayList<>();
         this.authorizers = new java.util.ArrayList<>();
         this.apiOperationValidators = new java.util.ArrayList<>();
         this.successResponsePolicy = null;
@@ -201,8 +209,8 @@ public final class ThingifierApiRouteRule {
      * <p>The scheme name is used in generated documentation, authenticator lookup, and the
      * authenticated-principal slot on the request context. The Basic realm is configured on {@link
      * uk.co.compendiumdev.thingifier.api.security.ThingifierApiSecuritySpec#basic(String, String)}.
-     * If both named Basic and named Bearer auth are configured on one route, the most recent named
-     * call selects the runtime enforcement scheme.
+     * This single-scheme convenience form replaces any previously configured runtime auth
+     * alternatives.
      *
      * @param schemeName named Basic scheme, for example {@code adminPassword}
      * @return this rule so route API configuration can be chained
@@ -211,9 +219,12 @@ public final class ThingifierApiRouteRule {
         final String normalizedSchemeName = SecuritySchemeNames.requireValid(schemeName);
         usesBasicAuth = true;
         usesBearerAuth = false;
+        usesApiKeyAuth = false;
         basicAuthSchemeName = normalizedSchemeName;
         enforcedBasicAuthSchemeName = normalizedSchemeName;
         enforcedBearerAuthSchemeName = null;
+        enforcedApiKeyAuthSchemeName = null;
+        replaceAuthEnforcementWith(normalizedSchemeName);
         return this;
     }
 
@@ -240,6 +251,9 @@ public final class ThingifierApiRouteRule {
      * through {@link ThingifierApiSpec#authenticator(String,
      * uk.co.compendiumdev.thingifier.api.security.ThingifierApiAuthenticator)}.
      *
+     * <p>This single-scheme convenience form replaces any previously configured runtime auth
+     * alternatives.
+     *
      * @param schemeName named bearer scheme, for example {@code cartToken}
      * @return this rule so route API configuration can be chained
      */
@@ -247,17 +261,76 @@ public final class ThingifierApiRouteRule {
         final String normalizedSchemeName = SecuritySchemeNames.requireValid(schemeName);
         usesBasicAuth = false;
         usesBearerAuth = true;
+        usesApiKeyAuth = false;
         bearerAuthSchemeName = normalizedSchemeName;
         enforcedBasicAuthSchemeName = null;
         enforcedBearerAuthSchemeName = normalizedSchemeName;
+        enforcedApiKeyAuthSchemeName = null;
+        replaceAuthEnforcementWith(normalizedSchemeName);
+        return this;
+    }
+
+    /**
+     * Marks the route as requiring a named API key authentication scheme.
+     *
+     * <p>API key auth is for public token headers such as {@code X-API-KEY} or {@code
+     * X-AUTH-TOKEN}. The scheme name is used for documentation, authenticator lookup, and the
+     * authenticated-principal slot on the request context. The header name is configured on {@link
+     * uk.co.compendiumdev.thingifier.api.security.ThingifierApiSecuritySpec#apiKey(String,
+     * String)}. This single-scheme convenience form replaces any previously configured runtime auth
+     * alternatives.
+     *
+     * @param schemeName named API key scheme, for example {@code authToken}
+     * @return this rule so route API configuration can be chained
+     */
+    public ThingifierApiRouteRule secureWithApiKey(final String schemeName) {
+        final String normalizedSchemeName = SecuritySchemeNames.requireValid(schemeName);
+        usesBasicAuth = false;
+        usesBearerAuth = false;
+        usesApiKeyAuth = true;
+        apiKeyAuthSchemeName = normalizedSchemeName;
+        enforcedBasicAuthSchemeName = null;
+        enforcedBearerAuthSchemeName = null;
+        enforcedApiKeyAuthSchemeName = normalizedSchemeName;
+        replaceAuthEnforcementWith(normalizedSchemeName);
+        return this;
+    }
+
+    /**
+     * Requires one of several named authentication schemes, tried in declaration order.
+     *
+     * <p>The named schemes must be declared on {@link
+     * uk.co.compendiumdev.thingifier.api.security.ThingifierApiSecuritySpec} so Thingifier knows
+     * whether each credential is Basic, Bearer, or API key. Runtime auth selects the first declared
+     * scheme whose credential source is present. If that credential is malformed or rejected,
+     * Thingifier stops immediately rather than falling through to later alternatives.
+     *
+     * @param schemeNames ordered security scheme names accepted by this route
+     * @return this rule so route API configuration can be chained
+     * @throws IllegalArgumentException when no scheme names are supplied or a name is blank
+     */
+    public ThingifierApiRouteRule secureWithAnyOf(final String... schemeNames) {
+        final List<String> normalizedSchemeNames = normalizedSchemeNames(schemeNames);
+        usesBasicAuth = false;
+        usesBearerAuth = false;
+        usesApiKeyAuth = false;
+        basicAuthSchemeName = SecuritySchemeNames.DEFAULT_BASIC_AUTH_SCHEME;
+        bearerAuthSchemeName = SecuritySchemeNames.DEFAULT_BEARER_AUTH_SCHEME;
+        apiKeyAuthSchemeName = SecuritySchemeNames.DEFAULT_API_KEY_AUTH_SCHEME;
+        enforcedBasicAuthSchemeName = null;
+        enforcedBearerAuthSchemeName = null;
+        enforcedApiKeyAuthSchemeName = null;
+        authEnforcementSchemeNames.clear();
+        authEnforcementSchemeNames.addAll(normalizedSchemeNames);
         return this;
     }
 
     /**
      * Adds a route-specific authorization callback.
      *
-     * <p>Authorizers run only after the named authenticator accepts the bearer token. Multiple
-     * authorizers are evaluated in registration order and the first rejection stops the request.
+     * <p>Authorizers run only after the named authenticator accepts the route's credential.
+     * Multiple authorizers are evaluated in registration order and the first rejection stops the
+     * request.
      *
      * @param authorizer authorization callback
      * @return this rule so route API configuration can be chained
@@ -305,6 +378,63 @@ public final class ThingifierApiRouteRule {
      */
     public String bearerAuthEnforcementSchemeName() {
         return enforcedBearerAuthSchemeName;
+    }
+
+    /**
+     * Reports whether this route is documented as API-key secured.
+     *
+     * @return true when API key auth should appear in generated documentation
+     */
+    public boolean isSecuredByApiKeyAuth() {
+        return usesApiKeyAuth;
+    }
+
+    /**
+     * Returns the API key scheme name used in generated documentation.
+     *
+     * @return API key auth scheme name
+     */
+    public String apiKeyAuthSchemeName() {
+        return apiKeyAuthSchemeName;
+    }
+
+    /**
+     * Reports whether this route should enforce API key auth at runtime.
+     *
+     * @return true when the route has a named API key enforcement scheme
+     */
+    public boolean hasApiKeyAuthEnforcement() {
+        return enforcedApiKeyAuthSchemeName != null;
+    }
+
+    /**
+     * Returns the API key scheme name used for runtime enforcement.
+     *
+     * @return API key enforcement scheme name, or null when API key auth is not enforced
+     */
+    public String apiKeyAuthEnforcementSchemeName() {
+        return enforcedApiKeyAuthSchemeName;
+    }
+
+    /**
+     * Reports whether this route has named runtime authentication enforcement.
+     *
+     * @return true when one or more auth schemes are enforced
+     */
+    public boolean hasAuthEnforcement() {
+        return !authEnforcementSchemeNames.isEmpty();
+    }
+
+    /**
+     * Returns runtime auth schemes in the order Thingifier should try them.
+     *
+     * <p>Single-scheme convenience methods return a one-item list. {@link
+     * #secureWithAnyOf(String...)} returns all configured alternatives in declaration order.
+     *
+     * @return immutable ordered auth scheme names
+     */
+    public List<String> authEnforcementSchemeNames() {
+        return List.copyOf(authEnforcementSchemeNames);
     }
 
     /**
@@ -822,6 +952,12 @@ public final class ThingifierApiRouteRule {
         if (usesBearerAuth) {
             route.secureWithBearerAuth(bearerAuthSchemeName);
         }
+        if (usesApiKeyAuth) {
+            route.secureWithApiKey(apiKeyAuthSchemeName);
+        }
+        if (hasAuthEnforcement() && !usesBasicAuth && !usesBearerAuth && !usesApiKeyAuth) {
+            route.secureWithAnyOf(authEnforcementSchemeNames.toArray(new String[0]));
+        }
         if (documentation != null) {
             route.addDocumentation(documentation);
         }
@@ -926,6 +1062,28 @@ public final class ThingifierApiRouteRule {
             Collections.addAll(selected, operations);
         }
         return selected;
+    }
+
+    private void replaceAuthEnforcementWith(final String schemeName) {
+        authEnforcementSchemeNames.clear();
+        authEnforcementSchemeNames.add(schemeName);
+    }
+
+    private List<String> normalizedSchemeNames(final String... schemeNames) {
+        if (schemeNames == null || schemeNames.length == 0) {
+            throw new IllegalArgumentException("secureWithAnyOf requires at least one scheme");
+        }
+        final List<String> normalizedSchemeNames = new java.util.ArrayList<>();
+        for (String schemeName : schemeNames) {
+            final String normalizedSchemeName = SecuritySchemeNames.requireValid(schemeName);
+            if (!normalizedSchemeNames.contains(normalizedSchemeName)) {
+                normalizedSchemeNames.add(normalizedSchemeName);
+            }
+        }
+        if (normalizedSchemeNames.isEmpty()) {
+            throw new IllegalArgumentException("secureWithAnyOf requires at least one scheme");
+        }
+        return normalizedSchemeNames;
     }
 
     private String requireText(final String value, final String label) {

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpec.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpec.java
@@ -111,9 +111,9 @@ public final class ThingifierApiSpec {
      * Registers an authenticator for a named security scheme.
      *
      * <p>Registering an authenticator makes a named scheme enforceable at runtime when a route rule
-     * selects that scheme with named Basic or Bearer auth. The route rule and security declaration
-     * decide which HTTP auth mechanism is documented and parsed; this callback only supplies the
-     * application-specific credential check.
+     * selects that scheme with named Basic, Bearer, or API key auth. The route rule and security
+     * declaration decide which HTTP auth mechanism is documented and parsed; this callback only
+     * supplies the application-specific credential check.
      *
      * @param schemeName named security scheme
      * @param authenticator callback used to authenticate parsed credentials for the scheme

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/Swaggerizer.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/swaggerizer/Swaggerizer.java
@@ -17,6 +17,7 @@ import java.math.BigDecimal;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import uk.co.compendiumdev.thingifier.Thingifier;
 import uk.co.compendiumdev.thingifier.api.docgen.ApiRoutingDefinition;
 import uk.co.compendiumdev.thingifier.api.docgen.ApiRoutingDefinitionDocGenerator;
@@ -26,6 +27,7 @@ import uk.co.compendiumdev.thingifier.api.docgen.RoutingVerb;
 import uk.co.compendiumdev.thingifier.api.docgen.ThingifierApiDocumentationDefn;
 import uk.co.compendiumdev.thingifier.api.http.ThingifierHttpApi;
 import uk.co.compendiumdev.thingifier.api.http.headers.headerparser.AcceptHeaderParser;
+import uk.co.compendiumdev.thingifier.api.security.ThingifierApiSecuritySchemeType;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.EntityViewDefinition;
 import uk.co.compendiumdev.thingifier.core.domain.definitions.field.definition.Field;
@@ -139,6 +141,12 @@ public class Swaggerizer {
         for (String basicSchemeName : thingifier.apiSpec().security().basicSchemes()) {
             addHttpSecurityScheme(components, basicSchemeName, "basic", null);
         }
+        for (String apiKeySchemeName : thingifier.apiSpec().security().apiKeySchemes()) {
+            addApiKeySecurityScheme(
+                    components,
+                    apiKeySchemeName,
+                    thingifier.apiSpec().security().apiKeyHeaderName(apiKeySchemeName));
+        }
 
         if (routes != null) {
 
@@ -247,19 +255,7 @@ public class Swaggerizer {
                                 operation.setRequestBody(requestBody);
                             }
 
-                            if (subroute.isSecuredByBasicAuth()) {
-                                final String basicSchemeName = subroute.basicAuthSchemeName();
-                                addHttpSecurityScheme(components, basicSchemeName, "basic", null);
-                                operation.addSecurityItem(
-                                        new SecurityRequirement().addList(basicSchemeName));
-                            }
-
-                            if (subroute.isSecuredByBearerAuth()) {
-                                final String bearerSchemeName = subroute.bearerAuthSchemeName();
-                                addHttpSecurityScheme(components, bearerSchemeName, "bearer", null);
-                                operation.addSecurityItem(
-                                        new SecurityRequirement().addList(bearerSchemeName));
-                            }
+                            addRouteSecuritySchemes(subroute, components, operation);
 
                             if (shouldDocumentSortParameter(thingifier, subroute)) {
                                 operationParameters.add(
@@ -585,6 +581,88 @@ public class Swaggerizer {
         }
     }
 
+    private void addRouteSecuritySchemes(
+            final RoutingDefinition subroute,
+            final Components components,
+            final Operation operation) {
+        if (subroute.hasAuthSchemeNames()) {
+            for (String schemeName : subroute.authSchemeNames()) {
+                addRouteSecurityScheme(subroute, components, operation, schemeName);
+            }
+            return;
+        }
+
+        addLegacyRouteSecuritySchemes(subroute, components, operation);
+    }
+
+    private void addLegacyRouteSecuritySchemes(
+            final RoutingDefinition subroute,
+            final Components components,
+            final Operation operation) {
+        if (subroute.isSecuredByBasicAuth()) {
+            final String basicSchemeName = subroute.basicAuthSchemeName();
+            addHttpSecurityScheme(components, basicSchemeName, "basic", null);
+            operation.addSecurityItem(new SecurityRequirement().addList(basicSchemeName));
+        }
+
+        if (subroute.isSecuredByBearerAuth()) {
+            final String bearerSchemeName = subroute.bearerAuthSchemeName();
+            addHttpSecurityScheme(components, bearerSchemeName, "bearer", null);
+            operation.addSecurityItem(new SecurityRequirement().addList(bearerSchemeName));
+        }
+
+        if (subroute.isSecuredByApiKeyAuth()) {
+            final String apiKeySchemeName = subroute.apiKeyAuthSchemeName();
+            addApiKeySecurityScheme(
+                    components, apiKeySchemeName, apiKeyHeaderNameFor(subroute, apiKeySchemeName));
+            operation.addSecurityItem(new SecurityRequirement().addList(apiKeySchemeName));
+        }
+    }
+
+    private void addRouteSecurityScheme(
+            final RoutingDefinition subroute,
+            final Components components,
+            final Operation operation,
+            final String schemeName) {
+        final Optional<ThingifierApiSecuritySchemeType> schemeType =
+                routeSecuritySchemeType(subroute, schemeName);
+        if (schemeType.isEmpty()) {
+            return;
+        }
+
+        switch (schemeType.get()) {
+            case BASIC:
+                addHttpSecurityScheme(components, schemeName, "basic", null);
+                break;
+            case BEARER:
+                addHttpSecurityScheme(components, schemeName, "bearer", null);
+                break;
+            case API_KEY:
+                addApiKeySecurityScheme(
+                        components, schemeName, apiKeyHeaderNameFor(subroute, schemeName));
+                break;
+            default:
+                return;
+        }
+        operation.addSecurityItem(new SecurityRequirement().addList(schemeName));
+    }
+
+    private Optional<ThingifierApiSecuritySchemeType> routeSecuritySchemeType(
+            final RoutingDefinition subroute, final String schemeName) {
+        if (subroute.isSecuredByBasicAuth() && subroute.basicAuthSchemeName().equals(schemeName)) {
+            return Optional.of(ThingifierApiSecuritySchemeType.BASIC);
+        }
+        if (subroute.isSecuredByBearerAuth()
+                && subroute.bearerAuthSchemeName().equals(schemeName)) {
+            return Optional.of(ThingifierApiSecuritySchemeType.BEARER);
+        }
+        if (subroute.isSecuredByApiKeyAuth()
+                && subroute.apiKeyAuthSchemeName().equals(schemeName)) {
+            return Optional.of(ThingifierApiSecuritySchemeType.API_KEY);
+        }
+        return apiDefn.getThingifier().apiSpec().security().schemeType(schemeName);
+    }
+
     private Content responseContentWith(final String jsonRef, final Schema<?> xmlSchema) {
         Content content = new Content();
         for (AcceptHeaderParser.ACCEPT_TYPE responseType :
@@ -624,6 +702,29 @@ public class Swaggerizer {
             securityScheme.bearerFormat(bearerFormat);
         }
         components.addSecuritySchemes(name, securityScheme);
+    }
+
+    private void addApiKeySecurityScheme(
+            final Components components, final String name, final String headerName) {
+        if (components.getSecuritySchemes() != null
+                && components.getSecuritySchemes().containsKey(name)) {
+            return;
+        }
+
+        final SecurityScheme securityScheme =
+                new SecurityScheme()
+                        .type(SecurityScheme.Type.APIKEY)
+                        .in(SecurityScheme.In.HEADER)
+                        .name(headerName);
+        components.addSecuritySchemes(name, securityScheme);
+    }
+
+    private String apiKeyHeaderNameFor(
+            final RoutingDefinition route, final String apiKeySchemeName) {
+        if (route.hasApiKeyHeaderName()) {
+            return route.apiKeyHeaderName();
+        }
+        return apiDefn.getThingifier().apiSpec().security().apiKeyHeaderName(apiKeySchemeName);
     }
 
     private ObjectSchema asJsonCollectionObjectSchema(EntityDefinition objectSchemaDefinition) {

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/adapter/internalhttp/conversion/InternalHttpRequestToHttpApiRequestTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/adapter/internalhttp/conversion/InternalHttpRequestToHttpApiRequestTest.java
@@ -39,7 +39,7 @@ class InternalHttpRequestToHttpApiRequestTest {
         Assertions.assertEquals("http://localhost/todos", apiRequest.getUrl());
         Assertions.assertEquals("127.0.0.1", apiRequest.getIP());
         Assertions.assertEquals("123", apiRequest.getUrlParam(":id"));
-        Assertions.assertEquals("application/json", apiRequest.getHeader("Accept"));
+        Assertions.assertEquals("APPLICATION/JSON", apiRequest.getHeader("Accept"));
         Assertions.assertEquals(3, apiRequest.getHeadersList().size());
         Assertions.assertEquals("1", apiRequest.getQueryParams().get("p"));
         Assertions.assertEquals("", apiRequest.getQueryParams().get("empty"));

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/ApiKeyHeaderParserTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/http/headers/headerparser/ApiKeyHeaderParserTest.java
@@ -1,0 +1,31 @@
+package uk.co.compendiumdev.thingifier.api.http.headers.headerparser;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ApiKeyHeaderParserTest {
+
+    @Test
+    void validApiKeyHeaderExposesTrimmedCredential() {
+        final ApiKeyHeaderParser parser = new ApiKeyHeaderParser("  Key-123  ");
+
+        Assertions.assertTrue(parser.isValid());
+        Assertions.assertEquals("Key-123", parser.credential());
+    }
+
+    @Test
+    void missingApiKeyHeaderIsInvalid() {
+        final ApiKeyHeaderParser parser = new ApiKeyHeaderParser(null);
+
+        Assertions.assertFalse(parser.isValid());
+        Assertions.assertEquals("", parser.credential());
+    }
+
+    @Test
+    void blankApiKeyHeaderIsInvalid() {
+        final ApiKeyHeaderParser parser = new ApiKeyHeaderParser("   ");
+
+        Assertions.assertFalse(parser.isValid());
+        Assertions.assertEquals("", parser.credential());
+    }
+}

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthPolicyTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAuthPolicyTest.java
@@ -95,6 +95,35 @@ class ThingifierApiAuthPolicyTest {
     }
 
     @Test
+    void namedApiKeySchemeIsDocumentedOnProtectedGeneratedRoute() {
+        final Thingifier thingifier = todoModel();
+        thingifier.apiSpec().security().apiKey("authToken", "X-AUTH-TOKEN");
+        thingifier.apiSpec().route(RoutingVerb.POST, "/api/todos").secureWithApiKey("authToken");
+        final ThingifierApiDocumentationDefn apiDefn = new ThingifierApiDocumentationDefn();
+        apiDefn.setThingifier(thingifier);
+        apiDefn.setPathPrefix("/api");
+
+        final OpenAPI openApi =
+                new uk.co.compendiumdev.thingifier.swaggerizer.Swaggerizer(apiDefn).swagger();
+
+        final SecurityScheme scheme = openApi.getComponents().getSecuritySchemes().get("authToken");
+        Assertions.assertNotNull(scheme);
+        Assertions.assertEquals(SecurityScheme.Type.APIKEY, scheme.getType());
+        Assertions.assertEquals(SecurityScheme.In.HEADER, scheme.getIn());
+        Assertions.assertEquals("X-AUTH-TOKEN", scheme.getName());
+        Assertions.assertEquals(
+                "authToken",
+                openApi.getPaths()
+                        .get("/api/todos")
+                        .getPost()
+                        .getSecurity()
+                        .get(0)
+                        .keySet()
+                        .iterator()
+                        .next());
+    }
+
+    @Test
     @SuppressWarnings("deprecation")
     void legacyBearerMarkerRemainsDocumentationOnly() {
         final Thingifier thingifier = todoModel();
@@ -167,6 +196,24 @@ class ThingifierApiAuthPolicyTest {
     }
 
     @Test
+    void directApiMissingApiKeyReturns401WithoutMutation() {
+        final Thingifier thingifier = todoModel();
+        protectTodoPostWithApiKey(thingifier);
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"blocked\"}"),
+                                new HttpHeadersBlock());
+
+        Assertions.assertEquals(401, response.getStatusCode());
+        Assertions.assertEquals("", response.getHeaders().get("WWW-Authenticate"));
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    @Test
     void directApiInvalidBearerTokenReturns401WithoutMutation() {
         final Thingifier thingifier = todoModel();
         protectTodoPost(thingifier);
@@ -200,6 +247,35 @@ class ThingifierApiAuthPolicyTest {
         Assertions.assertEquals(401, response.getStatusCode());
         Assertions.assertEquals(
                 "Basic realm=\"Thingifier\"", response.getHeaders().get("WWW-Authenticate"));
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    @Test
+    void blankApiKeyHeaderReturns401BeforeAuthenticator() {
+        final Thingifier thingifier = todoModel();
+        final AtomicReference<Boolean> authenticatorCalled = new AtomicReference<>(false);
+        thingifier.apiSpec().security().apiKey("authToken", "X-AUTH-TOKEN");
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "authToken",
+                        context -> {
+                            authenticatorCalled.set(true);
+                            return ThingifierApiAuthenticationResult.authenticated();
+                        });
+        thingifier.apiSpec().route(RoutingVerb.POST, "/todos").secureWithApiKey("authToken");
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"blocked\"}"),
+                                headersWithApiKey("   "));
+
+        Assertions.assertEquals(401, response.getStatusCode());
+        Assertions.assertEquals("", response.getHeaders().get("WWW-Authenticate"));
+        Assertions.assertFalse(authenticatorCalled.get());
         Assertions.assertEquals(0, todoCount(thingifier));
     }
 
@@ -338,6 +414,40 @@ class ThingifierApiAuthPolicyTest {
     }
 
     @Test
+    void validApiKeyHeaderCallsAuthenticatorWithCredentialAndSource() {
+        final Thingifier thingifier = todoModel();
+        final AtomicReference<ThingifierApiAuthenticationContext> seenContext =
+                new AtomicReference<>();
+        thingifier.apiSpec().security().apiKey("authToken", "X-AUTH-TOKEN");
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "authToken",
+                        context -> {
+                            seenContext.set(context);
+                            return ThingifierApiAuthenticationResult.rejected(403, "checked");
+                        });
+        thingifier.apiSpec().route(RoutingVerb.POST, "/todos").secureWithApiKey("authToken");
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"blocked\"}"),
+                                headersWithApiKey("Valid-API-Key"));
+
+        Assertions.assertEquals(403, response.getStatusCode());
+        Assertions.assertNotNull(seenContext.get());
+        Assertions.assertEquals("authToken", seenContext.get().authSchemeName());
+        Assertions.assertEquals("Valid-API-Key", seenContext.get().authCredential());
+        Assertions.assertEquals("Valid-API-Key", seenContext.get().apiKey());
+        Assertions.assertEquals("X-AUTH-TOKEN", seenContext.get().authCredentialSource());
+        Assertions.assertEquals("", seenContext.get().bearerToken());
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    @Test
     void directApiValidBasicCredentialsAllowMutation() {
         final Thingifier thingifier = todoModel();
         protectTodoPostWithBasic(thingifier);
@@ -352,6 +462,156 @@ class ThingifierApiAuthPolicyTest {
 
         Assertions.assertEquals(201, response.getStatusCode());
         Assertions.assertEquals(1, todoCount(thingifier));
+    }
+
+    @Test
+    void directApiValidApiKeyAllowsMutation() {
+        final Thingifier thingifier = todoModel();
+        protectTodoPostWithApiKey(thingifier);
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"created\"}"),
+                                headersWithApiKey("Valid-API-Key"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals(1, todoCount(thingifier));
+    }
+
+    @Test
+    void directApiApiKeyAlternativeAllowsMutation() {
+        final Thingifier thingifier = todoModel();
+        protectTodoPostWithAlternativeAuth(thingifier);
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"created\"}"),
+                                headersWithApiKey("Valid-API-Key"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals(1, todoCount(thingifier));
+    }
+
+    @Test
+    void directApiBearerAlternativeAllowsMutation() {
+        final Thingifier thingifier = todoModel();
+        protectTodoPostWithAlternativeAuth(thingifier);
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"created\"}"),
+                                headersWithBearer("valid-token"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals(1, todoCount(thingifier));
+    }
+
+    @Test
+    void alternativeAuthUsesDeclarationOrderWhenCredentialsCompete() {
+        final Thingifier thingifier = todoModel();
+        final AtomicReference<String> selectedScheme = new AtomicReference<>();
+        thingifier.apiSpec().security().bearer("secretBearer");
+        thingifier.apiSpec().security().apiKey("secretApiKey", "X-AUTH-TOKEN");
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "secretBearer",
+                        context -> {
+                            selectedScheme.set(context.authSchemeName());
+                            return ThingifierApiAuthenticationResult.authenticated(
+                                    "bearer-principal");
+                        });
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "secretApiKey",
+                        context -> {
+                            selectedScheme.set(context.authSchemeName());
+                            return ThingifierApiAuthenticationResult.authenticated(
+                                    "api-key-principal");
+                        });
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.POST, "/todos")
+                .secureWithAnyOf("secretBearer", "secretApiKey");
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"created\"}"),
+                                headersWithBearerAndApiKey("valid-token", "Valid-API-Key"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals("secretBearer", selectedScheme.get());
+        Assertions.assertEquals(1, todoCount(thingifier));
+    }
+
+    @Test
+    void selectedRejectedAlternativeDoesNotFallThrough() {
+        final Thingifier thingifier = todoModel();
+        final AtomicReference<Boolean> apiKeyAuthenticatorCalled = new AtomicReference<>(false);
+        thingifier.apiSpec().security().bearer("secretBearer");
+        thingifier.apiSpec().security().apiKey("secretApiKey", "X-AUTH-TOKEN");
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "secretBearer",
+                        context -> ThingifierApiAuthenticationResult.rejected("Invalid bearer"));
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "secretApiKey",
+                        context -> {
+                            apiKeyAuthenticatorCalled.set(true);
+                            return ThingifierApiAuthenticationResult.authenticated(
+                                    "api-key-principal");
+                        });
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.POST, "/todos")
+                .secureWithAnyOf("secretBearer", "secretApiKey");
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"blocked\"}"),
+                                headersWithBearerAndApiKey("wrong", "Valid-API-Key"));
+
+        Assertions.assertEquals(401, response.getStatusCode());
+        Assertions.assertEquals("Bearer", response.getHeaders().get("WWW-Authenticate"));
+        Assertions.assertFalse(apiKeyAuthenticatorCalled.get());
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    @Test
+    void alternativeAuthMissingCredentialsUsesFirstSchemeChallenge() {
+        final Thingifier thingifier = todoModel();
+        protectTodoPostWithAlternativeAuth(thingifier);
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"blocked\"}"),
+                                new HttpHeadersBlock());
+
+        Assertions.assertEquals(401, response.getStatusCode());
+        Assertions.assertEquals("Bearer", response.getHeaders().get("WWW-Authenticate"));
+        Assertions.assertEquals(0, todoCount(thingifier));
     }
 
     @Test
@@ -505,6 +765,32 @@ class ThingifierApiAuthPolicyTest {
     }
 
     @Test
+    void apiKeyAuthenticatorCustom401CanOmitChallengeAndBody() {
+        final Thingifier thingifier = todoModel();
+        thingifier.apiSpec().security().apiKey("authToken", "X-AUTH-TOKEN");
+        thingifier
+                .apiSpec()
+                .authenticator(
+                        "authToken",
+                        context ->
+                                ThingifierApiAuthenticationResult.rejected(new ApiResponse(401)));
+        thingifier.apiSpec().route(RoutingVerb.POST, "/todos").secureWithApiKey("authToken");
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"blocked\"}"),
+                                headersWithApiKey("Valid-API-Key"));
+
+        Assertions.assertEquals(401, response.getStatusCode());
+        Assertions.assertEquals("", response.getHeaders().get("WWW-Authenticate"));
+        Assertions.assertFalse(response.hasABody());
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    @Test
     void basicAuthenticatorCustom403PreservesHeadersAndBody() {
         final Thingifier thingifier = todoModel();
         thingifier
@@ -566,6 +852,21 @@ class ThingifierApiAuthPolicyTest {
     }
 
     @Test
+    void httpApiMissingApiKeyReturns401WithoutMutation() {
+        final Thingifier thingifier = todoModel();
+        thingifier.apiConfig().setFrom(new ThingifierApiConfig("/api"));
+        protectPrefixedTodoPostWithApiKey(thingifier);
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .post(jsonPostRequest("/api/todos", "{\"title\":\"blocked\"}"));
+
+        Assertions.assertEquals(401, response.getStatusCode());
+        Assertions.assertEquals("", response.getHeaders().get("WWW-Authenticate"));
+        Assertions.assertEquals(0, todoCount(thingifier));
+    }
+
+    @Test
     void httpApiValidBearerTokenAllowsMutation() {
         final Thingifier thingifier = todoModel();
         thingifier.apiConfig().setFrom(new ThingifierApiConfig("/api"));
@@ -576,6 +877,38 @@ class ThingifierApiAuthPolicyTest {
                         .post(
                                 jsonPostRequest("/api/todos", "{\"title\":\"created\"}")
                                         .addHeader("Authorization", "Bearer valid-token"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals(1, todoCount(thingifier));
+    }
+
+    @Test
+    void httpApiValidApiKeyPreservesCredentialCaseAndAllowsMutation() {
+        final Thingifier thingifier = todoModel();
+        thingifier.apiConfig().setFrom(new ThingifierApiConfig("/api"));
+        protectPrefixedTodoPostWithApiKey(thingifier);
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .post(
+                                jsonPostRequest("/api/todos", "{\"title\":\"created\"}")
+                                        .addHeader("X-AUTH-TOKEN", "Valid-API-Key"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals(1, todoCount(thingifier));
+    }
+
+    @Test
+    void httpApiApiKeyAlternativeAllowsMutation() {
+        final Thingifier thingifier = todoModel();
+        thingifier.apiConfig().setFrom(new ThingifierApiConfig("/api"));
+        protectPrefixedTodoPostWithAlternativeAuth(thingifier);
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .post(
+                                jsonPostRequest("/api/todos", "{\"title\":\"created\"}")
+                                        .addHeader("X-AUTH-TOKEN", "Valid-API-Key"));
 
         Assertions.assertEquals(201, response.getStatusCode());
         Assertions.assertEquals(1, todoCount(thingifier));
@@ -1018,6 +1351,23 @@ class ThingifierApiAuthPolicyTest {
                 .secureWithBasicAuth("adminPassword");
     }
 
+    private ThingifierApiRouteRule protectTodoPostWithApiKey(final Thingifier thingifier) {
+        thingifier.apiSpec().security().apiKey("authToken", "X-AUTH-TOKEN");
+        thingifier.apiSpec().authenticator("authToken", this::validApiKeyAuthenticator);
+        return thingifier.apiSpec().route(RoutingVerb.POST, "/todos").secureWithApiKey("authToken");
+    }
+
+    private ThingifierApiRouteRule protectTodoPostWithAlternativeAuth(final Thingifier thingifier) {
+        thingifier.apiSpec().security().bearer("secretBearer");
+        thingifier.apiSpec().security().apiKey("secretApiKey", "X-AUTH-TOKEN");
+        thingifier.apiSpec().authenticator("secretBearer", this::validTokenAuthenticator);
+        thingifier.apiSpec().authenticator("secretApiKey", this::validApiKeyAuthenticator);
+        return thingifier
+                .apiSpec()
+                .route(RoutingVerb.POST, "/todos")
+                .secureWithAnyOf("secretBearer", "secretApiKey");
+    }
+
     private void protectPrefixedTodoPost(final Thingifier thingifier) {
         thingifier.apiSpec().authenticator("cartToken", this::validTokenAuthenticator);
         thingifier
@@ -1034,6 +1384,23 @@ class ThingifierApiAuthPolicyTest {
                 .secureWithBasicAuth("adminPassword");
     }
 
+    private void protectPrefixedTodoPostWithApiKey(final Thingifier thingifier) {
+        thingifier.apiSpec().security().apiKey("authToken", "X-AUTH-TOKEN");
+        thingifier.apiSpec().authenticator("authToken", this::validApiKeyAuthenticator);
+        thingifier.apiSpec().route(RoutingVerb.POST, "/api/todos").secureWithApiKey("authToken");
+    }
+
+    private void protectPrefixedTodoPostWithAlternativeAuth(final Thingifier thingifier) {
+        thingifier.apiSpec().security().bearer("secretBearer");
+        thingifier.apiSpec().security().apiKey("secretApiKey", "X-AUTH-TOKEN");
+        thingifier.apiSpec().authenticator("secretBearer", this::validTokenAuthenticator);
+        thingifier.apiSpec().authenticator("secretApiKey", this::validApiKeyAuthenticator);
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.POST, "/api/todos")
+                .secureWithAnyOf("secretBearer", "secretApiKey");
+    }
+
     private ThingifierApiAuthenticationResult validTokenAuthenticator(
             final ThingifierApiAuthenticationContext context) {
         if ("valid-token".equals(context.bearerToken())) {
@@ -1048,6 +1415,14 @@ class ThingifierApiAuthPolicyTest {
             return ThingifierApiAuthenticationResult.authenticated("basic-principal");
         }
         return ThingifierApiAuthenticationResult.rejected("Invalid basic credentials");
+    }
+
+    private ThingifierApiAuthenticationResult validApiKeyAuthenticator(
+            final ThingifierApiAuthenticationContext context) {
+        if ("Valid-API-Key".equals(context.apiKey())) {
+            return ThingifierApiAuthenticationResult.authenticated("api-key-principal");
+        }
+        return ThingifierApiAuthenticationResult.rejected("Invalid API key");
     }
 
     private Thingifier todoModel() {
@@ -1121,6 +1496,19 @@ class ThingifierApiAuthPolicyTest {
 
     private HttpHeadersBlock headersWithBasic(final String username, final String password) {
         return headersWithAuthorization(basicAuthorization(username, password));
+    }
+
+    private HttpHeadersBlock headersWithApiKey(final String apiKey) {
+        final HttpHeadersBlock headers = new HttpHeadersBlock();
+        headers.put("X-AUTH-TOKEN", apiKey);
+        return headers;
+    }
+
+    private HttpHeadersBlock headersWithBearerAndApiKey(
+            final String bearerToken, final String apiKey) {
+        final HttpHeadersBlock headers = headersWithBearer(bearerToken);
+        headers.put("X-AUTH-TOKEN", apiKey);
+        return headers;
     }
 
     private HttpHeadersBlock headersWithSessionAndBearer(

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpecTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpecTest.java
@@ -92,6 +92,48 @@ class ThingifierApiSpecTest {
     }
 
     @Test
+    void apiKeySecuritySpecStoresConfiguredHeader() {
+        final ThingifierApiSecuritySpec securitySpec = new ThingifierApiSecuritySpec();
+
+        securitySpec.apiKey("authToken", "X-AUTH-TOKEN");
+
+        Assertions.assertTrue(securitySpec.hasApiKey("authToken"));
+        Assertions.assertEquals("X-AUTH-TOKEN", securitySpec.apiKeyHeaderName("authToken"));
+    }
+
+    @Test
+    void namedApiKeyRouteRecordsDocumentationAndRuntimeEnforcement() {
+        final Thingifier thingifier = model();
+        final ThingifierApiRouteRule rule =
+                thingifier
+                        .apiSpec()
+                        .route(RoutingVerb.POST, "/api/todos")
+                        .secureWithApiKey("authToken");
+
+        Assertions.assertTrue(rule.isSecuredByApiKeyAuth());
+        Assertions.assertEquals("authToken", rule.apiKeyAuthSchemeName());
+        Assertions.assertTrue(rule.hasApiKeyAuthEnforcement());
+        Assertions.assertEquals("authToken", rule.apiKeyAuthEnforcementSchemeName());
+    }
+
+    @Test
+    void alternativeAuthRouteRecordsOrderedRuntimeSchemes() {
+        final Thingifier thingifier = model();
+        final ThingifierApiRouteRule rule =
+                thingifier
+                        .apiSpec()
+                        .route(RoutingVerb.POST, "/api/todos")
+                        .secureWithAnyOf("secretBearer", "secretApiKey");
+
+        Assertions.assertTrue(rule.hasAuthEnforcement());
+        Assertions.assertEquals(
+                java.util.List.of("secretBearer", "secretApiKey"),
+                rule.authEnforcementSchemeNames());
+        Assertions.assertFalse(rule.hasBearerAuthEnforcement());
+        Assertions.assertFalse(rule.hasApiKeyAuthEnforcement());
+    }
+
+    @Test
     void namedBasicAuthClearsBearerEnforcementOnRoute() {
         final Thingifier thingifier = model();
         final ThingifierApiRouteRule rule =
@@ -117,6 +159,50 @@ class ThingifierApiSpecTest {
 
         Assertions.assertFalse(rule.hasBasicAuthEnforcement());
         Assertions.assertTrue(rule.hasBearerAuthEnforcement());
+    }
+
+    @Test
+    void namedApiKeyAuthClearsOtherEnforcementOnRoute() {
+        final Thingifier thingifier = model();
+        final ThingifierApiRouteRule rule =
+                thingifier
+                        .apiSpec()
+                        .route(RoutingVerb.POST, "/api/todos")
+                        .secureWithBasicAuth("adminPassword")
+                        .secureWithBearerAuth("cartToken")
+                        .secureWithApiKey("authToken");
+
+        Assertions.assertFalse(rule.hasBasicAuthEnforcement());
+        Assertions.assertFalse(rule.hasBearerAuthEnforcement());
+        Assertions.assertTrue(rule.hasApiKeyAuthEnforcement());
+    }
+
+    @Test
+    void namedBearerAuthClearsApiKeyEnforcementOnRoute() {
+        final Thingifier thingifier = model();
+        final ThingifierApiRouteRule rule =
+                thingifier
+                        .apiSpec()
+                        .route(RoutingVerb.POST, "/api/todos")
+                        .secureWithApiKey("authToken")
+                        .secureWithBearerAuth("cartToken");
+
+        Assertions.assertFalse(rule.hasApiKeyAuthEnforcement());
+        Assertions.assertTrue(rule.hasBearerAuthEnforcement());
+    }
+
+    @Test
+    void namedBasicAuthClearsApiKeyEnforcementOnRoute() {
+        final Thingifier thingifier = model();
+        final ThingifierApiRouteRule rule =
+                thingifier
+                        .apiSpec()
+                        .route(RoutingVerb.POST, "/api/todos")
+                        .secureWithApiKey("authToken")
+                        .secureWithBasicAuth("adminPassword");
+
+        Assertions.assertFalse(rule.hasApiKeyAuthEnforcement());
+        Assertions.assertTrue(rule.hasBasicAuthEnforcement());
     }
 
     @Test

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerSecurityTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/swaggerizer/SwaggerizerSecurityTest.java
@@ -83,6 +83,84 @@ class SwaggerizerSecurityTest {
     }
 
     @Test
+    void apiKeySecuredRoutesAddHeaderApiKeySecuritySchemeAndOperationRequirement() {
+        final ThingifierApiDocumentationDefn apiDefn = new ThingifierApiDocumentationDefn();
+        apiDefn.addRouteToDocumentation(
+                new RoutingDefinition(
+                                RoutingVerb.GET,
+                                "/secret/token",
+                                RoutingStatus.returnedFromCall(),
+                                null)
+                        .addDocumentation("read a token")
+                        .addPossibleStatuses(200, 401, 403)
+                        .secureWithApiKey("authToken", "X-AUTH-TOKEN"));
+
+        final OpenAPI openApi = new Swaggerizer(apiDefn).swagger();
+
+        final SecurityScheme apiKeyAuth =
+                openApi.getComponents().getSecuritySchemes().get("authToken");
+        Assertions.assertNotNull(apiKeyAuth);
+        Assertions.assertEquals(SecurityScheme.Type.APIKEY, apiKeyAuth.getType());
+        Assertions.assertEquals(SecurityScheme.In.HEADER, apiKeyAuth.getIn());
+        Assertions.assertEquals("X-AUTH-TOKEN", apiKeyAuth.getName());
+        Assertions.assertEquals(
+                "authToken",
+                openApi.getPaths()
+                        .get("/secret/token")
+                        .getGet()
+                        .getSecurity()
+                        .get(0)
+                        .keySet()
+                        .iterator()
+                        .next());
+    }
+
+    @Test
+    void alternativeAuthRendersOpenApiSecurityRequirementsInDeclarationOrder() {
+        final Thingifier thingifier = relationshipModel();
+        thingifier.apiSpec().security().bearer("secretBearer");
+        thingifier.apiSpec().security().apiKey("secretApiKey", "X-AUTH-TOKEN");
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.POST, "/api/todos")
+                .secureWithAnyOf("secretBearer", "secretApiKey");
+        final ThingifierApiDocumentationDefn apiDefn = new ThingifierApiDocumentationDefn();
+        apiDefn.setThingifier(thingifier);
+        apiDefn.setPathPrefix("/api");
+
+        final OpenAPI openApi = new Swaggerizer(apiDefn).swagger();
+
+        final SecurityScheme bearer =
+                openApi.getComponents().getSecuritySchemes().get("secretBearer");
+        final SecurityScheme apiKey =
+                openApi.getComponents().getSecuritySchemes().get("secretApiKey");
+        Assertions.assertEquals(SecurityScheme.Type.HTTP, bearer.getType());
+        Assertions.assertEquals("bearer", bearer.getScheme());
+        Assertions.assertEquals(SecurityScheme.Type.APIKEY, apiKey.getType());
+        Assertions.assertEquals("X-AUTH-TOKEN", apiKey.getName());
+        Assertions.assertEquals(
+                "secretBearer",
+                openApi.getPaths()
+                        .get("/api/todos")
+                        .getPost()
+                        .getSecurity()
+                        .get(0)
+                        .keySet()
+                        .iterator()
+                        .next());
+        Assertions.assertEquals(
+                "secretApiKey",
+                openApi.getPaths()
+                        .get("/api/todos")
+                        .getPost()
+                        .getSecurity()
+                        .get(1)
+                        .keySet()
+                        .iterator()
+                        .next());
+    }
+
+    @Test
     void bearerSecuredGeneratedRoutesAddOperationRequirement() {
         final Thingifier thingifier = relationshipModel();
         thingifier


### PR DESCRIPTION
Closes #160.

Summary:
- Add first-class API key security schemes with configurable header names for public token headers such as X-AUTH-TOKEN.
- Add route-level `secureWithAnyOf(...)` so applications can accept ordered alternative schemes on one route.
- Enforce declaration-order selection at runtime: the first present credential source is authenticated, and malformed/rejected selected credentials do not fall through.
- Render API key schemes and alternative auth requirements correctly in OpenAPI.

Verification:
- `mvn -pl thingifier verify`
- full reactor verification from the commit hook
- `mvn -pl thingifier install -DskipTests`