### PR TITLE
Add anonymous write scoped-session data scope

### DIFF
--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/ScopedSessionPolicyApplier.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/adapter/http/apihandlers/ScopedSessionPolicyApplier.java
@@ -207,8 +207,12 @@ public final class ScopedSessionPolicyApplier {
         if (policy.allowsAnonymousDefaultScope()) {
             return ThingifierApiDataScopeSelection.defaultDataScope();
         }
-        return definition.anonymousDataScopeSelection(
-                scopedSessionContext(definition, "", verb, path, context, route, queryParams));
+        final ThingifierApiScopedSessionContext scopedSessionContext =
+                scopedSessionContext(definition, "", verb, path, context, route, queryParams);
+        if (policy.allowsAnonymousConfiguredWriteScope()) {
+            return definition.anonymousWriteDataScopeSelection(scopedSessionContext);
+        }
+        return definition.anonymousReadDataScopeSelection(scopedSessionContext);
     }
 
     private ApiResponse scopedSessionRejected(

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAnonymousDataScopeResolver.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiAnonymousDataScopeResolver.java
@@ -4,14 +4,15 @@ package uk.co.compendiumdev.thingifier.api.security;
  * Chooses the data scope for a missing scoped-session credential.
  *
  * <p>This callback is trusted server-side configuration, not a request-controlled database mapper.
- * Thingifier calls it only after route matching has determined that anonymous read access is
- * allowed, and before validators, authorizers, hooks, handlers, and response rendering run.
+ * Thingifier calls it only after route matching has determined that anonymous access is allowed for
+ * the current operation, and before validators, authorizers, hooks, handlers, and response
+ * rendering run.
  */
 @FunctionalInterface
 public interface ThingifierApiAnonymousDataScopeResolver {
 
     /**
-     * Selects the data scope to use for an anonymous read request.
+     * Selects the data scope to use for an anonymous request.
      *
      * @param context immutable route and request context for the missing credential request
      * @return trusted data-scope selection, or null to signal a configuration error

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiScopedSessionDefinition.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiScopedSessionDefinition.java
@@ -18,7 +18,9 @@ public final class ThingifierApiScopedSessionDefinition {
     private ThingifierApiScopedSessionAuthenticator authenticator;
     private boolean anonymousScopeForReads;
     private boolean anonymousDefaultScopeForReads;
-    private ThingifierApiAnonymousDataScopeResolver anonymousDataScopeResolver;
+    private ThingifierApiAnonymousDataScopeResolver anonymousReadDataScopeResolver;
+    private boolean anonymousScopeForWrites;
+    private ThingifierApiAnonymousDataScopeResolver anonymousWriteDataScopeResolver;
     private boolean authenticatedScopeForWrites;
     private int missingCredentialStatusCode;
     private String missingCredentialMessage;
@@ -104,7 +106,7 @@ public final class ThingifierApiScopedSessionDefinition {
     public ThingifierApiScopedSessionDefinition allowAnonymousDefaultScopeForReads() {
         this.anonymousScopeForReads = true;
         this.anonymousDefaultScopeForReads = true;
-        this.anonymousDataScopeResolver =
+        this.anonymousReadDataScopeResolver =
                 context -> ThingifierApiDataScopeSelection.defaultDataScope();
         return this;
     }
@@ -156,17 +158,73 @@ public final class ThingifierApiScopedSessionDefinition {
         }
         this.anonymousScopeForReads = true;
         this.anonymousDefaultScopeForReads = false;
-        this.anonymousDataScopeResolver = resolver;
+        this.anonymousReadDataScopeResolver = resolver;
+        return this;
+    }
+
+    /**
+     * Allows write-style generated routes to use a named data scope when no credential is supplied.
+     *
+     * <p>This is intentionally opt-in for applications that offer public, demo, or single-user
+     * mutable state. If a credential is supplied, Thingifier still validates it and invalid
+     * credentials reject rather than falling back to the anonymous write scope.
+     *
+     * @param dataScopeName anonymous write data scope
+     * @return this definition for fluent configuration
+     */
+    public ThingifierApiScopedSessionDefinition allowAnonymousWritesUsingDataScope(
+            final String dataScopeName) {
+        return allowAnonymousWritesUsingDataScope(
+                dataScopeName, DataScopeCreationPolicy.USE_EXISTING_ONLY);
+    }
+
+    /**
+     * Allows write-style generated routes to use a named data scope when no credential is supplied.
+     *
+     * @param dataScopeName anonymous write data scope
+     * @param creationPolicy policy used when the anonymous scope does not exist
+     * @return this definition for fluent configuration
+     */
+    public ThingifierApiScopedSessionDefinition allowAnonymousWritesUsingDataScope(
+            final String dataScopeName, final DataScopeCreationPolicy creationPolicy) {
+        final ThingifierApiDataScopeSelection selection =
+                ThingifierApiDataScopeSelection.useDataScope(dataScopeName, creationPolicy);
+        return allowAnonymousWritesUsingDataScope(context -> selection);
+    }
+
+    /**
+     * Allows write-style generated routes to resolve the anonymous data scope dynamically.
+     *
+     * <p>The resolver runs only when the scoped-session credential is missing and anonymous write
+     * access is allowed for the route. Configuring anonymous writes clears the authenticated-write
+     * requirement so fluent write policy calls have predictable last-call-wins behaviour.
+     *
+     * @param resolver trusted anonymous data-scope resolver
+     * @return this definition for fluent configuration
+     */
+    public ThingifierApiScopedSessionDefinition allowAnonymousWritesUsingDataScope(
+            final ThingifierApiAnonymousDataScopeResolver resolver) {
+        if (resolver == null) {
+            throw new IllegalArgumentException("anonymous write data-scope resolver is required");
+        }
+        this.anonymousScopeForWrites = true;
+        this.anonymousWriteDataScopeResolver = resolver;
+        this.authenticatedScopeForWrites = false;
         return this;
     }
 
     /**
      * Requires write-style generated routes to have a valid scoped-session credential.
      *
+     * <p>Configuring required writes clears any anonymous write scope so fluent write policy calls
+     * have predictable last-call-wins behaviour.
+     *
      * @return this definition for fluent configuration
      */
     public ThingifierApiScopedSessionDefinition requireAuthenticatedScopeForWrites() {
         this.authenticatedScopeForWrites = true;
+        this.anonymousScopeForWrites = false;
+        this.anonymousWriteDataScopeResolver = null;
         return this;
     }
 
@@ -247,7 +305,19 @@ public final class ThingifierApiScopedSessionDefinition {
      * @return resolver when anonymous reads are configured
      */
     public Optional<ThingifierApiAnonymousDataScopeResolver> anonymousDataScopeResolver() {
-        return Optional.ofNullable(anonymousDataScopeResolver);
+        return anonymousReadDataScopeResolver();
+    }
+
+    /**
+     * Returns the trusted resolver used for missing-credential anonymous reads.
+     *
+     * <p>This named read accessor keeps the read and write anonymous scope policies explicit while
+     * {@link #anonymousDataScopeResolver()} remains as the original read-scope alias.
+     *
+     * @return resolver when anonymous reads are configured
+     */
+    public Optional<ThingifierApiAnonymousDataScopeResolver> anonymousReadDataScopeResolver() {
+        return Optional.ofNullable(anonymousReadDataScopeResolver);
     }
 
     /**
@@ -258,10 +328,51 @@ public final class ThingifierApiScopedSessionDefinition {
      */
     public ThingifierApiDataScopeSelection anonymousDataScopeSelection(
             final ThingifierApiScopedSessionContext context) {
-        if (anonymousDataScopeResolver == null) {
+        return anonymousReadDataScopeSelection(context);
+    }
+
+    /**
+     * Selects the anonymous data scope for a missing-credential read request.
+     *
+     * @param context route and request context
+     * @return selected data scope, or null if the resolver is absent or returns null
+     */
+    public ThingifierApiDataScopeSelection anonymousReadDataScopeSelection(
+            final ThingifierApiScopedSessionContext context) {
+        if (anonymousReadDataScopeResolver == null) {
             return null;
         }
-        return anonymousDataScopeResolver.selectDataScope(context);
+        return anonymousReadDataScopeResolver.selectDataScope(context);
+    }
+
+    /**
+     * @return true when write-style routes may fall back to an anonymous scope
+     */
+    public boolean allowsAnonymousScopeForWrites() {
+        return anonymousScopeForWrites;
+    }
+
+    /**
+     * Returns the trusted resolver used for missing-credential anonymous writes.
+     *
+     * @return resolver when anonymous writes are configured
+     */
+    public Optional<ThingifierApiAnonymousDataScopeResolver> anonymousWriteDataScopeResolver() {
+        return Optional.ofNullable(anonymousWriteDataScopeResolver);
+    }
+
+    /**
+     * Selects the anonymous data scope for a missing-credential write request.
+     *
+     * @param context route and request context
+     * @return selected data scope, or null if the resolver is absent or returns null
+     */
+    public ThingifierApiDataScopeSelection anonymousWriteDataScopeSelection(
+            final ThingifierApiScopedSessionContext context) {
+        if (anonymousWriteDataScopeResolver == null) {
+            return null;
+        }
+        return anonymousWriteDataScopeResolver.selectDataScope(context);
     }
 
     /**

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiScopedSessionPolicy.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiScopedSessionPolicy.java
@@ -17,9 +17,16 @@ public final class ThingifierApiScopedSessionPolicy {
         ALLOW_ANONYMOUS_DEFAULT_SCOPE,
 
         /**
-         * Missing credentials use the anonymous data-scope resolver configured on the definition.
+         * Missing credentials use the anonymous read data-scope resolver configured on the
+         * definition.
          */
         ALLOW_ANONYMOUS_CONFIGURED_SCOPE,
+
+        /**
+         * Missing credentials use the anonymous write data-scope resolver configured on the
+         * definition.
+         */
+        ALLOW_ANONYMOUS_CONFIGURED_WRITE_SCOPE,
 
         /** Missing or invalid credentials reject before validators and handlers run. */
         REQUIRE_AUTHENTICATED_SCOPE
@@ -108,10 +115,19 @@ public final class ThingifierApiScopedSessionPolicy {
     }
 
     /**
+     * @return true when missing credentials should use the definition's anonymous write resolver
+     */
+    public boolean allowsAnonymousConfiguredWriteScope() {
+        return mode == Mode.ALLOW_ANONYMOUS_CONFIGURED_WRITE_SCOPE;
+    }
+
+    /**
      * @return true when missing credentials should continue anonymously
      */
     public boolean allowsAnonymousScope() {
-        return allowsAnonymousDefaultScope() || allowsAnonymousConfiguredScope();
+        return allowsAnonymousDefaultScope()
+                || allowsAnonymousConfiguredScope()
+                || allowsAnonymousConfiguredWriteScope();
     }
 
     /**

--- a/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpec.java
+++ b/thingifier/src/main/java/uk/co/compendiumdev/thingifier/api/spec/ThingifierApiSpec.java
@@ -661,6 +661,20 @@ public final class ThingifierApiSpec {
                                             definition, Mode.ALLOW_ANONYMOUS_CONFIGURED_SCOPE));
         }
         if (isWriteVerb(verb)) {
+            final Optional<ThingifierApiScopedSessionPolicy> anonymousWritePolicy =
+                    scopedSessions.values().stream()
+                            .filter(
+                                    ThingifierApiScopedSessionDefinition
+                                            ::allowsAnonymousScopeForWrites)
+                            .findFirst()
+                            .map(
+                                    definition ->
+                                            ThingifierApiScopedSessionPolicy.configured(
+                                                    definition,
+                                                    Mode.ALLOW_ANONYMOUS_CONFIGURED_WRITE_SCOPE));
+            if (anonymousWritePolicy.isPresent()) {
+                return anonymousWritePolicy;
+            }
             return scopedSessions.values().stream()
                     .filter(
                             ThingifierApiScopedSessionDefinition

--- a/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiScopedSessionPolicyTest.java
+++ b/thingifier/src/test/java/uk/co/compendiumdev/thingifier/api/security/ThingifierApiScopedSessionPolicyTest.java
@@ -1,6 +1,7 @@
 package uk.co.compendiumdev.thingifier.api.security;
 
 import static uk.co.compendiumdev.thingifier.api.security.DataScopeCreationPolicy.ENSURE_EXISTS;
+import static uk.co.compendiumdev.thingifier.apiconfig.EntityPatchUpdateStyle.PARTIAL_JSON_UPDATE;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.security.SecurityScheme;
@@ -248,6 +249,193 @@ class ThingifierApiScopedSessionPolicyTest {
     }
 
     @Test
+    void missingCredentialOnAnonymousPostUsesConfiguredWriteScope() {
+        final Thingifier thingifier = todoModel();
+        scopedSession(thingifier)
+                .authenticateWith(this::validScopedSession)
+                .allowAnonymousWritesUsingDataScope("anonymous-scope", ENSURE_EXISTS);
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"anonymous post\"}"),
+                                new HttpHeadersBlock());
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals(0, todoCount(thingifier, EntityRelModel.DEFAULT_DATABASE_NAME));
+        Assertions.assertEquals(1, todoCount(thingifier, "anonymous-scope"));
+    }
+
+    @Test
+    void missingCredentialOnAnonymousPutUsesConfiguredWriteScope() {
+        final Thingifier thingifier = stringIdTodoModel();
+        scopedSession(thingifier)
+                .authenticateWith(this::validScopedSession)
+                .allowAnonymousWritesUsingDataScope("anonymous-scope", ENSURE_EXISTS);
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .put(
+                                "todos/1",
+                                parser(thingifier, "{\"title\":\"anonymous put\"}"),
+                                new HttpHeadersBlock());
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals(0, todoCount(thingifier, EntityRelModel.DEFAULT_DATABASE_NAME));
+        Assertions.assertEquals(1, todoCount(thingifier, "anonymous-scope"));
+        Assertions.assertEquals("anonymous put", todoTitle(thingifier, "anonymous-scope", "1"));
+    }
+
+    @Test
+    void missingCredentialOnAnonymousPatchUsesConfiguredWriteScope() {
+        final Thingifier thingifier = todoModel();
+        thingifier.apiConfig().writeMethods().entities().patchCan(PARTIAL_JSON_UPDATE);
+        createTodo(thingifier, "anonymous-scope", "before patch");
+        scopedSession(thingifier)
+                .authenticateWith(this::validScopedSession)
+                .allowAnonymousWritesUsingDataScope("anonymous-scope");
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .patch("todos/1", "{\"title\":\"anonymous patch\"}", patchHeaders());
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals(0, todoCount(thingifier, EntityRelModel.DEFAULT_DATABASE_NAME));
+        Assertions.assertEquals("anonymous patch", todoTitle(thingifier, "anonymous-scope", "1"));
+    }
+
+    @Test
+    void missingCredentialOnAnonymousDeleteUsesConfiguredWriteScope() {
+        final Thingifier thingifier = todoModel();
+        createTodo(thingifier, "anonymous-scope", "delete me");
+        scopedSession(thingifier)
+                .authenticateWith(this::validScopedSession)
+                .allowAnonymousWritesUsingDataScope("anonymous-scope");
+
+        final ApiResponse response = thingifier.api().delete("todos/1", new HttpHeadersBlock());
+
+        Assertions.assertEquals(204, response.getStatusCode());
+        Assertions.assertEquals(0, todoCount(thingifier, EntityRelModel.DEFAULT_DATABASE_NAME));
+        Assertions.assertEquals(0, todoCount(thingifier, "anonymous-scope"));
+    }
+
+    @Test
+    void anonymousWriteResolverChoosesDataScope() {
+        final Thingifier thingifier = todoModel();
+        final AtomicReference<String> seenPath = new AtomicReference<>();
+        scopedSession(thingifier)
+                .authenticateWith(this::validScopedSession)
+                .allowAnonymousWritesUsingDataScope(
+                        context -> {
+                            seenPath.set(context.path());
+                            return ThingifierApiDataScopeSelection.useDataScope(
+                                    "anonymous-scope", ENSURE_EXISTS);
+                        });
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"anonymous resolver\"}"),
+                                new HttpHeadersBlock());
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals("todos", seenPath.get());
+        Assertions.assertEquals(1, todoCount(thingifier, "anonymous-scope"));
+    }
+
+    @Test
+    void validCredentialOverridesAnonymousWriteScope() {
+        final Thingifier thingifier = todoModel();
+        scopedSession(thingifier)
+                .authenticateWith(this::validScopedSession)
+                .allowAnonymousWritesUsingDataScope("anonymous-scope", ENSURE_EXISTS);
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"tenant write\"}"),
+                                headersWithScopedCredential("valid-session"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals(0, todoCount(thingifier, "anonymous-scope"));
+        Assertions.assertEquals(1, todoCount(thingifier, "tenant-one"));
+    }
+
+    @Test
+    void invalidCredentialOnAnonymousWriteRejects() {
+        final Thingifier thingifier = todoModel();
+        scopedSession(thingifier)
+                .authenticateWith(this::validScopedSession)
+                .allowAnonymousWritesUsingDataScope("anonymous-scope", ENSURE_EXISTS)
+                .onInvalidCredential(403, "Invalid scoped session");
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"blocked\"}"),
+                                headersWithScopedCredential("bad-session"));
+
+        Assertions.assertEquals(403, response.getStatusCode());
+        Assertions.assertEquals(
+                "Invalid scoped session", response.getErrorMessages().iterator().next());
+        Assertions.assertEquals(0, todoCount(thingifier, "anonymous-scope"));
+    }
+
+    @Test
+    void requireAuthenticatedScopeForWritesOverridesEarlierAnonymousWriteScope() {
+        final Thingifier thingifier = todoModel();
+        scopedSession(thingifier)
+                .authenticateWith(this::validScopedSession)
+                .allowAnonymousWritesUsingDataScope("anonymous-scope", ENSURE_EXISTS)
+                .requireAuthenticatedScopeForWrites()
+                .onMissingRequiredCredential(401, "Missing scoped session");
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"blocked\"}"),
+                                new HttpHeadersBlock());
+
+        Assertions.assertEquals(401, response.getStatusCode());
+        Assertions.assertEquals(
+                "Missing scoped session", response.getErrorMessages().iterator().next());
+        Assertions.assertEquals(0, todoCount(thingifier, "anonymous-scope"));
+    }
+
+    @Test
+    void routeLevelDisableBypassesAnonymousWriteScope() {
+        final Thingifier thingifier = todoModel();
+        scopedSession(thingifier)
+                .authenticateWith(this::validScopedSession)
+                .allowAnonymousWritesUsingDataScope("anonymous-scope", ENSURE_EXISTS);
+        thingifier.apiSpec().route(RoutingVerb.POST, "/todos").disableScopedSession();
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"legacy session write\"}"),
+                                headersWithSession("tenant-one"));
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals(0, todoCount(thingifier, "anonymous-scope"));
+        Assertions.assertEquals(1, todoCount(thingifier, "tenant-one"));
+    }
+
+    @Test
     void routeLevelRequireOverridesAnonymousReadDefault() {
         final Thingifier thingifier = todoModel();
         createTodo(thingifier, EntityRelModel.DEFAULT_DATABASE_NAME, "default todo");
@@ -403,6 +591,37 @@ class ThingifierApiScopedSessionPolicyTest {
     }
 
     @Test
+    void authorizerReceivesAnonymousWriteDataScope() {
+        final Thingifier thingifier = todoModel();
+        final AtomicReference<String> seenDataScope = new AtomicReference<>();
+        final AtomicReference<Object> seenPrincipal = new AtomicReference<>();
+        scopedSession(thingifier)
+                .authenticateWith(this::validScopedSession)
+                .allowAnonymousWritesUsingDataScope("anonymous-scope", ENSURE_EXISTS);
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.POST, "/todos")
+                .authorizeWith(
+                        context -> {
+                            seenDataScope.set(context.dataScopeName());
+                            seenPrincipal.set(context.principal());
+                            return ThingifierApiAuthorizationResult.authorized();
+                        });
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"anonymous authorized\"}"),
+                                new HttpHeadersBlock());
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertEquals("anonymous-scope", seenDataScope.get());
+        Assertions.assertNull(seenPrincipal.get());
+    }
+
+    @Test
     void fixedRouteUsesAnonymousDataScope() {
         final Thingifier thingifier = todoModel();
         createTodo(thingifier, EntityRelModel.DEFAULT_DATABASE_NAME, "default todo");
@@ -423,6 +642,28 @@ class ThingifierApiScopedSessionPolicyTest {
         Assertions.assertEquals(
                 "anonymous fixed todo",
                 response.apiResponse().getReturnedInstance().getFieldValue("title").asString());
+    }
+
+    @Test
+    void fixedRoutePostUsesAnonymousWriteDataScope() {
+        final Thingifier thingifier = todoModel();
+        createTodo(thingifier, "anonymous-scope", "before fixed write");
+        scopedSession(thingifier)
+                .authenticateWith(this::validScopedSession)
+                .allowAnonymousWritesUsingDataScope("anonymous-scope");
+        thingifier
+                .apiSpec()
+                .route(RoutingVerb.POST, "/fixed/todo")
+                .mapsToEntity("todo")
+                .withFixedIdentifier("1");
+
+        final HttpApiResponse response =
+                new ThingifierHttpApi(thingifier)
+                        .post(jsonPost("/fixed/todo", "{\"title\":\"after fixed write\"}"));
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals("after fixed write", todoTitle(thingifier, "anonymous-scope", "1"));
+        Assertions.assertEquals(0, todoCount(thingifier, EntityRelModel.DEFAULT_DATABASE_NAME));
     }
 
     @Test
@@ -506,6 +747,33 @@ class ThingifierApiScopedSessionPolicyTest {
 
         Assertions.assertEquals(201, response.getStatusCode());
         Assertions.assertSame(thingifier.getStore("tenant-one"), seenStore.get());
+    }
+
+    @Test
+    void validatorReceivesAnonymousWriteSelectedStore() {
+        final Thingifier thingifier = todoModel();
+        final AtomicReference<ThingStore> seenStore = new AtomicReference<>();
+        thingifier
+                .getDefinitionNamed("todo")
+                .withDomainValidation(
+                        context -> {
+                            seenStore.set(context.store());
+                            return new ValidationReport();
+                        });
+        scopedSession(thingifier)
+                .authenticateWith(this::validScopedSession)
+                .allowAnonymousWritesUsingDataScope("anonymous-scope", ENSURE_EXISTS);
+
+        final ApiResponse response =
+                thingifier
+                        .api()
+                        .post(
+                                "todos",
+                                parser(thingifier, "{\"title\":\"anonymous validated\"}"),
+                                new HttpHeadersBlock());
+
+        Assertions.assertEquals(201, response.getStatusCode());
+        Assertions.assertSame(thingifier.getStore("anonymous-scope"), seenStore.get());
     }
 
     @Test
@@ -632,6 +900,14 @@ class ThingifierApiScopedSessionPolicyTest {
         return thingifier;
     }
 
+    private Thingifier stringIdTodoModel() {
+        final Thingifier thingifier = new Thingifier();
+        final EntityDefinition todo = thingifier.defineThing("todo", "todos", 5);
+        todo.addAsPrimaryKeyField(Field.is("id", FieldType.STRING).makeMandatory());
+        todo.addField(Field.is("title", FieldType.STRING).makeMandatory());
+        return thingifier;
+    }
+
     private EntityInstance createTodo(
             final Thingifier thingifier, final String dataScopeName, final String title) {
         thingifier.getERmodel().createInstanceDatabaseIfNotExisting(dataScopeName);
@@ -644,6 +920,14 @@ class ThingifierApiScopedSessionPolicyTest {
 
     private int todoCount(final Thingifier thingifier, final String dataScopeName) {
         return thingifier.listThingInstancesNamed("todos", dataScopeName).size();
+    }
+
+    private String todoTitle(
+            final Thingifier thingifier, final String dataScopeName, final String id) {
+        return thingifier
+                .findThingInstanceByFieldNameAndValue("todo", "id", id, dataScopeName)
+                .getFieldValue("title")
+                .asString();
     }
 
     private String firstReturnedTodoTitle(final ApiResponse response) {
@@ -660,6 +944,12 @@ class ThingifierApiScopedSessionPolicyTest {
 
     private HttpApiRequest jsonPost(final String path, final String body) {
         return new HttpApiRequest(path).addHeader("Content-Type", "application/json").setBody(body);
+    }
+
+    private HttpHeadersBlock patchHeaders() {
+        HttpHeadersBlock headers = new HttpHeadersBlock();
+        headers.put("Content-Type", PARTIAL_JSON_UPDATE.mediaType());
+        return headers;
     }
 
     private HttpHeadersBlock headersWithScopedCredential(final String credential) {


### PR DESCRIPTION
## Summary
- Adds opt-in anonymous write data-scope selection for scoped sessions.
- Supports fixed-name and resolver callback forms with creation policy.
- Keeps invalid scoped-session credentials rejecting instead of falling back to anonymous writes.
- Applies the resolved anonymous write scope before authorizers, validators, fixed routes, generated handlers, and callbacks.

## Verification
- Full Maven verification passed during commit hook: `mvn clean verify`
- Local Maven install completed for API Challenges: `mvn install -DskipTests`

Closes #172